### PR TITLE
kuring-37 앱이 처음 실행될 때 알림 권한을 받도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -117,15 +117,6 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
 
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                channelId,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-            notificationManager.createNotificationChannel(channel)
-        }
         notificationManager.notify(0, notificationBuilder.build())
     }
 
@@ -150,15 +141,6 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
 
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                channelId,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_DEFAULT
-            )
-            notificationManager.createNotificationChannel(channel)
-        }
         notificationManager.notify(1, notificationBuilder.build())
     }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -1,10 +1,15 @@
 package com.ku_stacks.ku_ring.ui.splash
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
+import com.ku_stacks.ku_ring.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivitySplashBinding
 import com.ku_stacks.ku_ring.ui.main.MainActivity
@@ -42,12 +47,16 @@ class SplashActivity : AppCompatActivity() {
                 launchedFromNoticeNotificationEvent(intent) -> {
                     handleNoticeNotification(intent)
                 }
+
                 launchedFromCustomNotificationEvent(intent) -> {
                     handleCustomNotification()
                 }
+
                 onboardingRequired() -> {
+                    createNotificationChannel()
                     startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
                 }
+
                 else -> {
                     startActivity(Intent(this@SplashActivity, MainActivity::class.java))
                 }
@@ -114,6 +123,20 @@ class SplashActivity : AppCompatActivity() {
 
     private fun onboardingRequired(): Boolean {
         return pref.firstRunFlag && pref.subscription.isNullOrEmpty()
+    }
+
+    private fun createNotificationChannel() {
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                MyFireBaseMessagingService.CHANNEL_ID,
+                MyFireBaseMessagingService.CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
     }
 
     override fun finish() {


### PR DESCRIPTION
# 문제 상황

알림 권한을 앱을 처음 실행할 때 얻지 않고, 두 번째로 실행할 때 또는 그 이후에 권한을 얻고 있습니다. Android 13(API 33)부터는 권한을 받지 않으면 알림을 보낼 수 없으므로 알림 권한을 앱 최초 실행 시에 받는 것이 바람직합니다.

# 수정

* https://github.com/ku-ring/KU-Ring-Android/commit/9f9c5a54859b9923a84918e5c5030351c923711c: Android 13에서 추가된 알림 권한을 정의했습니다. 현재 쿠링 앱은 API 31을 타겟팅하고 있어서 이 권한이 작동하지는 않지만, 향후 API 타겟을 상향 조정할 때 사용할 수 있도록 추가해 두었습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/9bfb321b19e2d95d8ce7225baf12845106b01bf3: API 32 이하에서는 Notification Channel을 만들 때 OS에서 알림 권한을 자동으로 요청합니다. 따라서 스플래시 화면에서 Notification Channel을 만들도록 수정했습니다.

# 참고자료
https://salmonpack.tistory.com/32