### PR TITLE
[수정] 구독 화면 디자인 수정 및 학과 구독 기능 추가

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,41 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,8 @@ plugins {
 def keystorePropertiesFile = rootProject.file("app/signing/keystore.properties")
 def localPropertiesFile = rootProject.file("local.properties")
 
+def composeCompilerVersion = "1.4.7"
+
 android {
     testOptions {
         unitTests {
@@ -30,7 +32,7 @@ android {
             }
         }
     }
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.ku_stacks.ku_ring"
@@ -101,6 +103,12 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = composeCompilerVersion
     }
 }
 
@@ -201,6 +209,27 @@ dependencies {
     implementation "androidx.room:room-ktx:$room_version"
     implementation "androidx.room:room-rxjava3:$room_version"
     testImplementation "androidx.room:room-testing:$room_version"
+
+    // Compose
+    def compose_bom = "2023.05.00"
+    implementation platform("androidx.compose:compose-bom:$compose_bom")
+    implementation "androidx.compose.foundation:foundation"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.material:material-icons-core"
+    implementation "androidx.compose.material:material-icons-extended"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-test"
+    implementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
+    implementation "androidx.compose.ui:ui-tooling"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+
+    implementation "androidx.activity:activity-compose:1.7.1"
+    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1"
+    implementation "androidx.paging:paging-compose:1.0.0-alpha19"
+    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
+
 
     // Shimmer effect
     implementation 'com.facebook.shimmer:shimmer:0.5.0'

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -12,7 +12,6 @@ import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ku_stacks.ku_ring.data.db.PushDao
-import com.ku_stacks.ku_ring.data.db.PushEntity
 import com.ku_stacks.ku_ring.ui.main.MainActivity
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import com.ku_stacks.ku_ring.util.DateUtil
@@ -21,9 +20,6 @@ import com.ku_stacks.ku_ring.util.PreferenceUtil
 import com.ku_stacks.ku_ring.util.UrlGenerator
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -41,6 +37,9 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         Timber.e("refreshed token : $token")
+        if (pref.fcmToken != token) {
+            pref.fcmToken = token
+        }
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/DepartmentClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/DepartmentClient.kt
@@ -1,7 +1,14 @@
 package com.ku_stacks.ku_ring.data.api
 
+import com.ku_stacks.ku_ring.data.api.request.DepartmentSubscribeRequest
 import javax.inject.Inject
 
 class DepartmentClient @Inject constructor(private val departmentService: DepartmentService) {
     suspend fun fetchDepartmentList() = departmentService.fetchDepartmentList()
+
+    suspend fun subscribeDepartments(fcmToken: String, departments: List<String>) =
+        departmentService.subscribeDepartments(fcmToken, DepartmentSubscribeRequest(departments))
+
+    suspend fun getSubscribedDepartments(fcmToken: String) =
+        departmentService.getSubscribedDepartments(fcmToken)
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/DepartmentService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/DepartmentService.kt
@@ -1,9 +1,22 @@
 package com.ku_stacks.ku_ring.data.api
 
+import com.ku_stacks.ku_ring.data.api.request.DepartmentSubscribeRequest
 import com.ku_stacks.ku_ring.data.api.response.DepartmentListResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
 
 interface DepartmentService {
     @GET("v2/notices/departments")
     suspend fun fetchDepartmentList(): DepartmentListResponse
+
+    @POST("v2/users/subscriptions/departments")
+    suspend fun subscribeDepartments(
+        @Header("User-Token") fcmToken: String,
+        @Body body: DepartmentSubscribeRequest,
+    ): DepartmentListResponse
+
+    @GET("v2/users/subscriptions/departments")
+    suspend fun getSubscribedDepartments(@Header("User-Token") fcmToken: String): DepartmentListResponse
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/request/DepartmentSubscribeRequest.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/request/DepartmentSubscribeRequest.kt
@@ -1,0 +1,5 @@
+package com.ku_stacks.ku_ring.data.api.request
+
+data class DepartmentSubscribeRequest(
+    val departments: List<String>,
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
@@ -63,5 +63,6 @@ fun DepartmentEntity.toDepartment() = Department(
     shortName = shortName,
     koreanName = koreanName,
     isSubscribed = isSubscribed,
-    isSelected = false
+    isSelected = false,
+    isNotificationEnabled = false,
 )

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ResponseToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ResponseToModelMapper.kt
@@ -1,8 +1,10 @@
 package com.ku_stacks.ku_ring.data.mapper
 
+import com.ku_stacks.ku_ring.data.api.response.DepartmentResponse
 import com.ku_stacks.ku_ring.data.api.response.NoticeListResponse
 import com.ku_stacks.ku_ring.data.api.response.SearchNoticeListResponse
 import com.ku_stacks.ku_ring.data.api.response.SearchStaffListResponse
+import com.ku_stacks.ku_ring.data.model.Department
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.data.model.Staff
 
@@ -90,3 +92,12 @@ fun SearchStaffListResponse.toStaffList(): List<Staff> {
         )
     } ?: emptyList()
 }
+
+fun DepartmentResponse.toDepartment() = Department(
+    name = name!!,
+    shortName = shortName!!,
+    koreanName = this.korName!!,
+    isSubscribed = false,
+    isSelected = false,
+    isNotificationEnabled = false
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/model/Department.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/model/Department.kt
@@ -6,4 +6,5 @@ data class Department(
     val koreanName: String,
     val isSubscribed: Boolean,
     val isSelected: Boolean,
+    val isNotificationEnabled: Boolean,
 )

--- a/app/src/main/java/com/ku_stacks/ku_ring/di/RepositoryModule.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/di/RepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.ku_stacks.ku_ring.di
 
+import com.ku_stacks.ku_ring.data.api.DepartmentClient
 import com.ku_stacks.ku_ring.data.api.NoticeClient
 import com.ku_stacks.ku_ring.data.api.SendbirdClient
 import com.ku_stacks.ku_ring.data.db.BlackUserDao
+import com.ku_stacks.ku_ring.data.db.DepartmentDao
 import com.ku_stacks.ku_ring.data.db.NoticeDao
 import com.ku_stacks.ku_ring.data.db.PushDao
 import com.ku_stacks.ku_ring.repository.*
@@ -41,9 +43,10 @@ object RepositoryModule {
     @Singleton
     fun provideSubscribeRepository(
         noticeClient: NoticeClient,
+        departmentClient: DepartmentClient,
         pref: PreferenceUtil
     ): SubscribeRepository {
-        return SubscribeRepositoryImpl(noticeClient, pref)
+        return SubscribeRepositoryImpl(noticeClient, departmentClient, pref)
     }
 
     @Provides
@@ -69,5 +72,12 @@ object RepositoryModule {
         noticeDao: NoticeDao,
         pref: PreferenceUtil,
     ): DepartmentNoticeRepository = DepartmentNoticeRepositoryImpl(noticeClient, noticeDao, pref)
+
+    @Provides
+    @Singleton
+    fun provideDepartmentRepository(
+        departmentDao: DepartmentDao,
+        departmentClient: DepartmentClient
+    ): DepartmentRepository = DepartmentRepositoryImpl(departmentDao, departmentClient)
 
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
@@ -4,6 +4,8 @@ import com.ku_stacks.ku_ring.data.model.Department
 import kotlinx.coroutines.flow.Flow
 
 interface DepartmentRepository {
+    suspend fun insertAllDepartmentsFromRemote()
+    suspend fun fetchAllDepartmentsFromRemote(): List<Department>
     suspend fun insertDepartment(department: Department)
     suspend fun insertDepartments(departments: List<Department>)
     suspend fun getAllDepartments(): List<Department>

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepository.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.repository
 
 import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
+import com.ku_stacks.ku_ring.data.model.Department
 import io.reactivex.rxjava3.core.Single
 
 interface SubscribeRepository {
@@ -8,4 +9,6 @@ interface SubscribeRepository {
     fun saveSubscriptionToRemote(subscribeRequest: SubscribeRequest)
     fun getSubscriptionFromLocal(): Set<String>
     fun saveSubscriptionToLocal(stringArray: ArrayList<String>)
+    suspend fun fetchSubscribedDepartments(): List<Department>
+    suspend fun saveSubscribedDepartmentsToRemote(departments: List<Department>)
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryImpl.kt
@@ -1,17 +1,25 @@
 package com.ku_stacks.ku_ring.repository
 
+import com.ku_stacks.ku_ring.data.api.DepartmentClient
 import com.ku_stacks.ku_ring.data.api.NoticeClient
 import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
+import com.ku_stacks.ku_ring.data.mapper.toDepartment
+import com.ku_stacks.ku_ring.data.model.Department
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import com.ku_stacks.ku_ring.util.WordConverter
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
 
 class SubscribeRepositoryImpl @Inject constructor(
     private val noticeClient: NoticeClient,
-    private val pref: PreferenceUtil
+    private val departmentClient: DepartmentClient,
+    private val pref: PreferenceUtil,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SubscribeRepository {
     override fun fetchSubscriptionFromRemote(token: String): Single<List<String>> {
         return noticeClient.fetchSubscribe(token)
@@ -47,5 +55,29 @@ class SubscribeRepositoryImpl @Inject constructor(
         }.toSet()
 
         pref.subscription = stringSet
+    }
+
+    override suspend fun fetchSubscribedDepartments(): List<Department> {
+        return try {
+            pref.fcmToken?.let { fcmToken ->
+                withContext(ioDispatcher) {
+                    departmentClient.getSubscribedDepartments(fcmToken).data?.map {
+                        it.toDepartment().copy(isSubscribed = true)
+                    }
+                }
+            } ?: emptyList()
+        } catch (e: Exception) {
+            Timber.e(e)
+            emptyList()
+        }
+    }
+
+    override suspend fun saveSubscribedDepartmentsToRemote(departments: List<Department>) {
+        withContext(ioDispatcher) {
+            pref.fcmToken?.let { fcmToken ->
+                departmentClient.subscribeDepartments(fcmToken, departments.map { it.shortName })
+            }
+            Timber.d("Subscribed departments: ${departments.map { it.shortName }}")
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
@@ -26,9 +26,6 @@ class EditSubscriptionActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEditSubscriptionBinding
     private val viewModel by viewModels<EditSubscriptionViewModel>()
 
-    private lateinit var subscribeAdapter: SubscribeAdapter
-    private lateinit var unSubscribeListAdapter: UnSubscribeAdapter
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -52,8 +49,8 @@ class EditSubscriptionActivity : AppCompatActivity() {
             viewModel.rollback()
         }
         binding.startBt.setOnClickListener {
-            Timber.d("Init count = ${viewModel.initCount}")
-            if (viewModel.initCount == 2) {
+            Timber.d("Init status = ${viewModel.isInitialLoadDone}")
+            if (viewModel.isInitialLoadDone) {
                 viewModel.saveSubscribe()
                 setResult(RESULT_OK)
                 finish()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -63,9 +63,10 @@ class EditSubscriptionViewModel @Inject constructor(
     private var fcmToken: String? = null
 
     /** 초기 설정이 끝나기 전에 뒤로가기를 하면 빈 목록을 구독하는 경우를 방지하기 위함 */
-    private var _initCount = 0
-    val initCount: Int
-        get() = _initCount
+    private var isInitialCategoryLoaded = false
+    private var isInitialDepartmentLoaded = false
+    val isInitialLoadDone: Boolean
+        get() = isInitialCategoryLoaded && isInitialDepartmentLoaded
 
     /** 첫 앱 구동자에게 보여지는 온보딩 후의 푸시 세팅을 위한 분기처리 용도 */
     var firstRunFlag = false
@@ -104,7 +105,7 @@ class EditSubscriptionViewModel @Inject constructor(
             addDepartmentsToMap(subscribedDepartments)
             val notificationEnabledDepartments = repository.fetchSubscribedDepartments()
             markDepartmentsAsEnabled(notificationEnabledDepartments)
-            _initCount++
+            isInitialDepartmentLoaded = true
             initialDepartments.modifySet { addAll(departmentsByKoreanName.value.values) }
         }
     }
@@ -118,8 +119,8 @@ class EditSubscriptionViewModel @Inject constructor(
     }
 
     fun saveSubscribe() {
-        if (_initCount < 2) {
-            Timber.d("return because init count is $_initCount")
+        if (!isInitialLoadDone) {
+            Timber.d("return because category: $isInitialCategoryLoaded, department: $isInitialDepartmentLoaded")
             return
         }
 
@@ -188,7 +189,7 @@ class EditSubscriptionViewModel @Inject constructor(
             }
         }
         initialCategories.modifySet { addAll(categories.value.values) }
-        _initCount++
+        isInitialCategoryLoaded = true
     }
 
     /**

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -9,6 +9,8 @@ import com.ku_stacks.ku_ring.data.model.Department
 import com.ku_stacks.ku_ring.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.repository.SubscribeRepository
 import com.ku_stacks.ku_ring.util.WordConverter
+import com.ku_stacks.ku_ring.util.modifyMap
+import com.ku_stacks.ku_ring.util.modifySet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -223,18 +225,6 @@ class EditSubscriptionViewModel @Inject constructor(
         content = koreanName,
         isNotificationEnabled = isNotificationEnabled
     )
-
-    private fun <K, V> MutableStateFlow<MutableMap<K, V>>.modifyMap(block: MutableMap<K, V>.() -> Unit) {
-        val newValue = this.value.toMutableMap().apply { block() }
-        Timber.d("before: $value, after: $newValue")
-        this.value = newValue
-    }
-
-    private fun <E> MutableStateFlow<MutableSet<E>>.modifySet(block: MutableSet<E>.() -> Unit) {
-        val newValue = this.value.toMutableSet().apply { block() }
-        Timber.d("before: $value, after: $newValue")
-        this.value = newValue
-    }
 
     private fun Department.toggle() =
         Department(name, shortName, koreanName, isSubscribed, isSelected, !isNotificationEnabled)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -1,49 +1,69 @@
 package com.ku_stacks.ku_ring.ui.edit_subscription
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.firebase.messaging.FirebaseMessaging
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
+import com.ku_stacks.ku_ring.data.model.Department
+import com.ku_stacks.ku_ring.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.repository.SubscribeRepository
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class EditSubscriptionViewModel @Inject constructor(
     private val repository: SubscribeRepository,
+    private val departmentRepository: DepartmentRepository,
+    private val subscribeRepository: SubscribeRepository,
     private val analytics: EventAnalytics,
     firebaseMessaging: FirebaseMessaging
 ) : ViewModel() {
 
     private val disposable = CompositeDisposable()
 
-    private val _subscriptionList = ArrayList<String>()
-    val subscriptionList = MutableLiveData<List<String>>()
-    val isSubscriptionEmpty = MutableLiveData(true)
+    private val initialCategories = MutableStateFlow(mutableSetOf<SubscriptionUiModel>())
+    private val initialDepartments = MutableStateFlow(mutableSetOf<Department>())
 
-    private val _unSubscriptionList = ArrayList<String>()
-    val unSubscriptionList = MutableLiveData<List<String>>()
+    private val categories = MutableStateFlow(mutableMapOf<String, SubscriptionUiModel>())
+    val sortedCategories: Flow<List<SubscriptionUiModel>> =
+        categories.map { it.values.sortedWith(CategoryComparator) }
 
-    private val sortedSubscriptionList: List<String>
-        get() = _subscriptionList.sortedWith(CategoryComparator)
+    private val departmentsByKoreanName = MutableStateFlow(mutableMapOf<String, Department>())
 
-    private val sortedUnSubscriptionList: List<String>
-        get() = _unSubscriptionList.sortedWith(CategoryComparator)
+    val sortedDepartments: Flow<List<SubscriptionUiModel>> =
+        departmentsByKoreanName.map { departments ->
+            departments.values.map { it.toSubscriptionUiModel() }.sortedWith(DepartmentComparator)
+        }
 
-    private val _hasUpdate = MutableLiveData(false)
-    val hasUpdate: LiveData<Boolean>
-        get() = _hasUpdate
+    val hasUpdate: StateFlow<Boolean> =
+        combine(
+            categories,
+            departmentsByKoreanName,
+            initialCategories,
+            initialDepartments
+        ) { categories, departments, initialCategories, initialDepartments ->
+            (categories.values.toSet() != initialCategories) || (departments.values.toSet() != initialDepartments)
+        }.stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     private var fcmToken: String? = null
 
     /** 초기 설정이 끝나기 전에 뒤로가기를 하면 빈 목록을 구독하는 경우를 방지하기 위함 */
-    private var initFlag = false
+    private var _initCount = 0
+    val initCount: Int
+        get() = _initCount
 
     /** 첫 앱 구동자에게 보여지는 온보딩 후의 푸시 세팅을 위한 분기처리 용도 */
     var firstRunFlag = false
@@ -65,99 +85,115 @@ class EditSubscriptionViewModel @Inject constructor(
 
     fun syncWithServer() {
         fcmToken?.let {
-            _subscriptionList.clear()
-            _unSubscriptionList.clear()
-            _unSubscriptionList.addAll(
-                listOf(
-                    "학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관"
-                )
-            )
-
             disposable.add(
                 repository.fetchSubscriptionFromRemote(fcmToken!!)
                     .subscribeOn(Schedulers.io())
                     .subscribe({
                         initialSortSubscription(it)
-                        refreshAfterUpdate()
                     }, {
                         Timber.e("getSubscribeList fail $it")
                     })
             )
         }
+
+        viewModelScope.launch {
+            departmentRepository.insertAllDepartmentsFromRemote()
+            val subscribedDepartments = departmentRepository.getSubscribedDepartments()
+            addDepartmentsToMap(subscribedDepartments)
+            val notificationEnabledDepartments = repository.fetchSubscribedDepartments()
+            markDepartmentsAsEnabled(notificationEnabledDepartments)
+            _initCount++
+            initialDepartments.modifySet { addAll(departmentsByKoreanName.value.values) }
+        }
+    }
+
+    private fun addDepartmentsToMap(departments: List<Department>) {
+        departmentsByKoreanName.modifyMap {
+            departments.forEach {
+                this[it.koreanName] = it
+            }
+        }
     }
 
     fun saveSubscribe() {
-        if (initFlag == false) {
+        if (_initCount < 2) {
+            Timber.d("return because init count is $_initCount")
             return
         }
 
-        fcmToken?.let {
-            repository.saveSubscriptionToLocal(_subscriptionList)
+        fcmToken?.let { fcmToken ->
+            val notificationEnabledCategories =
+                categories.value.values.filter { it.isNotificationEnabled }.map { it.content }
+            repository.saveSubscriptionToLocal(ArrayList(notificationEnabledCategories))
             repository.saveSubscriptionToRemote(
-                SubscribeRequest(it, _subscriptionList.toList().map { category ->
+                SubscribeRequest(fcmToken, notificationEnabledCategories.map { category ->
                     WordConverter.convertKoreanToEnglish(category)
                 })
             )
         }
-    }
-
-    fun removeSubscription(category: String) {
-        _subscriptionList.remove(category)
-        subscriptionList.postValue(sortedSubscriptionList)
-    }
-
-    fun removeUnSubscription(category: String) {
-        _unSubscriptionList.remove(category)
-        unSubscriptionList.postValue(sortedUnSubscriptionList)
-    }
-
-    fun addSubscription(category: String) {
-        if (!_subscriptionList.contains(category)) {
-            _subscriptionList.add(category)
+        viewModelScope.launch {
+            val subscribedDepartments =
+                departmentsByKoreanName.value.values.filter { it.isNotificationEnabled }
+            subscribeRepository.saveSubscribedDepartmentsToRemote(subscribedDepartments)
         }
-        subscriptionList.postValue(sortedSubscriptionList)
     }
 
-    fun addUnSubscription(category: String) {
-        if (!_unSubscriptionList.contains(category)) {
-            _unSubscriptionList.add(category)
-        }
-        unSubscriptionList.postValue(sortedUnSubscriptionList)
-    }
-
-    fun refreshAfterUpdate() {
-        if (firstRunFlag) {
-            return
-        }
-        val localSubscription = repository.getSubscriptionFromLocal()
-        if (localSubscription.size != _subscriptionList.size) {
-            _hasUpdate.postValue(true)
-            return
-        }
-        for (data in _subscriptionList) {
-            if (!localSubscription.contains(WordConverter.convertKoreanToShortEnglish(data))) {
-                _hasUpdate.postValue(true)
-                return
+    private fun markDepartmentsAsEnabled(departments: List<Department>) {
+        Timber.d("Mark: add $departments to $departmentsByKoreanName")
+        departmentsByKoreanName.modifyMap {
+            departments.forEach {
+                this[it.koreanName] = this[it.koreanName]!!.copy(isNotificationEnabled = true)
             }
         }
-        _hasUpdate.postValue(false)
+    }
+
+    fun onItemClick(item: SubscriptionUiModel) {
+        val content = item.content
+        if (content in departmentsByKoreanName.value) {
+            // department
+            departmentsByKoreanName.modifyMap {
+                this[content] = this[content]!!.toggle()
+            }
+        } else {
+            // category
+            categories.modifyMap {
+                this[content] = this[content]!!.toggle()
+            }
+        }
+    }
+
+    fun rollback() {
+        categories.modifyMap {
+            this.clear()
+            initialCategories.value.forEach {
+                this[it.content] = it
+            }
+        }
+
+        departmentsByKoreanName.modifyMap {
+            this.clear()
+            initialDepartments.value.forEach {
+                this[it.koreanName] = it
+            }
+        }
     }
 
     private fun initialSortSubscription(subscribingList: List<String>) {
-        for (str in subscribingList) {
-            _subscriptionList.add(str)
-            _unSubscriptionList.remove(str)
+        val subscribingSet = subscribingList.toSet()
+        categories.modifyMap {
+            listOf("학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관").forEach {
+                this[it] = SubscriptionUiModel(it, it in subscribingSet)
+            }
         }
-        subscriptionList.postValue(sortedSubscriptionList)
-        unSubscriptionList.postValue(sortedUnSubscriptionList)
-        initFlag = true
+        initialCategories.modifySet { addAll(categories.value.values) }
+        _initCount++
     }
 
     /**
      * 변경될때마다 정렬하는 방식 채택
      * getPriority()가 낮을수록 앞쪽으로 정렬
      */
-    object CategoryComparator : Comparator<String> {
+    object CategoryComparator : Comparator<SubscriptionUiModel> {
         private fun getPriority(category: String): Int {
             return when (category) {
                 "학사" -> 1
@@ -172,10 +208,36 @@ class EditSubscriptionViewModel @Inject constructor(
             }
         }
 
-        override fun compare(a: String, b: String): Int {
-            return getPriority(a) - getPriority(b)
+        override fun compare(a: SubscriptionUiModel, b: SubscriptionUiModel): Int {
+            return getPriority(a.content) - getPriority(b.content)
         }
     }
+
+    object DepartmentComparator : Comparator<SubscriptionUiModel> {
+        override fun compare(p0: SubscriptionUiModel, p1: SubscriptionUiModel): Int {
+            return p0.content.compareTo(p1.content)
+        }
+    }
+
+    private fun Department.toSubscriptionUiModel() = SubscriptionUiModel(
+        content = koreanName,
+        isNotificationEnabled = isNotificationEnabled
+    )
+
+    private fun <K, V> MutableStateFlow<MutableMap<K, V>>.modifyMap(block: MutableMap<K, V>.() -> Unit) {
+        val newValue = this.value.toMutableMap().apply { block() }
+        Timber.d("before: $value, after: $newValue")
+        this.value = newValue
+    }
+
+    private fun <E> MutableStateFlow<MutableSet<E>>.modifySet(block: MutableSet<E>.() -> Unit) {
+        val newValue = this.value.toMutableSet().apply { block() }
+        Timber.d("before: $value, after: $newValue")
+        this.value = newValue
+    }
+
+    private fun Department.toggle() =
+        Department(name, shortName, koreanName, isSubscribed, isSelected, !isNotificationEnabled)
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/SubscriptionUiModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/SubscriptionUiModel.kt
@@ -1,0 +1,8 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription
+
+data class SubscriptionUiModel(
+    val content: String,
+    val isNotificationEnabled: Boolean,
+) {
+    fun toggle() = SubscriptionUiModel(content, !isNotificationEnabled)
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/NonLazyGrid.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/NonLazyGrid.kt
@@ -1,0 +1,71 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme.KuringTheme
+
+@Composable
+fun NonLazyGrid(
+    columns: Int,
+    itemCount: Int,
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    content: @Composable (Int) -> Unit
+) {
+    val rows = (itemCount - 1) / columns + 1
+    Column(
+        modifier = modifier,
+        verticalArrangement = verticalArrangement,
+    ) {
+        repeat(rows) { row ->
+            Row(
+                horizontalArrangement = horizontalArrangement,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                repeat(columns) { column ->
+                    val index = row * columns + column
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    ) {
+                        if (index < itemCount) {
+                            content(index)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NonLazyGridPreview() {
+    KuringTheme {
+        NonLazyGrid(
+            columns = 3,
+            itemCount = 8,
+        ) {
+            Text(
+                text = it.toString(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/SubscriptionDrawer.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/SubscriptionDrawer.kt
@@ -1,0 +1,297 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.ku_stacks.ku_ring.R
+import com.ku_stacks.ku_ring.ui.edit_subscription.SubscriptionUiModel
+import com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme.KuringTheme
+import com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme.SfProDisplay
+
+@Composable
+fun SubscriptionDrawer(
+    title: String,
+    subscriptionItems: List<SubscriptionUiModel>,
+    onHeaderClick: () -> Unit,
+    onItemClick: (SubscriptionUiModel) -> Unit,
+    isOpen: Boolean,
+    modifier: Modifier = Modifier,
+    columns: Int = 1,
+) {
+    val horizontalMargin = 16.dp
+    val roundedCornerShape = RoundedCornerShape(16.dp)
+
+    ConstraintLayout(
+        modifier = modifier
+            .clip(roundedCornerShape)
+            .background(Color.White.copy(alpha = .2f))
+            .animateContentSize()
+    ) {
+        val (header, grid, emptyText) = createRefs()
+        SubscriptionHeader(
+            title = title,
+            isOpen = isOpen,
+            horizontalMargin = horizontalMargin,
+            modifier = Modifier
+                .constrainAs(header) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    width = Dimension.matchParent
+                    if (!isOpen) {
+                        bottom.linkTo(parent.bottom)
+                    }
+                }
+                .clip(roundedCornerShape)
+                .clickable(onClick = onHeaderClick),
+        )
+        if (isOpen) {
+            if (subscriptionItems.isEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.subscribe_items_empty),
+                    fontFamily = SfProDisplay,
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier.constrainAs(emptyText) {
+                        top.linkTo(header.bottom, margin = 16.dp)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
+                        bottom.linkTo(parent.bottom, margin = 34.dp)
+                    },
+                )
+            } else {
+                SubscriptionGrid(
+                    columns = columns,
+                    subscriptionItems = subscriptionItems,
+                    onClick = onItemClick,
+                    modifier = Modifier.constrainAs(grid) {
+                        top.linkTo(header.bottom, margin = 3.dp)
+                        start.linkTo(parent.start, margin = horizontalMargin)
+                        end.linkTo(parent.end, margin = horizontalMargin)
+                        bottom.linkTo(parent.bottom, margin = 12.dp)
+                        width = Dimension.matchParent
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubscriptionHeader(
+    title: String,
+    isOpen: Boolean,
+    horizontalMargin: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val arrowAngle by animateFloatAsState(targetValue = if (isOpen) -90f else 90f)
+
+    ConstraintLayout(modifier = modifier) {
+        val (titleText, arrow) = createRefs()
+        SubscriptionTitle(
+            title = title,
+            modifier = Modifier.constrainAs(titleText) {
+                top.linkTo(parent.top, margin = 11.dp)
+                bottom.linkTo(parent.bottom, margin = 11.dp)
+                start.linkTo(parent.start, margin = horizontalMargin)
+            }
+        )
+        Image(
+            painter = painterResource(R.drawable.ic_arrow),
+            contentDescription = stringResource(R.string.subscribe_header_description),
+            modifier = Modifier
+                .rotate(arrowAngle)
+                .constrainAs(arrow) {
+                    top.linkTo(titleText.top)
+                    bottom.linkTo(titleText.bottom)
+                    end.linkTo(parent.end, margin = horizontalMargin)
+                }
+                .scale(0.7f),
+            colorFilter = ColorFilter.tint(Color.White),
+        )
+    }
+}
+
+@Composable
+private fun SubscriptionGrid(
+    columns: Int,
+    subscriptionItems: List<SubscriptionUiModel>,
+    onClick: (SubscriptionUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    NonLazyGrid(
+        columns = columns,
+        itemCount = subscriptionItems.size,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        SubscriptionItem(
+            subscriptionUiModel = subscriptionItems[it],
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+fun SubscriptionTitle(
+    title: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = title,
+        modifier = modifier,
+        fontFamily = SfProDisplay,
+        fontWeight = FontWeight.Bold,
+        fontSize = 15.sp,
+        color = Color.White,
+    )
+}
+
+@Composable
+fun SubscriptionItem(
+    subscriptionUiModel: SubscriptionUiModel,
+    onClick: (SubscriptionUiModel) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isEnabled = subscriptionUiModel.isNotificationEnabled
+    val backgroundColor by animateColorAsState(if (isEnabled) Color.White else Color.Transparent)
+    val textColor by animateColorAsState(if (isEnabled) MaterialTheme.colors.primary else Color.White)
+
+    val shape = RoundedCornerShape(8.dp)
+    TextButton(
+        onClick = { onClick(subscriptionUiModel) },
+        modifier = modifier
+            .border(1.dp, Color.White, shape)
+            .clip(shape)
+            .background(backgroundColor)
+            .height(44.dp)
+            .defaultMinSize(minWidth = 88.dp),
+    ) {
+        Text(
+            text = subscriptionUiModel.content,
+            fontFamily = SfProDisplay,
+            fontWeight = FontWeight.Normal,
+            fontSize = 15.sp,
+            color = textColor,
+        )
+    }
+}
+
+@Preview()
+@Composable
+fun SubscriptionTitlePreview() {
+    KuringTheme {
+        SubscriptionTitle(
+            title = "대학 공지 카테고리",
+            modifier = Modifier
+                .background(Color.Black)
+                .padding(10.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SubscriptionItemPreview() {
+    KuringTheme {
+        Box(
+            modifier = Modifier
+                .size(100.dp)
+                .background(MaterialTheme.colors.primary)
+                .background(Color.White.copy(alpha = 0.2f))
+        ) {
+            SubscriptionItem(
+                modifier = Modifier.align(Alignment.Center),
+                subscriptionUiModel = SubscriptionUiModel(
+                    content = "학사",
+                    isNotificationEnabled = true,
+                ),
+                onClick = { },
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SubscriptionDrawerPreview() {
+    val items = listOf("학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관").mapIndexed { index, s ->
+        SubscriptionUiModel(s, isNotificationEnabled = (index % 2 == 0))
+    }
+    var isOpen by remember { mutableStateOf(true) }
+    KuringTheme {
+        SubscriptionDrawer(
+            title = "대학 공지 카테고리",
+            isOpen = isOpen,
+            subscriptionItems = items,
+            onHeaderClick = { isOpen = !isOpen },
+            onItemClick = {},
+            columns = 3,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.primary)
+                .background(Color.White.copy(alpha = 0.2f))
+                .padding(10.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SubscriptionDrawerPreview_Empty() {
+    var isOpen by remember { mutableStateOf(true) }
+    KuringTheme {
+        SubscriptionDrawer(
+            title = "대학 공지 카테고리",
+            isOpen = isOpen,
+            subscriptionItems = emptyList(),
+            onHeaderClick = { isOpen = !isOpen },
+            onItemClick = {},
+            columns = 3,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.primary)
+                .background(Color.White.copy(alpha = 0.2f))
+                .padding(10.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/Subscriptions.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/Subscriptions.kt
@@ -1,0 +1,92 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import com.ku_stacks.ku_ring.ui.edit_subscription.SubscriptionUiModel
+import com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme.KuringTheme
+
+@Composable
+fun Subscriptions(
+    categories: List<SubscriptionUiModel>,
+    categoriesHeaderTitle: String,
+    departments: List<SubscriptionUiModel>,
+    departmentsHeaderTitle: String,
+    onItemClick: (SubscriptionUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isCategoryOpen by rememberSaveable { mutableStateOf(false) }
+    var isDepartmentOpen by rememberSaveable { mutableStateOf(false) }
+
+    ConstraintLayout(modifier = modifier) {
+        val (categoryGrid, departmentGrid) = createRefs()
+        SubscriptionDrawer(
+            title = categoriesHeaderTitle,
+            subscriptionItems = categories,
+            onHeaderClick = { isCategoryOpen = !isCategoryOpen },
+            onItemClick = onItemClick,
+            isOpen = isCategoryOpen,
+            columns = 3,
+            modifier = Modifier.constrainAs(categoryGrid) {
+                top.linkTo(parent.top)
+                start.linkTo(parent.start)
+                end.linkTo(parent.end)
+                width = Dimension.matchParent
+                height = Dimension.wrapContent
+            }
+        )
+        SubscriptionDrawer(
+            title = departmentsHeaderTitle,
+            subscriptionItems = departments,
+            onHeaderClick = { isDepartmentOpen = !isDepartmentOpen },
+            onItemClick = onItemClick,
+            isOpen = isDepartmentOpen,
+            columns = 1,
+            modifier = Modifier.constrainAs(departmentGrid) {
+                top.linkTo(categoryGrid.bottom, margin = 26.dp)
+                start.linkTo(categoryGrid.start)
+                end.linkTo(categoryGrid.end)
+                width = Dimension.matchParent
+                height = Dimension.wrapContent
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SubscriptionsPreview() {
+    val categories =
+        listOf("학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관").mapIndexed { index, s ->
+            SubscriptionUiModel(s, index < 3)
+        }
+    val departments = listOf("컴퓨터공학부", "스마트ICT융합공학과", "전기전자공학부").mapIndexed { index, s ->
+        SubscriptionUiModel(s, index == 0)
+    }
+    KuringTheme {
+        Subscriptions(
+            categories = categories,
+            categoriesHeaderTitle = "대학 공지 카테고리",
+            departments = departments,
+            departmentsHeaderTitle = "학과 공지 카테고리",
+            onItemClick = {},
+            modifier = Modifier
+                .background(MaterialTheme.colors.primary)
+                .padding(10.dp)
+                .fillMaxWidth()
+                .wrapContentHeight()
+        )
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/Color.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/Color.kt
@@ -1,0 +1,22 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme
+
+import androidx.compose.material.Colors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import com.ku_stacks.ku_ring.R
+
+private val KuringGreen: Color
+    @Composable get() = colorResource(R.color.kus_green)
+private val KuringGreen50: Color
+    @Composable get() = colorResource(R.color.kus_green_50)
+private val KuringSecondaryGreen: Color
+    @Composable get() = colorResource(R.color.kus_secondary_green)
+
+val colorPalette: Colors
+    @Composable get() = lightColors(
+        primary = KuringGreen,
+        primaryVariant = KuringGreen50,
+        secondary = KuringSecondaryGreen,
+    )

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/KuringTheme.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/KuringTheme.kt
@@ -1,0 +1,10 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+
+
+@Composable
+fun KuringTheme(content: @Composable () -> Unit) {
+    MaterialTheme(colors = colorPalette, content = content)
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/Typography.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/compose/theme/Typography.kt
@@ -1,0 +1,12 @@
+package com.ku_stacks.ku_ring.ui.edit_subscription.compose.theme
+
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import com.ku_stacks.ku_ring.R
+
+val SfProDisplay = FontFamily(
+    Font(R.font.sfpro_display_medium, FontWeight.Medium),
+    Font(R.font.sfpro_display_regular, FontWeight.Normal),
+    Font(R.font.sfpro_display_bold, FontWeight.Bold),
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/StateFlowUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/StateFlowUtil.kt
@@ -1,0 +1,16 @@
+package com.ku_stacks.ku_ring.util
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import timber.log.Timber
+
+fun <K, V> MutableStateFlow<MutableMap<K, V>>.modifyMap(block: MutableMap<K, V>.() -> Unit) {
+    val newValue = this.value.toMutableMap().apply { block() }
+    Timber.d("before: $value, after: $newValue")
+    this.value = newValue
+}
+
+fun <E> MutableStateFlow<MutableSet<E>>.modifySet(block: MutableSet<E>.() -> Unit) {
+    val newValue = this.value.toMutableSet().apply { block() }
+    Timber.d("before: $value, after: $newValue")
+    this.value = newValue
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/StateFlowUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/StateFlowUtil.kt
@@ -4,13 +4,21 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import timber.log.Timber
 
 fun <K, V> MutableStateFlow<MutableMap<K, V>>.modifyMap(block: MutableMap<K, V>.() -> Unit) {
-    val newValue = this.value.toMutableMap().apply { block() }
+    val newValue = try {
+        this.value.toMutableMap().apply { block() }
+    } catch (e: Exception) {
+        return
+    }
     Timber.d("before: $value, after: $newValue")
     this.value = newValue
 }
 
 fun <E> MutableStateFlow<MutableSet<E>>.modifySet(block: MutableSet<E>.() -> Unit) {
-    val newValue = this.value.toMutableSet().apply { block() }
+    val newValue = try {
+        this.value.toMutableSet().apply { block() }
+    } catch (e: Exception) {
+        return
+    }
     Timber.d("before: $value, after: $newValue")
     this.value = newValue
 }

--- a/app/src/main/res/layout/activity_edit_subscription.xml
+++ b/app/src/main/res/layout/activity_edit_subscription.xml
@@ -12,93 +12,94 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/kus_green">
+        android:background="@color/kus_green"
+        android:fillViewport="true">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <ImageButton
-            android:id="@+id/dismiss_bt"
-            confirmedImageIf="@{viewModel.hasUpdate}"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginStart="12dp"
-            android:layout_marginTop="20dp"
-            android:background="@null"
-            android:src="@drawable/ic_close"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/white" />
-
-        <ImageButton
-            android:id="@+id/rollback_bt"
-            visibleIf="@{viewModel.hasUpdate}"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginEnd="12dp"
-            android:background="@null"
-            android:src="@drawable/ic_undo"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/white" />
-
-        <ImageView
-            android:id="@+id/bell_img"
-            android:layout_width="44dp"
-            android:layout_height="46dp"
-            android:layout_marginTop="60dp"
-            android:background="@null"
-            android:src="@drawable/ic_bell"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/white" />
-
-        <TextView
-            android:id="@+id/explain_txt"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="18dp"
-            android:layout_marginTop="20dp"
-            android:layout_marginEnd="18dp"
-            android:fontFamily="@font/sfpro_display_semi_bold_italic"
-            android:gravity="center"
-            android:paddingTop="18dp"
-            android:paddingBottom="18dp"
-            android:text="@string/setting_notification_explain"
-            android:textColor="@color/white"
-            android:textSize="17sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/bell_img" />
+            android:layout_height="wrap_content">
 
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/compose_view"
-            android:layout_width="320dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/explain_txt" />
+            <ImageButton
+                android:id="@+id/dismiss_bt"
+                confirmedImageIf="@{viewModel.hasUpdate}"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="12dp"
+                android:layout_marginTop="20dp"
+                android:background="@null"
+                android:src="@drawable/ic_close"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/white" />
 
-        <Button
-            android:id="@+id/start_bt"
-            disableStartButtonIf="@{false}"
-            android:layout_width="match_parent"
-            android:layout_height="52dp"
-            android:layout_marginStart="64dp"
-            android:layout_marginEnd="64dp"
-            android:layout_marginBottom="20dp"
-            android:background="@drawable/button_white_disabled"
-            android:fontFamily="@font/sfpro_display_regular"
-            android:gravity="center"
-            android:text="@string/setting_notification_start"
-            android:textSize="15sp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            <ImageButton
+                android:id="@+id/rollback_bt"
+                visibleIf="@{viewModel.hasUpdate}"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="12dp"
+                android:background="@null"
+                android:src="@drawable/ic_undo"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/white" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <ImageView
+                android:id="@+id/bell_img"
+                android:layout_width="44dp"
+                android:layout_height="46dp"
+                android:layout_marginTop="60dp"
+                android:background="@null"
+                android:src="@drawable/ic_bell"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/white" />
+
+            <TextView
+                android:id="@+id/explain_txt"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="18dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="18dp"
+                android:fontFamily="@font/sfpro_display_semi_bold_italic"
+                android:gravity="center"
+                android:paddingTop="18dp"
+                android:paddingBottom="18dp"
+                android:text="@string/setting_notification_explain"
+                android:textColor="@color/white"
+                android:textSize="17sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/bell_img" />
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/compose_view"
+                android:layout_width="320dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/explain_txt" />
+
+            <Button
+                android:id="@+id/start_bt"
+                disableStartButtonIf="@{false}"
+                android:layout_width="match_parent"
+                android:layout_height="52dp"
+                android:layout_marginStart="64dp"
+                android:layout_marginEnd="64dp"
+                android:layout_marginBottom="20dp"
+                android:background="@drawable/button_white_disabled"
+                android:fontFamily="@font/sfpro_display_regular"
+                android:gravity="center"
+                android:text="@string/setting_notification_start"
+                android:textSize="15sp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/activity_edit_subscription.xml
+++ b/app/src/main/res/layout/activity_edit_subscription.xml
@@ -17,7 +17,8 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:paddingBottom="20dp">
 
             <ImageButton
                 android:id="@+id/dismiss_bt"
@@ -91,7 +92,6 @@
                 android:layout_height="52dp"
                 android:layout_marginStart="64dp"
                 android:layout_marginEnd="64dp"
-                android:layout_marginBottom="20dp"
                 android:background="@drawable/button_white_disabled"
                 android:fontFamily="@font/sfpro_display_regular"
                 android:gravity="center"

--- a/app/src/main/res/layout/activity_edit_subscription.xml
+++ b/app/src/main/res/layout/activity_edit_subscription.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.ku_stacks.ku_ring.ui.edit_subscription.EditSubscriptionViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/kus_green">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
         <ImageButton
             android:id="@+id/dismiss_bt"
@@ -70,45 +74,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/bell_img" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/subscribe_recyclerview"
-            android:layout_width="292dp"
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_view"
+            android:layout_width="320dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="22dp"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            android:layout_marginTop="20dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/explain_txt"
-            tools:itemCount="2" />
-
-        <View
-            android:id="@+id/partition_view"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginStart="90dp"
-            android:layout_marginTop="45dp"
-            android:layout_marginEnd="90dp"
-            android:background="@color/white"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/subscribe_recyclerview" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/unsubscribe_recyclerview"
-            android:layout_width="292dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="45dp"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/partition_view"
-            tools:itemCount="5" />
+            app:layout_constraintTop_toBottomOf="@id/explain_txt" />
 
         <Button
             android:id="@+id/start_bt"
-            disableStartButtonIf="@{viewModel.isSubscriptionEmpty}"
+            disableStartButtonIf="@{false}"
             android:layout_width="match_parent"
             android:layout_height="52dp"
             android:layout_marginStart="64dp"
@@ -123,4 +100,5 @@
             app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,12 @@
     <string name="setting_notification_explain"> 어떤 알림들을 받아보시겠습니까?\n알림 받고 싶은 카테고리를 선택해주세요.</string>
     <string name="setting_notification_start">시작하기</string>
 
+    <!--  subscribe screen -->
+    <string name="subscribe_category_title">대학 공지 카테고리</string>
+    <string name="subscribe_department_title">학과 공지 카테고리</string>
+    <string name="subscribe_items_empty">추가된 학과가 없습니다.</string>
+    <string name="subscribe_header_description">대학 공지 카테고리 열기</string>
+
     <!--  search  -->
     <string name="search_enter_keyword">검색어를 입력해주세요</string>
     <string name="search">검색</string>

--- a/app/src/test/java/com/ku_stacks/ku_ring/TestingLiveDataExt.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/TestingLiveDataExt.kt
@@ -20,8 +20,8 @@ fun <T> LiveData<T>.getOrAwaitValue(
     var data: T? = null
     val latch = CountDownLatch(1)
     val observer = object : Observer<T> {
-        override fun onChanged(o: T?) {
-            data = o
+        override fun onChanged(value: T) {
+            data = value
             latch.countDown()
             this@getOrAwaitValue.removeObserver(this)
         }

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.ku_stacks.ku_ring.MockUtil.mockDefaultResponse
 import com.ku_stacks.ku_ring.MockUtil.mockSubscribeListResponse
 import com.ku_stacks.ku_ring.MockUtil.mockSubscribeRequest
 import com.ku_stacks.ku_ring.SchedulersTestRule
+import com.ku_stacks.ku_ring.data.api.DepartmentClient
 import com.ku_stacks.ku_ring.data.api.NoticeClient
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import com.ku_stacks.ku_ring.util.WordConverter
@@ -26,6 +27,7 @@ class SubscribeRepositoryTest {
 
     private lateinit var repository: SubscribeRepository
     private val client: NoticeClient = Mockito.mock(NoticeClient::class.java)
+    private val departmentClient: DepartmentClient = Mockito.mock(DepartmentClient::class.java)
     private lateinit var pref: PreferenceUtil
 
     @get:Rule
@@ -38,7 +40,7 @@ class SubscribeRepositoryTest {
     @Before
     fun setup() {
         pref = PreferenceUtil(getApplicationContext())
-        repository = SubscribeRepositoryImpl(client, pref)
+        repository = SubscribeRepositoryImpl(client, departmentClient, pref)
     }
 
     @Test


### PR DESCRIPTION
# 배경

학과별 공지 기능의 일부로, 알림을 받을 학과를 고르는 화면이 필요함에 따라 개발하였습니다.

# 구현한 내용

## UI

Compose 프레임워크를 사용하여 개발하였습니다. Preview를 함께 보시면 코드를 이해하는 데 도움이 될 듯합니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/4160c293-7c2c-4995-a6f2-4b19d934fa6d)

`EditSubscriptionActivity`에 있던 `RecyclerView`를 제거하고, Compose로 구현한 `Subscriptions`로 교체했습니다. 동시에 `ViewModel`에 있던 여러 `LiveData`도 `Flow`로 수정했습니다.


## 로직

이전 PR에서 추가된 학과 데이터, 학과별 공지 데이터를 사용하여 구현하였습니다. 자세한 내용은 코멘트로 설명하겠습니다.