### PR TITLE
[수정] 검색 API 변경사항 대응

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchNoticeDataResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchNoticeDataResponse.kt
@@ -1,0 +1,7 @@
+package com.ku_stacks.ku_ring.data.api.response
+
+import com.google.gson.annotations.SerializedName
+
+data class SearchNoticeDataResponse(
+    @SerializedName("noticeList") val noticeList: List<SearchNoticeResponse>
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchNoticeListResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchNoticeListResponse.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class SearchNoticeListResponse(
     @SerializedName("code") val code: Int,
     @SerializedName("message") val message: String,
-    @SerializedName("data") val data: List<SearchNoticeResponse>?,
+    @SerializedName("data") val data: SearchNoticeDataResponse?,
 ) {
     val isSuccess: Boolean
         get() = (code == 200)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchStaffDataResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchStaffDataResponse.kt
@@ -1,0 +1,7 @@
+package com.ku_stacks.ku_ring.data.api.response
+
+import com.google.gson.annotations.SerializedName
+
+data class SearchStaffDataResponse(
+    @SerializedName("staffList") val staffList: List<SearchStaffResponse>?
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchStaffListResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/SearchStaffListResponse.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class SearchStaffListResponse(
     @SerializedName("code") val code: Int,
     @SerializedName("message") val message: String,
-    @SerializedName("data") val data: List<SearchStaffResponse>?,
+    @SerializedName("data") val data: SearchStaffDataResponse?,
 ) {
     val isSuccess: Boolean
         get() = (code == 200)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ResponseToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ResponseToModelMapper.kt
@@ -56,18 +56,13 @@ fun NoticeListResponse.toNoticeList(type: String): List<Notice> {
 }
 
 fun SearchNoticeListResponse.toNoticeList(): List<Notice> {
-    return data?.map {
-        val url = if (it.category == "library") {
-            "${it.baseUrl}/${it.articleId}"
-        } else {
-            "${it.baseUrl}?id=${it.articleId}"
-        }
+    return data?.noticeList?.map {
 
         return@map Notice(
             postedDate = it.postedDate,
             subject = it.subject,
             category = it.category,
-            url = url,
+            url = it.baseUrl,
             articleId = it.articleId,
             isNew = false,
             isRead = false,
@@ -80,7 +75,7 @@ fun SearchNoticeListResponse.toNoticeList(): List<Notice> {
 }
 
 fun SearchStaffListResponse.toStaffList(): List<Staff> {
-    return data?.map {
+    return data?.staffList?.map {
         Staff(
             name = it.name,
             major = it.major,


### PR DESCRIPTION
# 검색 API 변경사항

* `baseUrl` 필드에 전체 URL을 담아줍니다.
* 아직 검색 API에서는 response 구조에서 응답 리스트의 level이 1 줄어들지 않았습니다.

# 대응
* https://github.com/ku-ring/KU-Ring-Android/commit/61efa118dbd16a787a8f5d1975c9fb29984a1dfd: baseUrl
* https://github.com/ku-ring/KU-Ring-Android/commit/1bc908b8a2337aacdec83a4761b7b5d6ef45061e: depth