### PR TITLE
[수정] 학과 구독 request가 서버에 전달되지 않던 문제 해결

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,6 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.ku_stacks.ku_ring.data.api.request.** { *; }
 -keep class com.ku_stacks.ku_ring.data.api.response.** { *; }
 -keep class com.ku_stacks.ku_ring.data.db.** { *; }
 -keep class com.ku_stacks.ku_ring.data.model.** { *; }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/request/DepartmentSubscribeRequest.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/request/DepartmentSubscribeRequest.kt
@@ -1,5 +1,8 @@
 package com.ku_stacks.ku_ring.data.api.request
 
+import com.google.gson.annotations.SerializedName
+
 data class DepartmentSubscribeRequest(
+    @SerializedName(value = "departments")
     val departments: List<String>,
 )


### PR DESCRIPTION
# 배경

프로덕션 앱에서 학과를 구독해도, 구독한 결과가 서버에 반영되지 않습니다.

# 문제

**난독화된 파라미터 이름이 request에 들어가고 있었기 때문입니다.** 
```json
{"a":["khistory","kugeo"]}
```

다른 request에서 문제가 없었던 이유는 `@SerializedName` 어노테이션으로 파라미터 이름을 지정하고 있었기 때문입니다. 이 어노테이션이 없으면 필드 이름이 그대로 파라미터 이름으로 사용됩니다. 
```Kotlin
data class FeedbackRequest(
    @SerializedName(value = "id")
    val token: String,
    @SerializedName(value = "content")
    val content: String
)
```

# 수정사항
* https://github.com/ku-ring/KU-Ring-Android/commit/6ff2e993aa30fd3a1202a4e20c27fd0dd64caa02 : Proguard 난독화 규칙에서 모든 request 객체를 제외했습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/76b8ace71a1df2324626ac76c23b830e3159e7dd : 학과 구독 request의 파라미터 이름을 `@SerializedName`을 사용하여 명시적으로 지정했습니다.