### PR TITLE
[수정] 공지보관함 아이콘 패딩 조정

### DIFF
--- a/app/src/main/res/drawable/ic_notice_storage.xml
+++ b/app/src/main/res/drawable/ic_notice_storage.xml
@@ -1,6 +1,6 @@
-<vector android:height="32dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
-    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M20,2H4C3,2 2,2.9 2,4v3.01C2,7.73 2.43,8.35 3,8.7V20c0,1.1 1.1,2 2,2h14c0.9,0 2,-0.9 2,-2V8.7c0.57,-0.35 1,-0.97 1,-1.69V4C22,2.9 21,2 20,2zM19,20H5V9h14V20zM20,7H4V4h16V7z"/>
     <path android:fillColor="@android:color/white" android:pathData="M9,12h6v2h-6z"/>
 </vector>


### PR DESCRIPTION
우선순위는 낮지만 작업내용도 간단하여 수정작업하였습니다.

#### 변경 사항
- 공지리리스트탭의 공지보관함 아이콘 사이즈조정

#### Screen shot

|AS IS|TO BE|
|:---:|:---:|
|<img width="300" alt="image" src="https://github.com/ku-ring/KU-Ring-Android/assets/45001093/14aa9e5d-4374-432e-bc4e-cd1af6803c82">|<img width="300" alt="image" src="https://github.com/ku-ring/KU-Ring-Android/assets/45001093/2fcceb78-8c96-4a5d-86c2-4a73299eb387">|



