### PR TITLE
[수정] gradle, AGP, kotlin, hilt 버전 업데이트

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.21" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -109,7 +108,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,12 +109,12 @@ dependencies {
 
     // dagger hilt
     kapt "androidx.hilt:hilt-compiler:1.0.0"
-    implementation 'com.google.dagger:hilt-android:2.39'
-    kapt 'com.google.dagger:hilt-compiler:2.39'
-    androidTestImplementation  'com.google.dagger:hilt-android-testing:2.39'
-    kaptAndroidTest 'com.google.dagger:hilt-compiler:2.39'
-    testImplementation 'com.google.dagger:hilt-android-testing:2.39'
-    kaptTest 'com.google.dagger:hilt-compiler:2.39'
+    implementation 'com.google.dagger:hilt-android:2.45'
+    kapt 'com.google.dagger:hilt-compiler:2.45'
+    androidTestImplementation  'com.google.dagger:hilt-android-testing:2.45'
+    kaptAndroidTest 'com.google.dagger:hilt-compiler:2.45'
+    testImplementation 'com.google.dagger:hilt-android-testing:2.45'
+    kaptTest 'com.google.dagger:hilt-compiler:2.45'
 
     // start up
     implementation "androidx.startup:startup-runtime:1.1.0"
@@ -145,7 +145,7 @@ dependencies {
     // viewModel
     def lifecycle_version = "1.1.1"
     implementation "android.arch.lifecycle:extensions:$lifecycle_version"
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     implementation "androidx.activity:activity-ktx:1.2.3"
 
     // Timber

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.0.0"
 
     // fragment
-    def fragment_version = '1.4.0-alpha03'
+    def fragment_version = '1.5.0'
     implementation "androidx.fragment:fragment-ktx:$fragment_version"
     debugImplementation "androidx.fragment:fragment-testing:$fragment_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.39'
+        classpath 'com.android.tools.build:gradle:7.1.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.45'
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 01 22:29:23 KST 2021
+#Wed Apr 26 20:18:44 KST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Android Studio 버전별로 사용 가능한 AGP 버전이 다릅니다. 다람쥐 버전에서는 AGP 3.2-7.2 버전을 지원하므로 적당히 AGP 7.1 버전을 채용하고, 동시에 원래 목적이었던 gradle 버전도 Flamingo 지원 하한선인 7.2로 업데이트했습니다.

요약하면 다음과 같습니다.
* AGP: 7.0.2 -> 7.1 (Chipmunk, Flamingo 모두 지원)
* gradle: 7.0.2 -> 7.2 (Flamingo 하한선)

그런데 빌드 과정에서 Hilt 관련 문제가 있었습니다. Kotlin과 Hilt 버전을 업데이트하는 게 해결방법이라고 해서, 둘 다 업데이트했습니다. Kotlin 버전은 Android Studio 버전과 상관 없는 듯합니다. Hilt 버전업에 따라 ViewModel을 inject하는 `fragment-ktx` 라이브러리도 버전을 올렸습니다.

* Hilt: 2.39 -> 2.45
* Kotlin: 1.5.10 -> 1.8.21
* `fragment-ktx`: 1.4.0-alpha03 -> 1.5.0

그런데 빌드 과정에서 또 문제가 있어서;; 봤더니 `lifecycle-viewmodel-ktx` 라이브러리와 Hilt에 내장된 `lifecycle-viewmodel` 간의 충돌 문제가 있었습니다. `lifecycle-viewmodel-ktx` 라이브러리의 버전을 업데이트하여 해결했습니다.

* `lifecycle-viewmodel-ktx`: 2.3.1 -> 2.5.1

`.xml` 파일들은 Flamingo로 오면서 새로 추가된 파일이라고 합니다. 일단 커밋에는 포함했는데, 다람쥐 버전에서도 잘 빌드될지....? 확인 부탁드립니다. 감사합니다.