### PR TITLE
kuring-38 [수정] 서버에서 학과 이름이 바뀌었을 때 로컬 DB에도 반영하도록 수정

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
@@ -20,8 +20,10 @@ interface DepartmentDao {
     @Query("SELECT * FROM departments WHERE koreanName LIKE '%' || :koreanName || '%'")
     suspend fun getDepartmentsByKoreanName(koreanName: String): List<DepartmentEntity>
 
-    @Query("SELECT COUNT(*) FROM departments")
-    suspend fun getDepartmentsSize(): Int
+    @Query("SELECT EXISTS (SELECT 1 FROM departments LIMIT 1)")
+    suspend fun isNotEmpty(): Boolean
+
+    suspend fun isEmpty(): Boolean = !isNotEmpty()
 
     @Query("UPDATE departments SET shortName = :shortName, koreanName = :koreanName WHERE name = :name")
     suspend fun updateDepartment(name: String, shortName: String, koreanName: String)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
@@ -20,6 +20,9 @@ interface DepartmentDao {
     @Query("SELECT * FROM departments WHERE koreanName LIKE '%' || :koreanName || '%'")
     suspend fun getDepartmentsByKoreanName(koreanName: String): List<DepartmentEntity>
 
+    @Query("SELECT COUNT(*) FROM departments")
+    suspend fun getDepartmentsSize(): Int
+
     @Query("UPDATE departments SET shortName = :shortName, koreanName = :koreanName WHERE name = :name")
     suspend fun updateDepartment(name: String, shortName: String, koreanName: String)
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/DepartmentDao.kt
@@ -20,6 +20,9 @@ interface DepartmentDao {
     @Query("SELECT * FROM departments WHERE koreanName LIKE '%' || :koreanName || '%'")
     suspend fun getDepartmentsByKoreanName(koreanName: String): List<DepartmentEntity>
 
+    @Query("UPDATE departments SET shortName = :shortName, koreanName = :koreanName WHERE name = :name")
+    suspend fun updateDepartment(name: String, shortName: String, koreanName: String)
+
     @Query("SELECT * FROM departments WHERE isSubscribed = :isSubscribed")
     suspend fun getDepartmentsBySubscribed(isSubscribed: Boolean): List<DepartmentEntity>
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
@@ -4,8 +4,8 @@ import com.ku_stacks.ku_ring.data.model.Department
 import kotlinx.coroutines.flow.Flow
 
 interface DepartmentRepository {
-    suspend fun insertAllDepartmentsFromRemote()
-    suspend fun fetchAllDepartmentsFromRemote(): List<Department>?
+    suspend fun updateDepartmentsFromRemote()
+    suspend fun fetchDepartmentsFromRemote(): List<Department>?
     suspend fun insertDepartment(department: Department)
     suspend fun insertDepartments(departments: List<Department>)
     suspend fun getAllDepartments(): List<Department>

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepository.kt
@@ -5,8 +5,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface DepartmentRepository {
     suspend fun updateDepartmentsFromRemote()
-    suspend fun fetchDepartmentsFromRemote(): List<Department>?
-    suspend fun insertDepartment(department: Department)
     suspend fun insertDepartments(departments: List<Department>)
     suspend fun getAllDepartments(): List<Department>
     suspend fun getDepartmentsByKoreanName(koreanName: String): List<Department>

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -34,7 +34,7 @@ class DepartmentRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun fetchDepartmentsFromRemote(): List<Department>? {
+    private suspend fun fetchDepartmentsFromRemote(): List<Department>? {
         return runCatching {
             departmentClient.fetchDepartmentList().data?.map { it.toDepartment() } ?: emptyList()
         }.getOrNull()
@@ -58,7 +58,7 @@ class DepartmentRepositoryImpl @Inject constructor(
         this.departments = null
     }
 
-    override suspend fun insertDepartment(department: Department) {
+    private suspend fun insertDepartment(department: Department) {
         withContext(ioDispatcher) {
             departmentDao.insertDepartment(department.toEntity())
         }

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -23,8 +23,8 @@ class DepartmentRepositoryImpl @Inject constructor(
     // null: 데이터가 업데이트되어 새 데이터를 가져와야 함
     private var departments: List<Department>? = null
 
-    override suspend fun insertAllDepartmentsFromRemote() {
-        val departments = fetchAllDepartmentsFromRemote()
+    override suspend fun updateDepartmentsFromRemote() {
+        val departments = fetchDepartmentsFromRemote()
         departments?.let {
             if (departmentDao.getDepartmentsSize() == 0) {
                 departmentDao.insertDepartments(departments.toEntityList())
@@ -34,7 +34,7 @@ class DepartmentRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun fetchAllDepartmentsFromRemote(): List<Department>? {
+    override suspend fun fetchDepartmentsFromRemote(): List<Department>? {
         return runCatching {
             departmentClient.fetchDepartmentList().data?.map { it.toDepartment() } ?: emptyList()
         }.getOrNull()

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -26,7 +26,7 @@ class DepartmentRepositoryImpl @Inject constructor(
     override suspend fun updateDepartmentsFromRemote() {
         val departments = fetchDepartmentsFromRemote()
         departments?.let {
-            if (departmentDao.getDepartmentsSize() == 0) {
+            if (departmentDao.isEmpty()) {
                 departmentDao.insertDepartments(departments.toEntityList())
             } else {
                 updateDepartmentsName(it)

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -45,8 +45,9 @@ class DepartmentRepositoryImpl @Inject constructor(
         val updateTargets = departments.filter { department ->
             val originalPosition =
                 sortedOriginalDepartments.binarySearch { it.name.compareTo(department.name) }
+                    .takeIf { it >= 0 } ?: return@filter false
             val originalDepartment = sortedOriginalDepartments[originalPosition]
-            return@filter originalDepartment.name != department.name || originalDepartment.koreanName != department.koreanName
+            return@filter originalDepartment.shortName != department.shortName || originalDepartment.koreanName != department.koreanName
         }
 
         withContext(ioDispatcher) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -41,8 +41,17 @@ class DepartmentRepositoryImpl @Inject constructor(
     }
 
     private suspend fun updateDepartmentsName(departments: List<Department>) {
+        val sortedOriginalDepartments = this.departments?.sortedBy { it.name }
+        val updateTargets = departments.filter { department ->
+            val originalPosition =
+                sortedOriginalDepartments?.binarySearch { it.name.compareTo(department.name) }
+                    ?: return@filter true
+            val originalDepartment = sortedOriginalDepartments[originalPosition]
+            return@filter originalDepartment.name != department.name || originalDepartment.koreanName != department.koreanName
+        }
+
         withContext(ioDispatcher) {
-            departments.forEach { (name, shortName, koreanName, _) ->
+            updateTargets.forEach { (name, shortName, koreanName, _) ->
                 departmentDao.updateDepartment(name, shortName, koreanName)
             }
         }

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryImpl.kt
@@ -41,11 +41,10 @@ class DepartmentRepositoryImpl @Inject constructor(
     }
 
     private suspend fun updateDepartmentsName(departments: List<Department>) {
-        val sortedOriginalDepartments = this.departments?.sortedBy { it.name }
+        val sortedOriginalDepartments = getAllDepartments().sortedBy { it.name }
         val updateTargets = departments.filter { department ->
             val originalPosition =
-                sortedOriginalDepartments?.binarySearch { it.name.compareTo(department.name) }
-                    ?: return@filter true
+                sortedOriginalDepartments.binarySearch { it.name.compareTo(department.name) }
             val originalDepartment = sortedOriginalDepartments[originalPosition]
             return@filter originalDepartment.name != department.name || originalDepartment.koreanName != department.koreanName
         }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -100,7 +100,7 @@ class EditSubscriptionViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            departmentRepository.insertAllDepartmentsFromRemote()
+            departmentRepository.updateDepartmentsFromRemote()
             val subscribedDepartments = departmentRepository.getSubscribedDepartments()
             addDepartmentsToMap(subscribedDepartments)
             val notificationEnabledDepartments = repository.fetchSubscribedDepartments()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/fragment_subscribe/DepartmentSubscribeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/fragment_subscribe/DepartmentSubscribeViewModel.kt
@@ -27,7 +27,7 @@ class DepartmentSubscribeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            departmentRepository.insertAllDepartmentsFromRemote()
+            departmentRepository.updateDepartmentsFromRemote()
         }
 
         searchKeyword.onEach { loadFilteredDepartment(it) }

--- a/app/src/test/java/com/ku_stacks/ku_ring/LocalDbAbstract.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/LocalDbAbstract.kt
@@ -1,4 +1,4 @@
-package com.ku_stacks.ku_ring.persistence
+package com.ku_stacks.ku_ring
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider.getApplicationContext

--- a/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
@@ -10,6 +10,7 @@ import com.ku_stacks.ku_ring.data.api.response.NoticeResponse
 import com.ku_stacks.ku_ring.data.api.response.SubscribeListResponse
 import com.ku_stacks.ku_ring.data.api.response.UserListResponse
 import com.ku_stacks.ku_ring.data.api.response.UserResponse
+import com.ku_stacks.ku_ring.data.db.DepartmentEntity
 import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.db.PushEntity
 import com.ku_stacks.ku_ring.data.model.Notice
@@ -56,6 +57,13 @@ object MockUtil {
         isRead = true,
         isSaved = false,
         isReadOnStorage = false,
+    )
+
+    fun mockDepartmentEntity() = DepartmentEntity(
+        name = "smart_ict_convergence",
+        shortName = "sicte",
+        koreanName = "스마트ICT융합공학과",
+        isSubscribed = false,
     )
 
     fun mockNotice() = Notice(

--- a/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/MockUtil.kt
@@ -13,6 +13,7 @@ import com.ku_stacks.ku_ring.data.api.response.UserResponse
 import com.ku_stacks.ku_ring.data.db.DepartmentEntity
 import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.db.PushEntity
+import com.ku_stacks.ku_ring.data.model.Department
 import com.ku_stacks.ku_ring.data.model.Notice
 import org.mockito.Mockito
 
@@ -78,6 +79,15 @@ object MockUtil {
         isSaved = false,
         isReadOnStorage = false,
         tag = emptyList()
+    )
+
+    fun mockDepartment() = Department(
+        name = "smart_ict_convergence",
+        shortName = "sicte",
+        koreanName = "스마트ICT융합공학과",
+        isSubscribed = false,
+        isSelected = false,
+        isNotificationEnabled = false,
     )
 
     fun mockPushEntity() = PushEntity(

--- a/app/src/test/java/com/ku_stacks/ku_ring/paging_source/DepartmentNoticeMediatorTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/paging_source/DepartmentNoticeMediatorTest.kt
@@ -13,7 +13,7 @@ import com.ku_stacks.ku_ring.data.api.NoticeClient
 import com.ku_stacks.ku_ring.data.db.NoticeDao
 import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.source.DepartmentNoticeMediator
-import com.ku_stacks.ku_ring.persistence.LocalDbAbstract
+import com.ku_stacks.ku_ring.LocalDbAbstract
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.persistence
 
+import com.ku_stacks.ku_ring.LocalDbAbstract
 import com.ku_stacks.ku_ring.MockUtil
 import com.ku_stacks.ku_ring.data.db.DepartmentDao
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
@@ -1,0 +1,44 @@
+package com.ku_stacks.ku_ring.persistence
+
+import com.ku_stacks.ku_ring.MockUtil
+import com.ku_stacks.ku_ring.data.db.DepartmentDao
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class DepartmentDaoTest : LocalDbAbstract() {
+    private lateinit var departmentDao: DepartmentDao
+
+    @Before
+    fun setup() {
+        departmentDao = db.departmentDao()
+    }
+
+    @Test
+    fun `insertDepartment and updateDepartment test`() = runTest {
+        // given
+        val entity = MockUtil.mockDepartmentEntity()
+        departmentDao.insertDepartment(entity)
+
+        // when
+        val newShortName = "ict"
+        val newKoreanName = "스융공"
+        departmentDao.updateDepartment(
+            name = entity.name,
+            shortName = newShortName,
+            koreanName = newKoreanName
+        )
+
+        // then
+        val result = departmentDao.getDepartmentsByName(entity.name)
+        assert(result.isNotEmpty())
+        assertEquals(1, result.size)
+        assertEquals(result[0], entity.copy(shortName = newShortName, koreanName = newKoreanName))
+    }
+}

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/DepartmentDaoTest.kt
@@ -6,6 +6,7 @@ import com.ku_stacks.ku_ring.data.db.DepartmentDao
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,8 +25,10 @@ class DepartmentDaoTest : LocalDbAbstract() {
     @Test
     fun `insertDepartment and updateDepartment test`() = runTest {
         // given
+        assert(departmentDao.isEmpty())
         val entity = MockUtil.mockDepartmentEntity()
         departmentDao.insertDepartment(entity)
+        assertFalse(departmentDao.isEmpty())
 
         // when
         val newShortName = "ict"

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.persistence
 
 import androidx.paging.PagingSource
+import com.ku_stacks.ku_ring.LocalDbAbstract
 import com.ku_stacks.ku_ring.data.db.NoticeDao
 import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.persistence
 
+import com.ku_stacks.ku_ring.LocalDbAbstract
 import com.ku_stacks.ku_ring.data.db.PushDao
 import com.ku_stacks.ku_ring.data.db.PushEntity
 import kotlinx.coroutines.runBlocking

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryTest.kt
@@ -58,13 +58,14 @@ class DepartmentRepositoryTest : LocalDbAbstract() {
         assertEquals(departments.size, departmentRepository.getAllDepartments().size)
 
         // when
-        val updatedDepartmentsResponse = departments.map { department ->
-            DepartmentResponse(
-                name = department.name,
-                shortName = department.shortName.repeat(2),
-                korName = department.koreanName.repeat(2),
-            )
-        }
+        val updatedDepartmentsResponse =
+            departments.mapIndexed { index, (name, shortName, koreanName, _) ->
+                DepartmentResponse(
+                    name = name,
+                    shortName = if (index % 2 == 0) shortName else shortName.repeat(2),
+                    korName = if (index % 2 == 0) koreanName else koreanName.repeat(2),
+                )
+            }
         Mockito.`when`(departmentClient.fetchDepartmentList())
             .thenReturn(DepartmentListResponse(200, "success", updatedDepartmentsResponse))
         departmentRepository.updateDepartmentsFromRemote()

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/DepartmentRepositoryTest.kt
@@ -1,0 +1,78 @@
+package com.ku_stacks.ku_ring.repository
+
+import com.ku_stacks.ku_ring.LocalDbAbstract
+import com.ku_stacks.ku_ring.MockUtil
+import com.ku_stacks.ku_ring.data.api.DepartmentClient
+import com.ku_stacks.ku_ring.data.api.response.DepartmentListResponse
+import com.ku_stacks.ku_ring.data.api.response.DepartmentResponse
+import com.ku_stacks.ku_ring.data.db.DepartmentDao
+import com.ku_stacks.ku_ring.data.mapper.toDepartment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DepartmentRepositoryTest : LocalDbAbstract() {
+    private lateinit var departmentRepository: DepartmentRepository
+    private lateinit var departmentDao: DepartmentDao
+    private val departmentClient = Mockito.mock(DepartmentClient::class.java)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        departmentDao = db.departmentDao()
+        departmentRepository = DepartmentRepositoryImpl(
+            departmentDao = departmentDao,
+            departmentClient = departmentClient,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // integrated test
+    @Test
+    fun `insert and update departments test`() = runTest {
+        // given
+        val departments = (1..10).map {
+            MockUtil.mockDepartment().copy(
+                name = it.toString(),
+                shortName = "dep$it",
+                koreanName = "학과 $it",
+            )
+        }
+        departmentRepository.insertDepartments(departments)
+        assertEquals(departments.size, departmentRepository.getAllDepartments().size)
+
+        // when
+        val updatedDepartmentsResponse = departments.map { department ->
+            DepartmentResponse(
+                name = department.name,
+                shortName = department.shortName.repeat(2),
+                korName = department.koreanName.repeat(2),
+            )
+        }
+        Mockito.`when`(departmentClient.fetchDepartmentList())
+            .thenReturn(DepartmentListResponse(200, "success", updatedDepartmentsResponse))
+        departmentRepository.updateDepartmentsFromRemote()
+
+        // then
+        val expectedDepartments =
+            updatedDepartmentsResponse.map { it.toDepartment() }.sortedBy { it.name }
+        val actual = departmentRepository.getAllDepartments().sortedBy { it.name }
+        assertEquals(expectedDepartments, actual)
+    }
+}


### PR DESCRIPTION
# 문제 상황

서버에서 학과 이름이 바뀌어도(예: 문화컨텐츠 -> 문화콘텐츠) 로컬 DB에서 바뀐 이름을 저장하지 않습니다.

# 해결 방법

서버에서 학과 데이터를 가져올 때, 로컬 DB가 비어 있지 않다면 DB에 저장된 학과 중 이름이 바뀐 학과를 업데이트하면 됩니다.

# 커밋 설명

코멘트로 설명하겠습니다.