### PR TITLE
[수정] 공지 알림을 터치했을 때 공지 페이지가 보이지 않던 현상 해결

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -17,7 +17,6 @@ import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
-import com.ku_stacks.ku_ring.util.UrlGenerator
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -43,12 +42,15 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        Timber.d("Notification hello")
         if (fcmUtil.isNoticeNotification(remoteMessage.data)) {
             val articleId = remoteMessage.data["articleId"]!!
             val category = remoteMessage.data["category"]!!
             val postedDate = remoteMessage.data["postedDate"]!!
             val subject = remoteMessage.data["subject"]!!
-            val baseUrl = remoteMessage.data["baseUrl"]!!
+            // 키 이름은 baseUrl이지만, 실제로는 full url이 내려오고 있음
+            val fullUrl = remoteMessage.data["baseUrl"]!!
+            Timber.d("Notification fullUrl at firebase messaging: $fullUrl")
 
             // insert into db
             val receivedDate = DateUtil.getCurrentTime()
@@ -57,21 +59,16 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
                 category = category,
                 postedDate = postedDate,
                 subject = subject,
-                baseUrl = baseUrl,
+                fullUrl = fullUrl,
                 receivedDate = receivedDate
             )
 
             // show notification
-            val webUrl = UrlGenerator.generateNoticeUrl(
-                articleId = articleId,
-                category = category,
-                baseUrl = baseUrl
-            )
             val categoryKr = WordConverter.convertEnglishToKorean(category)
             showNotificationWithUrl(
                 title = subject,
                 body = categoryKr,
-                url = webUrl,
+                url = fullUrl,
                 articleId = articleId,
                 category = category
             )

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/PushEntity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/PushEntity.kt
@@ -11,7 +11,7 @@ class PushEntity(
     @ColumnInfo(name = "category") val category: String,
     @ColumnInfo(name = "postedDate") val postedDate: String,
     @ColumnInfo(name = "subject") val subject: String,
-    @ColumnInfo(name = "baseUrl") val baseUrl: String,
+    @ColumnInfo(name = "baseUrl") val fullUrl: String,
     @ColumnInfo(name = "isNew") val isNew: Boolean,
     @ColumnInfo(name = "receivedDate") val receivedDate: String
 )

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
@@ -25,7 +25,7 @@ fun PushEntity.toPush(): Push {
         category = categoryEng,
         postedDate = postedDate,
         subject = subjectAndTag.first,
-        baseUrl = baseUrl,
+        fullUrl = fullUrl,
         isNew = isNew,
         receivedDate = receivedDate,
         tag = subjectAndTag.second

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
@@ -37,7 +37,7 @@ fun Push.toPushContentUiModel(): PushContentUiModel {
         categoryKor = categoryKor,
         postedDate = postedDate,
         subject = subject,
-        baseUrl = baseUrl,
+        fullUrl = fullUrl,
         isNew = isNew,
         receivedDate = receivedDate,
         tag = tag

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/model/Push.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/model/Push.kt
@@ -5,7 +5,7 @@ data class Push(
     val category: String,
     val postedDate: String,
     val subject: String,
-    val baseUrl: String,
+    val fullUrl: String,
     var isNew: Boolean,
     val receivedDate: String,
     val tag: List<String>

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -12,6 +12,7 @@ import com.ku_stacks.ku_ring.databinding.ActivityMainBinding
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import com.ku_stacks.ku_ring.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -52,6 +53,7 @@ class MainActivity : AppCompatActivity() {
             val category = intent.getStringExtra(NoticeWebActivity.NOTICE_CATEGORY)
             val postedDate = intent.getStringExtra(NoticeWebActivity.NOTICE_POSTED_DATE)
             val subject = intent.getStringExtra(NoticeWebActivity.NOTICE_SUBJECT)
+            Timber.d("Notification: received $articleId, $category, $postedDate, $subject, $it")
             navToNoticeActivity(it, articleId, category, postedDate, subject)
         }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
@@ -11,7 +11,7 @@ data class PushContentUiModel(
     val categoryKor: String,
     val postedDate: String,
     val subject: String,
-    val baseUrl: String,
+    val fullUrl: String,
     val isNew: Boolean,
     val receivedDate: String,
     val tag: List<String>

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
@@ -15,7 +15,6 @@ import com.ku_stacks.ku_ring.data.mapper.concatSubjectAndTag
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.ActivityNoticeWebBinding
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
-import com.ku_stacks.ku_ring.util.UrlGenerator
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -137,10 +136,9 @@ class NoticeWebActivity : AppCompatActivity() {
         fun createIntent(context: Context, pushContent: PushContentUiModel): Intent {
             with(pushContent) {
                 val categoryEng = WordConverter.convertKoreanToEnglish(categoryKor)
-                val url = UrlGenerator.generateNoticeUrl(articleId, categoryEng, baseUrl)
                 return createIntent(
                     context,
-                    url,
+                    fullUrl,
                     articleId,
                     categoryEng,
                     postedDate,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -12,10 +12,10 @@ import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
-import com.ku_stacks.ku_ring.util.UrlGenerator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -42,14 +42,17 @@ class SplashActivity : AppCompatActivity() {
                 launchedFromNoticeNotificationEvent(intent) -> {
                     handleNoticeNotification(intent)
                 }
+
                 launchedFromCustomNotificationEvent(intent) -> {
                     handleCustomNotification()
                 }
+
                 onboadingRequired() -> {
                     startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
                     overridePendingTransition(0, 0)
                     finish()
                 }
+
                 else -> {
                     startActivity(Intent(this@SplashActivity, MainActivity::class.java))
                     overridePendingTransition(0, 0)
@@ -71,6 +74,7 @@ class SplashActivity : AppCompatActivity() {
         for (key in this.keySet()) {
             map[key] = this.getString(key)
         }
+        Timber.d("Notification result: $map")
         return map
     }
 
@@ -80,25 +84,20 @@ class SplashActivity : AppCompatActivity() {
             val category = map["category"] ?: return
             val postedDate = map["postedDate"] ?: return
             val subject = map["subject"] ?: return
-            val baseUrl = map["baseUrl"] ?: return
-            val url = UrlGenerator.generateNoticeUrl(
-                articleId = articleId,
-                category = category,
-                baseUrl = baseUrl
-            )
+            val fullUrl = map["baseUrl"] ?: return
 
             fcmUtil.insertNotificationIntoDatabase(
                 articleId = articleId,
                 category = category,
                 postedDate = postedDate,
                 subject = subject,
-                baseUrl = baseUrl,
+                fullUrl = fullUrl,
                 receivedDate = DateUtil.getCurrentTime()
             )
 
             MainActivity.start(
                 activity = this@SplashActivity,
-                url = url,
+                url = fullUrl,
                 articleId = articleId,
                 category = category,
                 postedDate = postedDate,

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
@@ -19,10 +19,10 @@ class FcmUtil @Inject constructor(
         val categoryEng = data["category"]
         val postedDate = data["postedDate"]
         val subject = data["subject"]
-        val baseUrl = data["baseUrl"]
+        val fullUrl = data["baseUrl"]
 
         return articleId != null && categoryEng != null && postedDate != null
-            && subject != null && baseUrl != null
+            && subject != null && fullUrl != null
     }
 
     fun isCustomNotification(data: Map<String, String?>): Boolean {
@@ -40,7 +40,7 @@ class FcmUtil @Inject constructor(
         category: String,
         postedDate: String,
         subject: String,
-        baseUrl: String,
+        fullUrl: String,
         receivedDate: String
     ) {
         CoroutineScope(ioDispatcher).launch {
@@ -51,7 +51,7 @@ class FcmUtil @Inject constructor(
                         category = category,
                         postedDate = postedDate,
                         subject = subject,
-                        baseUrl = baseUrl,
+                        fullUrl = fullUrl,
                         isNew = true,
                         receivedDate = receivedDate
                     )

--- a/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
@@ -74,7 +74,7 @@ object MockUtil {
         category = "bachelor",
         postedDate = "20220203",
         subject = "2022학년도 1학기 재입학 합격자 유의사항 안내",
-        baseUrl = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do",
+        fullUrl = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do",
         isNew = false,
         receivedDate = "20220207-132051"
     )

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
@@ -27,7 +27,7 @@ class PushDaoTest : LocalDbAbstract() {
         category = "bachelor",
         postedDate = "2022-01-14 00:50:33",
         subject = "실감미디어 혁신 공유대학 융합전공 안내",
-        baseUrl = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do",
+        fullUrl = "http://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?forum=notice&sort=6&id=ababab",
         isNew = true,
         receivedDate = "20220114-005036"
     )
@@ -51,7 +51,7 @@ class PushDaoTest : LocalDbAbstract() {
         assertThat(pushFromDB.category, `is`(pushMock.category))
         assertThat(pushFromDB.postedDate, `is`(pushMock.postedDate))
         assertThat(pushFromDB.subject, `is`(pushMock.subject))
-        assertThat(pushFromDB.baseUrl, `is`(pushMock.baseUrl))
+        assertThat(pushFromDB.fullUrl, `is`(pushMock.fullUrl))
         assertThat(pushFromDB.isNew, `is`(pushMock.isNew))
         assertThat(pushFromDB.receivedDate, `is`(pushMock.receivedDate))
     }


### PR DESCRIPTION
# 배경
공지 알림을 터치했을 때 다음과 같이 공지 페이지가 보이지 않습니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/a2767831-8304-4a51-b605-934322c2da10)

원인은 서버에서 `baseUrl` 키 값에 전체 url을 넣어서 보내주는데, 앱에서는 base url을 받고 있다고 가정하여 이 뒤에 `articleId`를 덧붙였기 때문입니다.

## expected
구체적으로, 서버가 반환하는 url은 다음과 같으므로 이 url을 그대로 사용하면 문제가 없습니다.
```
https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b514fb
```

## actual
그런데 앱에서는 서버가 다음의 base url을 반환한다고 가정하여, 뒤에 `articleId`를 덧붙이고 있었습니다.
```
https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do
```
결과적으로 앱에서 웹뷰를 열기 위해 사용한 URL은 다음과 같습니다.
```
https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b514fb?id=5b514fb
```

# 변경사항

따라서 서버가 반환하는 url을 그대로 사용하도록 수정했습니다. 그런데 키 값이 `baseUrl`이라서 혼동을 불러일으킬 수 있으므로, 전체 url임을 명시적으로 보이기 위해 변수 이름은 `fullUrl`로 사용했습니다.

**단, DB의 column 이름은 변경하지 않았습니다**. 추후 서버에서 보내주는 키 값이 확정되면 한번에 바꾸려 합니다.

# 기타
핫픽스로 적용되어야 할 것 같은데, target branch를 `develop`이 아니라 `main`으로 해야 할까요?