### PR TITLE
kuring-46 공지 웹뷰 화면용 데이터 객체 생성

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -1,13 +1,11 @@
 package com.ku_stacks.ku_ring
 
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
@@ -95,8 +93,6 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
             url,
             articleId,
             category,
-            DateUtil.getToday(),
-            title
         )
         val pendingIntent = PendingIntent.getActivity(
             this,

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToModelMapper.kt
@@ -1,0 +1,10 @@
+package com.ku_stacks.ku_ring.data.mapper
+
+import com.ku_stacks.ku_ring.data.model.Notice
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
+
+fun Notice.toWebViewNotice() = WebViewNotice(
+    url = url,
+    articleId = articleId,
+    category = category
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/UiModelToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/UiModelToModelMapper.kt
@@ -1,0 +1,11 @@
+package com.ku_stacks.ku_ring.data.mapper
+
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
+import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
+import com.ku_stacks.ku_ring.util.WordConverter
+
+fun PushContentUiModel.toWebViewNotice() = WebViewNotice(
+    url = fullUrl,
+    articleId = articleId,
+    category = WordConverter.convertKoreanToEnglish(categoryKor),
+)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/model/WebViewNotice.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/model/WebViewNotice.kt
@@ -1,0 +1,9 @@
+package com.ku_stacks.ku_ring.data.model
+
+import java.io.Serializable
+
+data class WebViewNotice(
+    val url: String,
+    val articleId: String,
+    val category: String,
+): Serializable

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -132,8 +132,6 @@ class MainActivity : AppCompatActivity() {
             url: String,
             articleId: String,
             category: String,
-            postedDate: String,
-            subject: String
         ) {
             val intent = Intent(activity, MainActivity::class.java).apply {
                 putExtras(

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -5,9 +5,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.os.bundleOf
 import androidx.viewpager2.widget.ViewPager2
 import com.ku_stacks.ku_ring.R
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
 import com.ku_stacks.ku_ring.databinding.ActivityMainBinding
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import com.ku_stacks.ku_ring.util.showToast
@@ -36,25 +36,16 @@ class MainActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
 
-        intent?.getStringExtra(NoticeWebActivity.NOTICE_URL)?.let {
-            val articleId = intent.getStringExtra(NoticeWebActivity.NOTICE_ARTICLE_ID)
-            val category = intent.getStringExtra(NoticeWebActivity.NOTICE_CATEGORY)
-            val postedDate = intent.getStringExtra(NoticeWebActivity.NOTICE_POSTED_DATE)
-            val subject = intent.getStringExtra(NoticeWebActivity.NOTICE_SUBJECT)
-            navToNoticeActivity(it, articleId, category, postedDate, subject)
+        (intent?.getSerializableExtra(NoticeWebActivity.WEB_VIEW_NOTICE) as? WebViewNotice)?.let { webViewNotice ->
+            navToNoticeActivity(webViewNotice)
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        intent?.getStringExtra(NoticeWebActivity.NOTICE_URL)?.let {
-            val articleId = intent.getStringExtra(NoticeWebActivity.NOTICE_ARTICLE_ID)
-            val category = intent.getStringExtra(NoticeWebActivity.NOTICE_CATEGORY)
-            val postedDate = intent.getStringExtra(NoticeWebActivity.NOTICE_POSTED_DATE)
-            val subject = intent.getStringExtra(NoticeWebActivity.NOTICE_SUBJECT)
-            Timber.d("Notification: received $articleId, $category, $postedDate, $subject, $it")
-            navToNoticeActivity(it, articleId, category, postedDate, subject)
+        (intent?.getSerializableExtra(NoticeWebActivity.WEB_VIEW_NOTICE) as? WebViewNotice)?.let { webViewNotice ->
+            navToNoticeActivity(webViewNotice)
         }
 
         setupBinding()
@@ -93,22 +84,10 @@ class MainActivity : AppCompatActivity() {
         return true
     }
 
-    private fun navToNoticeActivity(
-        noticeUrl: String?,
-        articleId: String?,
-        category: String?,
-        postedDate: String?,
-        subject: String?,
-    ) {
-        val newIntent = NoticeWebActivity.createIntent(
-            this,
-            noticeUrl,
-            articleId,
-            category,
-            postedDate,
-            subject
-        )
-        startActivity(newIntent)
+    private fun navToNoticeActivity(webViewNotice: WebViewNotice) {
+        Timber.d("Notification received: $webViewNotice")
+        val intent = NoticeWebActivity.createIntent(this, webViewNotice)
+        startActivity(intent)
         overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
     }
 
@@ -134,14 +113,9 @@ class MainActivity : AppCompatActivity() {
             category: String,
         ) {
             val intent = Intent(activity, MainActivity::class.java).apply {
-                putExtras(
-                    bundleOf(
-                        NoticeWebActivity.NOTICE_URL to url,
-                        NoticeWebActivity.NOTICE_ARTICLE_ID to articleId,
-                        NoticeWebActivity.NOTICE_CATEGORY to category,
-                        NoticeWebActivity.NOTICE_POSTED_DATE to postedDate,
-                        NoticeWebActivity.NOTICE_SUBJECT to subject
-                    )
+                putExtra(
+                    NoticeWebActivity.WEB_VIEW_NOTICE,
+                    WebViewNotice(url, articleId, category),
                 )
             }
             activity.startActivity(intent)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.ui.notice_webview
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
 import com.ku_stacks.ku_ring.repository.NoticeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -20,12 +21,8 @@ class NoticeWebViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val disposable = CompositeDisposable()
-
-    private val articleId = savedStateHandle.getString(NoticeWebActivity.NOTICE_ARTICLE_ID)
-    private val category = savedStateHandle.getString(NoticeWebActivity.NOTICE_CATEGORY)
-    private val url = savedStateHandle.getString(NoticeWebActivity.NOTICE_URL)
-    private val postedDate = savedStateHandle.getString(NoticeWebActivity.NOTICE_POSTED_DATE)
-    private val subject = savedStateHandle.getString(NoticeWebActivity.NOTICE_SUBJECT)
+    private val webViewNotice =
+        savedStateHandle.get(NoticeWebActivity.WEB_VIEW_NOTICE) as? WebViewNotice
 
     private val _isSaved = MutableStateFlow(false)
     val isSaved: StateFlow<Boolean>
@@ -34,7 +31,7 @@ class NoticeWebViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->
-                _isSaved.value = savedNotices.any { it.articleId == articleId }
+                _isSaved.value = savedNotices.any { it.articleId == webViewNotice?.articleId }
             }
         }
     }
@@ -52,10 +49,14 @@ class NoticeWebViewModel @Inject constructor(
     }
 
     fun onSaveButtonClick() {
-        Timber.e("Save button click: $articleId, $category, $url, $postedDate, $subject")
-        if (articleId == null || category == null || url == null || postedDate == null || subject == null) return
+        Timber.e("Save button click: $webViewNotice")
+        if (webViewNotice == null) return
         viewModelScope.launch {
-            noticeRepository.updateSavedStatus(articleId, category, !isSaved.value)
+            noticeRepository.updateSavedStatus(
+                webViewNotice.articleId,
+                webViewNotice.category,
+                !isSaved.value
+            )
         }
     }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
@@ -67,6 +67,4 @@ class NoticeWebViewModel @Inject constructor(
             disposable.dispose()
         }
     }
-
-    private fun SavedStateHandle.getString(key: String) = get<String>(key)
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -104,8 +104,6 @@ class SplashActivity : AppCompatActivity() {
                 url = fullUrl,
                 articleId = articleId,
                 category = category,
-                postedDate = postedDate,
-                subject = subject
             )
         }
     }


### PR DESCRIPTION
# 문제 상황

공지 웹뷰를 보여주는 데 필요한 매개변수가 많아지면서, Intent에 데이터를 put, get하는 코드가 너무 길어졌습니다. 심지어 몇몇 필드는 아예 필요하지도 않습니다.

```Kotlin
intent?.getStringExtra(NoticeWebActivity.NOTICE_URL)?.let {
    val articleId = intent.getStringExtra(NoticeWebActivity.NOTICE_ARTICLE_ID)
    val category = intent.getStringExtra(NoticeWebActivity.NOTICE_CATEGORY)
    val postedDate = intent.getStringExtra(NoticeWebActivity.NOTICE_POSTED_DATE) // postedDate와 subject는 필요하지 않음
    val subject = intent.getStringExtra(NoticeWebActivity.NOTICE_SUBJECT)
    navToNoticeActivity(it, articleId, category, postedDate, subject)
}
```

공지 웹뷰를 보여줄 때 필요한 데이터를 클래스로 선언하고, 필요없는 일부 매개변수는 제거하였습니다.

# 수정 사항

* e58a00f513702d1678a5df1a933387545f67b9a3: 공지 웹뷰를 보여주는 데 사용되는 `WebViewNotice`를 선언했습니다. 
* 8cfe273c205d880f13f5cc01a260cb3ba5b86538: 웹뷰에서 사용하지 않는 `postedDate`, `subject` 매개변수를 제거했습니다.
* e26847ef208cdf9f258431c5d0102375cb1b7bb7: Intent에 개별 매개변수 대신 `WebViewNotice`만을 put, get하도록 수정했습니다.
* c86f987b4588118820f1acd992a0918cc142abd5: 더 이상 사용하지 않는 함수를 제거했습니다.