### PR TITLE
[수정] 내 알림 화면에서 industry_university를 제대로 번역하지 않던 문제 해결

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
@@ -5,7 +5,6 @@ import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDataUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDateHeaderUiModel
 import com.ku_stacks.ku_ring.util.WordConverter
-import com.ku_stacks.ku_ring.util.isOnlyAlphabets
 
 fun List<Push>.toPushUiModelList(): List<PushDataUiModel> {
     val pushDataList = ArrayList<PushDataUiModel>()
@@ -27,11 +26,7 @@ fun List<Push>.toPushUiModelList(): List<PushDataUiModel> {
 }
 
 fun Push.toPushContentUiModel(): PushContentUiModel {
-    val categoryKor = if (category.isOnlyAlphabets()) {
-        WordConverter.convertEnglishToKorean(category)
-    } else {
-        category
-    }
+    val categoryKor = WordConverter.convertEnglishToKorean(category)
     return PushContentUiModel(
         articleId = articleId,
         categoryKor = categoryKor,


### PR DESCRIPTION
# 배경
제목이 곧 내용입니다.
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/6e05f974-51c3-4b06-9efa-925eba4f4cd4)

이 이유는 카테고리 문자열이 알파벳만으로 이루어졌을 때만 한국어로 번역했는데, 번역 로직에서 알파벳이 없는 경우도 고려하고 있기 때문에 조건문을 사용할 필요가 없습니다.

되려 `_`를 포함하는 `industry_university`가 `산학`으로 번역되지 않는 문제가 있었습니다.

# 변경사항
* https://github.com/ku-ring/KU-Ring-Android/commit/f6a670ae951f6ac1d231cd44f10d472e8ddeae52 : `industry_university`가 `산학`으로 제대로 번역되지 않던 문제를 해결했습니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/1b06a285-f1b0-4b95-8755-af769205522e)
