### PR TITLE
[수정] 학과별공지 로직 수정

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeFragment.kt
@@ -79,14 +79,14 @@ class DepartmentNoticeFragment : Fragment() {
             KuringTheme {
                 val selectedDepartments by viewModel.subscribedDepartments.collectAsState()
                 val noticesFlow by viewModel.currentDepartmentNotice.collectAsState()
-                val notices = noticesFlow.collectAsLazyPagingItems()
+                val notices = noticesFlow?.collectAsLazyPagingItems()
 
                 var isRefreshing by remember { mutableStateOf(false) }
                 val refreshState = rememberPullRefreshState(
                     refreshing = isRefreshing,
                     onRefresh = {
                         isRefreshing = true
-                        notices.refresh()
+                        notices?.refresh()
                         isRefreshing = false
                     },
                     refreshThreshold = 100.dp,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -48,11 +49,15 @@ class DepartmentNoticeViewModel @Inject constructor(
         initialValue = DepartmentNoticeScreenState.InitialLoading
     )
 
-    private var _currentDepartmentNotice: MutableStateFlow<Flow<PagingData<Notice>>> =
-        MutableStateFlow(departmentNoticeRepository.getDepartmentNotices("empty dept"))
-    val currentDepartmentNotice: StateFlow<Flow<PagingData<Notice>>>
-        get() = _currentDepartmentNotice
-
+    val currentDepartmentNotice: StateFlow<Flow<PagingData<Notice>>?> =
+        subscribedDepartments.map { departments ->
+            val selectedDepartment = departments.firstOrNull { it.isSelected }
+            if (selectedDepartment == null) {
+                null
+            } else {
+                departmentNoticeRepository.getDepartmentNotices(selectedDepartment.shortName)
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     init {
         collectSubscribedDepartments()
@@ -61,18 +66,40 @@ class DepartmentNoticeViewModel @Inject constructor(
     private fun collectSubscribedDepartments() {
         viewModelScope.launch {
             departmentRepository.getSubscribedDepartmentsAsFlow().collectLatest { departments ->
-                val sortedDepartments = departments.sortedBy { it.koreanName }
-                _subscribedDepartments.value = sortedDepartments
-                selectFirstDepartmentIfInitialLoad()
+                val beforeSelected = subscribedDepartments.value.firstOrNull { it.isSelected }
 
+                val markedDepartment =
+                    if (beforeSelected != null && departments.containsSelected(beforeSelected)) {
+                        departments.markDepartment(beforeSelected)
+                    } else {
+                        departments.selectFirstDepartment()
+                    }
+
+                _subscribedDepartments.value = markedDepartment
                 isInitialLoading.value = false
             }
         }
     }
 
-    private fun selectFirstDepartmentIfInitialLoad() {
-        if (isInitialLoading.value && _subscribedDepartments.value.isNotEmpty()) {
-            selectDepartment(_subscribedDepartments.value.first())
+    private fun List<Department>.containsSelected(selected: Department) =
+        this.any { it.koreanName == selected.koreanName }
+
+    private fun List<Department>.selectFirstDepartment(): List<Department> {
+        return if (this.isEmpty()) {
+            this
+        } else {
+            this.toMutableList().apply {
+                this[0] = this[0].copy(isSelected = true)
+            }
+        }
+    }
+
+    private fun List<Department>.markDepartment(department: Department): List<Department> {
+        return this.toMutableList().apply {
+            val index = this.indexOfFirst { it.koreanName == department.koreanName }
+            if (index != -1) {
+                this[index] = this[index].copy(isSelected = true)
+            }
         }
     }
 
@@ -90,8 +117,6 @@ class DepartmentNoticeViewModel @Inject constructor(
                 this[currentSelectedIndex] = this[currentSelectedIndex].copy(isSelected = false)
             }
         }
-        _currentDepartmentNotice.value =
-            departmentNoticeRepository.getDepartmentNotices(department.shortName)
     }
 }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeViewModel.kt
@@ -95,10 +95,11 @@ class DepartmentNoticeViewModel @Inject constructor(
     }
 
     private fun List<Department>.markDepartment(department: Department): List<Department> {
-        return this.toMutableList().apply {
-            val index = this.indexOfFirst { it.koreanName == department.koreanName }
-            if (index != -1) {
-                this[index] = this[index].copy(isSelected = true)
+        return this.map {
+            if (it.koreanName == department.koreanName) {
+                it.copy(isSelected = true)
+            } else {
+                it
             }
         }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentHeader.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentHeader.kt
@@ -1,6 +1,5 @@
 package com.ku_stacks.ku_ring.ui.main.notice.department.compose
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -25,7 +24,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.R
@@ -39,12 +37,17 @@ fun DepartmentHeader(
     onClick: () -> Unit,
     showArrow: Boolean,
     modifier: Modifier = Modifier,
+    isClickable: Boolean = true,
 ) {
     val description =
         if (showArrow) stringResource(id = R.string.department_selector_description) else ""
 
     Button(
-        onClick = onClick,
+        onClick = {
+            if (isClickable) {
+                onClick()
+            }
+        },
         modifier = modifier
             .clip(RoundedCornerShape(15.dp))
             .clearAndSetSemantics {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentNoticeScreen.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentNoticeScreen.kt
@@ -110,6 +110,7 @@ fun DepartmentNoticeScreen(
                 DepartmentHeader(
                     selectedDepartmentName = selectedDepartment?.koreanName ?: "d",
                     onClick = { scope.launch { sheetState.show() } },
+                    isClickable = selectedDepartments.size > 1,
                     showArrow = selectedDepartments.size > 1,
                     modifier = Modifier.constrainAs(selector) {
                         top.linkTo(parent.top, margin = 18.dp)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentNoticeScreen.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/compose/DepartmentNoticeScreen.kt
@@ -108,7 +108,7 @@ fun DepartmentNoticeScreen(
                 val (selector, noticesList, refreshIndicator) = createRefs()
                 val selectedDepartment = selectedDepartments.firstOrNull { it.isSelected }
                 DepartmentHeader(
-                    selectedDepartmentName = selectedDepartment?.koreanName ?: "d",
+                    selectedDepartmentName = selectedDepartment?.koreanName ?: "",
                     onClick = { scope.launch { sheetState.show() } },
                     isClickable = selectedDepartments.size > 1,
                     showArrow = selectedDepartments.size > 1,


### PR DESCRIPTION
# 문제 상황

* `선택한 학과`가 1개일 때에도 onClickListener가 작동합니다.
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/c7f49f40-9bc9-49ae-b84f-d93f8d401e64)


* `구독한 학과` 중 UI에서 보여줄 학과(`선택한 학과`)를 고르는 로직에 문제가 있었습니다. 구체적으로는 `선택한 학과`가 구독 취소되었음에도 불구하고 보여주려 한다던가, `선택한 학과`의 이름을 UI에 제대로 보여주지 못하는 문제가 있었습니다.

# 해결

* https://github.com/ku-ring/KU-Ring-Android/commit/d352b833c208c05152539157ea5d4a7650a7e7a9: 이제 `선택한 학과`가 1개일 때 onClickListener가 작동하지 않습니다.
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/44d35c35-b239-4c9d-87bb-e34e15b5618f)
* https://github.com/ku-ring/KU-Ring-Android/commit/81ba921de9df0fae3e4ae788f27adeb5a21148a2: `선택한 학과`를 고르는 로직을 단순하게 수정했습니다.