### PR TITLE
kuring-43 알림으로 온 공지를 북마크할 수 없던 문제 해결

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -13,6 +13,9 @@ interface NoticeDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertNoticeAsOld(notice: NoticeEntity): Completable
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertNotice(notice: NoticeEntity)
+
     @Query("SELECT * FROM NoticeEntity")
     fun getOldNoticeList(): Single<List<NoticeEntity>>
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/FcmUtil.kt
@@ -1,5 +1,7 @@
 package com.ku_stacks.ku_ring.util
 
+import com.ku_stacks.ku_ring.data.db.NoticeDao
+import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.db.PushDao
 import com.ku_stacks.ku_ring.data.db.PushEntity
 import com.ku_stacks.ku_ring.di.IODispatcher
@@ -11,6 +13,7 @@ import javax.inject.Inject
 
 class FcmUtil @Inject constructor(
     private val pushDao: PushDao,
+    private val noticeDao: NoticeDao,
     @IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
 
@@ -54,6 +57,19 @@ class FcmUtil @Inject constructor(
                         fullUrl = fullUrl,
                         isNew = true,
                         receivedDate = receivedDate
+                    )
+                )
+                noticeDao.insertNotice(
+                    NoticeEntity(
+                        articleId = articleId,
+                        category = category,
+                        subject = subject,
+                        postedDate = postedDate,
+                        url = fullUrl,
+                        isNew = true,
+                        isRead = false,
+                        isSaved = false,
+                        isReadOnStorage = false
                     )
                 )
                 Timber.e("insert notification success")


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-43

# 문제 상황

알림으로 온 새 공지를 북마크할 수 없습니다.

# 원인

알림으로 온 새 공지가 `NoticeEntity` 테이블에 저장되어 있지 않았기 때문입니다. 현재 로직상 공지를 북마크하려면 해당 공지가 DB에 존재해야 하는데, 기존 코드에서는 알림이 왔을 때 `PushEntity`만 저장하고 `NoticeEntity`는 저장하지 않았습니다.

# 해결 방법

`PushEntity`를 저장할 때 `NoticeEntity`도 함께 저장하도록 수정하면 됩니다.

# Jira

브랜치, PR, 커밋 모두 `kuring-{티켓번호}`를 맨 앞에 붙여야 Jira에 연결됩니다. 이 PR에서는 커밋 앞에 접두사를 붙이지 않아서 Jira에서 커밋 목록을 확인할 수 없습니다.

커밋도 보이면 좋긴 한데.. 커밋 이름 앞에도 접두사를 붙여야 할까요?