### PR TITLE
kuring-42 푸시알림 클릭했을때 splashActivity 종료하도록 변경

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -42,23 +42,18 @@ class SplashActivity : AppCompatActivity() {
                 launchedFromNoticeNotificationEvent(intent) -> {
                     handleNoticeNotification(intent)
                 }
-
                 launchedFromCustomNotificationEvent(intent) -> {
                     handleCustomNotification()
                 }
-
                 onboadingRequired() -> {
                     startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
-                    overridePendingTransition(0, 0)
-                    finish()
                 }
-
                 else -> {
                     startActivity(Intent(this@SplashActivity, MainActivity::class.java))
-                    overridePendingTransition(0, 0)
-                    finish()
                 }
             }
+
+            finish()
         }
     }
 
@@ -119,5 +114,10 @@ class SplashActivity : AppCompatActivity() {
 
     private fun onboadingRequired(): Boolean {
         return pref.firstRunFlag && pref.subscription.isNullOrEmpty()
+    }
+
+    override fun finish() {
+        overridePendingTransition(0, 0)
+        super.finish()
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -45,7 +45,7 @@ class SplashActivity : AppCompatActivity() {
                 launchedFromCustomNotificationEvent(intent) -> {
                     handleCustomNotification()
                 }
-                onboadingRequired() -> {
+                onboardingRequired() -> {
                     startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
                 }
                 else -> {
@@ -112,7 +112,7 @@ class SplashActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
-    private fun onboadingRequired(): Boolean {
+    private fun onboardingRequired(): Boolean {
         return pref.firstRunFlag && pref.subscription.isNullOrEmpty()
     }
 


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-42

## 원인
- handleNoticeNotification(), handleCustomNotification() 호출된 이후에는 finish()가 불리지않았음

## 변경 내용
- SplashActivity가 노출된 모든 경우에 finish() 되도록 변경
