### PR TITLE
[추가] 모든 request에 OS 버전과 앱 버전을 헤더로 추가

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
@@ -1,8 +1,11 @@
 package com.ku_stacks.ku_ring.data.api
 
+import android.os.Build
+import com.ku_stacks.ku_ring.BuildConfig
 import com.ku_stacks.ku_ring.data.api.request.FeedbackRequest
 import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import io.reactivex.rxjava3.core.Single
+import timber.log.Timber
 import javax.inject.Inject
 
 class FeedbackClient @Inject constructor(
@@ -11,5 +14,19 @@ class FeedbackClient @Inject constructor(
     fun sendFeedback(
         token: String,
         feedbackRequest: FeedbackRequest,
-    ): Single<DefaultResponse> = feedbackService.sendFeedback(token, feedbackRequest)
+    ): Single<DefaultResponse> {
+        val kuringVersion = BuildConfig.VERSION_NAME
+        val kuringVersionHeader = "Kuring/$kuringVersion"
+
+        val androidVersion = Build.VERSION.SDK_INT.toString() // 33
+        val androidVersionHeader = "Android/$androidVersion"
+
+        Timber.d("$androidVersionHeader, $kuringVersionHeader")
+        return feedbackService.sendFeedback(
+            token = token,
+            appVersion = kuringVersionHeader,
+            androidVersion = androidVersionHeader,
+            feedbackRequest = feedbackRequest
+        )
+    }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
@@ -1,11 +1,8 @@
 package com.ku_stacks.ku_ring.data.api
 
-import android.os.Build
-import com.ku_stacks.ku_ring.BuildConfig
 import com.ku_stacks.ku_ring.data.api.request.FeedbackRequest
 import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import io.reactivex.rxjava3.core.Single
-import timber.log.Timber
 import javax.inject.Inject
 
 class FeedbackClient @Inject constructor(
@@ -15,17 +12,8 @@ class FeedbackClient @Inject constructor(
         token: String,
         feedbackRequest: FeedbackRequest,
     ): Single<DefaultResponse> {
-        val kuringVersion = BuildConfig.VERSION_NAME
-        val kuringVersionHeader = "Kuring/$kuringVersion"
-
-        val androidVersion = Build.VERSION.SDK_INT.toString() // 33
-        val androidVersionHeader = "Android/$androidVersion"
-
-        Timber.d("$androidVersionHeader, $kuringVersionHeader")
         return feedbackService.sendFeedback(
             token = token,
-            appVersion = kuringVersionHeader,
-            androidVersion = androidVersionHeader,
             feedbackRequest = feedbackRequest
         )
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
@@ -11,6 +11,8 @@ interface FeedbackService {
     @POST("v2/users/feedbacks")
     fun sendFeedback(
         @Header("User-Token") token: String,
+        @Header("User-Agent") appVersion: String,
+        @Header("User-Agent") androidVersion: String,
         @Body feedbackRequest: FeedbackRequest,
     ): Single<DefaultResponse>
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
@@ -11,8 +11,6 @@ interface FeedbackService {
     @POST("v2/users/feedbacks")
     fun sendFeedback(
         @Header("User-Token") token: String,
-        @Header("User-Agent") appVersion: String,
-        @Header("User-Agent") androidVersion: String,
         @Body feedbackRequest: FeedbackRequest,
     ): Single<DefaultResponse>
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/HeaderInterceptor.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/HeaderInterceptor.kt
@@ -1,0 +1,28 @@
+package com.ku_stacks.ku_ring.data.api
+
+import android.os.Build
+import com.ku_stacks.ku_ring.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import timber.log.Timber
+
+class HeaderInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val newRequest = chain.request().newBuilder().addVersionHeader().build()
+        return chain.proceed(newRequest)
+    }
+
+    private fun Request.Builder.addVersionHeader(): Request.Builder {
+        val kuringVersion = BuildConfig.VERSION_NAME
+        val kuringVersionHeader = "Kuring/$kuringVersion"
+
+        val androidVersion = Build.VERSION.SDK_INT.toString() // 33
+        val androidVersionHeader = "Android/$androidVersion"
+
+        Timber.d("$androidVersionHeader, $kuringVersionHeader")
+        addHeader("User-Agent", kuringVersionHeader)
+        addHeader("User-Agent", androidVersionHeader)
+        return this
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/di/NetworkModule.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/di/NetworkModule.kt
@@ -31,6 +31,7 @@ object NetworkModule {
                     HttpLoggingInterceptor.Level.NONE
                 }
             })
+            .addInterceptor(HeaderInterceptor())
             .build()
     }
 


### PR DESCRIPTION
# 배경

피드백을 보낸 유저의 OS 버전과 앱 버전을 알고 있다면 이슈에 대응하기 더 쉬워집니다. 당연히 있어야 하는 기능이지만 생각도 못 하고 있었네요.

그런데 지금 생각해 보니, 피드백에만 넣는 게 아니라 모든 request에 추가하는 게 좋을 것 같습니다. 그래서 모든 요청에 헤더를 넣는 기능을 추가했습니다.

# 변경사항
* https://github.com/ku-ring/KU-Ring-Android/commit/3309134a318dc8bd79480ce83a093635cca32c47: 모든 request의 헤더에 app version 및 OS version을 넣는 OkHttp `Interceptor`를 구현했습니다.

FeedbackRequest
![](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/9c348d5f-c729-413e-a654-620af936d1f1)
NoticeRequest
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/089e39f8-7f11-431f-949b-6343a5fae5f7)
