### PR TITLE
백그라운드 Notification 클릭하여 앱 진입시 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,6 +118,11 @@
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-6671968113098923~7129948779" />
 
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_status_bar"
+            />
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,7 @@
             android:exported="true" />
 
         <activity
-            android:name=".ui.on_boarding.OnBoardingActivity"
+            android:name=".ui.onboarding.OnboardingActivity"
             android:exported="true"
             android:screenOrientation="portrait" />
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.ku_stacks.ku_ring.ui.main
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
 import androidx.viewpager2.widget.ViewPager2
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivityMainBinding
@@ -120,5 +122,29 @@ class MainActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         binding.mainViewPager.unregisterOnPageChangeCallback(pageChangeCallback)
+    }
+
+    companion object {
+        fun start(
+            activity: Activity,
+            url: String,
+            articleId: String,
+            category: String,
+            postedDate: String,
+            subject: String
+        ) {
+            val intent = Intent(activity, MainActivity::class.java).apply {
+                putExtras(
+                    bundleOf(
+                        NoticeWebActivity.NOTICE_URL to url,
+                        NoticeWebActivity.NOTICE_ARTICLE_ID to articleId,
+                        NoticeWebActivity.NOTICE_CATEGORY to category,
+                        NoticeWebActivity.NOTICE_POSTED_DATE to postedDate,
+                        NoticeWebActivity.NOTICE_SUBJECT to subject
+                    )
+                )
+            }
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
@@ -1,4 +1,4 @@
-package com.ku_stacks.ku_ring.ui.on_boarding
+package com.ku_stacks.ku_ring.ui.onboarding
 
 import android.content.Intent
 import android.os.Bundle
@@ -14,14 +14,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class OnBoardingActivity : AppCompatActivity() {
+class OnboardingActivity : AppCompatActivity() {
     @Inject
     lateinit var analytics: EventAnalytics
 
     @Inject
     lateinit var pref: PreferenceUtil
 
-    private val getOnBoardingFinishResult = registerForActivityResult(
+    private val getOnboardingFinishResult = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == RESULT_OK) {
@@ -41,10 +41,10 @@ class OnBoardingActivity : AppCompatActivity() {
             val intent = Intent(this, EditSubscriptionActivity::class.java).apply {
                 putExtra(EditSubscriptionActivity.FIRST_RUN_FLAG, true)
             }
-            getOnBoardingFinishResult.launch(intent)
+            getOnboardingFinishResult.launch(intent)
 
             overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
-            analytics.click("start first Subscription Notification", "OnBoardingActivity")
+            analytics.click("start first Subscription Notification", "OnboardingActivity")
         }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivitySplashBinding
 import com.ku_stacks.ku_ring.ui.main.MainActivity
-import com.ku_stacks.ku_ring.ui.on_boarding.OnBoardingActivity
+import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
@@ -45,8 +45,8 @@ class SplashActivity : AppCompatActivity() {
                 launchedFromCustomNotificationEvent(intent) -> {
                     handleCustomNotification()
                 }
-                onBoardingNotFinished() -> {
-                    startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
+                onboadingRequired() -> {
+                    startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
                     overridePendingTransition(0, 0)
                     finish()
                 }
@@ -118,7 +118,7 @@ class SplashActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
-    private fun onBoardingNotFinished(): Boolean {
+    private fun onboadingRequired(): Boolean {
         return pref.firstRunFlag && pref.subscription.isNullOrEmpty()
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -9,7 +9,10 @@ import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivitySplashBinding
 import com.ku_stacks.ku_ring.ui.main.MainActivity
 import com.ku_stacks.ku_ring.ui.on_boarding.OnBoardingActivity
+import com.ku_stacks.ku_ring.util.DateUtil
+import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
+import com.ku_stacks.ku_ring.util.UrlGenerator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -20,6 +23,9 @@ class SplashActivity : AppCompatActivity() {
 
     @Inject
     lateinit var pref: PreferenceUtil
+
+    @Inject
+    lateinit var fcmUtil: FcmUtil
 
     private lateinit var binding: ActivitySplashBinding
 
@@ -32,16 +38,87 @@ class SplashActivity : AppCompatActivity() {
         lifecycleScope.launch {
             delay(1000)
 
-            // 저장한 구독목록이 있거나 firstRunFlag 가 false 면 바로 홈화면 진입
-            if (!pref.firstRunFlag || !pref.subscription.isNullOrEmpty()) {
-                startActivity(Intent(this@SplashActivity, MainActivity::class.java))
-                overridePendingTransition(0, 0)
-                finish()
-            } else {
-                startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
-                overridePendingTransition(0, 0)
-                finish()
+            when {
+                launchedFromNoticeNotificationEvent(intent) -> {
+                    handleNoticeNotification(intent)
+                }
+                launchedFromCustomNotificationEvent(intent) -> {
+                    handleCustomNotification()
+                }
+                onBoardingNotFinished() -> {
+                    startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
+                    overridePendingTransition(0, 0)
+                    finish()
+                }
+                else -> {
+                    startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+                    overridePendingTransition(0, 0)
+                    finish()
+                }
             }
         }
+    }
+
+    private fun launchedFromNoticeNotificationEvent(intent: Intent): Boolean {
+        val data = intent.extras?.toMap()
+            ?: return false
+        return fcmUtil.isNoticeNotification(data)
+    }
+
+    private fun Bundle.toMap(): Map<String, String?> {
+        val map: MutableMap<String, String?> = HashMap()
+
+        for (key in this.keySet()) {
+            map[key] = this.getString(key)
+        }
+        return map
+    }
+
+    private fun handleNoticeNotification(intent: Intent) {
+        intent.extras?.toMap()?.let { map ->
+            val articleId = map["articleId"] ?: return
+            val category = map["category"] ?: return
+            val postedDate = map["postedDate"] ?: return
+            val subject = map["subject"] ?: return
+            val baseUrl = map["baseUrl"] ?: return
+            val url = UrlGenerator.generateNoticeUrl(
+                articleId = articleId,
+                category = category,
+                baseUrl = baseUrl
+            )
+
+            fcmUtil.insertNotificationIntoDatabase(
+                articleId = articleId,
+                category = category,
+                postedDate = postedDate,
+                subject = subject,
+                baseUrl = baseUrl,
+                receivedDate = DateUtil.getCurrentTime()
+            )
+
+            MainActivity.start(
+                activity = this@SplashActivity,
+                url = url,
+                articleId = articleId,
+                category = category,
+                postedDate = postedDate,
+                subject = subject
+            )
+        }
+    }
+
+    private fun launchedFromCustomNotificationEvent(intent: Intent): Boolean {
+        val data = intent.extras?.toMap()
+            ?: return false
+        return fcmUtil.isCustomNotification(data)
+    }
+
+    private fun handleCustomNotification() {
+        val intent = Intent(this@SplashActivity, MainActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun onBoardingNotFinished(): Boolean {
+        return pref.firstRunFlag && pref.subscription.isNullOrEmpty()
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
@@ -1,0 +1,65 @@
+package com.ku_stacks.ku_ring.util
+
+import com.ku_stacks.ku_ring.data.db.PushDao
+import com.ku_stacks.ku_ring.data.db.PushEntity
+import com.ku_stacks.ku_ring.di.IODispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+class FcmUtil @Inject constructor(
+    private val pushDao: PushDao,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    fun isNoticeNotification(data: Map<String, String?>): Boolean {
+        val articleId = data["articleId"]
+        val categoryEng = data["category"]
+        val postedDate = data["postedDate"]
+        val subject = data["subject"]
+        val baseUrl = data["baseUrl"]
+
+        return articleId != null && categoryEng != null && postedDate != null
+            && subject != null && baseUrl != null
+    }
+
+    fun isCustomNotification(data: Map<String, String?>): Boolean {
+        val customTypeSet = setOf("admin")
+
+        val type = data["type"]?.lowercase()
+        val title = data["title"]
+        val body = data["body"]
+
+        return type != null && title != null && body != null && customTypeSet.contains(type)
+    }
+
+    fun insertNotificationIntoDatabase(
+        articleId: String,
+        category: String,
+        postedDate: String,
+        subject: String,
+        baseUrl: String,
+        receivedDate: String
+    ) {
+        CoroutineScope(ioDispatcher).launch {
+            try {
+                pushDao.insertNotification(
+                    PushEntity(
+                        articleId = articleId,
+                        category = category,
+                        postedDate = postedDate,
+                        subject = subject,
+                        baseUrl = baseUrl,
+                        isNew = true,
+                        receivedDate = receivedDate
+                    )
+                )
+                Timber.e("insert notification success")
+            } catch (e: Exception) {
+                Timber.e("insert notification error : $e")
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### 배경
- 서버단에서 iOS 푸시알림 대응을 위해 데이터페이로드 방식에서 Notification 방식으로 변경되었음
  - https://github.com/ku-ring/ku-ring-backend-web/pull/23/commits/fa7f5ef5443642412a76a2ef4439b3ff4b61b14f?diff=split&w=0
- 안드로이드앱이 foreground 상태일땐 파이어베이스의 onMessageReceived 이 호출되지만 background 상태일땐 호출되지 않는 현상 발생

변경 사항
- SplashActivity에서 받은 intent로 Notification 이벤트를 처리하도록 수정
  - MyFireBaseMessagingService와 공통된 로직은 FcmUtil 클래스로 분리
  - FcmUtil은 필요한 곳에서 주입 받을수 있도록 변경

참고 링크
https://firebase.google.com/docs/cloud-messaging/android/receive?hl=ko#override-onmessagereceived