### PR TITLE
kuring-62 [추가] 앱 재실행 유도 알림을 발송하는 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,6 +230,10 @@ dependencies {
     implementation "androidx.paging:paging-compose:1.0.0-alpha19"
     implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
 
+    // WorkManager
+    def work_version = '2.7.1'
+    implementation "androidx.work:work-runtime-ktx:$work_version"
+    androidTestImplementation "androidx.work:work-testing:$work_version"
 
     // Shimmer effect
     implementation 'com.facebook.shimmer:shimmer:0.5.0'

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -9,6 +9,9 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.ku_stacks.ku_ring.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivitySplashBinding
@@ -17,10 +20,12 @@ import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
+import com.ku_stacks.ku_ring.work.ReengagementNotificationWork
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,6 +44,8 @@ class SplashActivity : AppCompatActivity() {
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_splash)
         binding.lifecycleOwner = this
+
+        enqueueReengagementNotificationWork()
 
         lifecycleScope.launch {
             delay(1000)
@@ -64,6 +71,22 @@ class SplashActivity : AppCompatActivity() {
 
             finish()
         }
+    }
+
+    private fun enqueueReengagementNotificationWork() {
+        val currentTime = System.currentTimeMillis()
+        val afterOneWeek = DateUtil.getCalendar(7, 12, 0, 0)
+        val delayInMillis = afterOneWeek.timeInMillis - currentTime
+
+        val notificationWorkRequest = OneTimeWorkRequestBuilder<ReengagementNotificationWork>()
+            .setInitialDelay(delayInMillis, TimeUnit.MILLISECONDS)
+            .build()
+        WorkManager.getInstance(this).enqueueUniqueWork(
+            ReengagementNotificationWork.WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            notificationWorkRequest,
+        )
+        Timber.d("Enqueue re-engagement notification work at $afterOneWeek")
     }
 
     private fun launchedFromNoticeNotificationEvent(intent: Intent): Boolean {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -75,7 +75,7 @@ class SplashActivity : AppCompatActivity() {
 
     private fun enqueueReengagementNotificationWork() {
         val currentTime = System.currentTimeMillis()
-        val afterOneWeek = DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0)
+        val afterOneWeek = DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0) ?: return
         val delayInMillis = afterOneWeek.timeInMillis - currentTime
 
         val notificationWorkRequest = OneTimeWorkRequestBuilder<ReengagementNotificationWork>()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -20,7 +20,7 @@ import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
-import com.ku_stacks.ku_ring.work.ReengagementNotificationWork
+import com.ku_stacks.ku_ring.work.ReEngagementNotificationWork
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -78,11 +78,11 @@ class SplashActivity : AppCompatActivity() {
         val afterOneWeek = DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0) ?: return
         val delayInMillis = afterOneWeek.timeInMillis - currentTime
 
-        val notificationWorkRequest = OneTimeWorkRequestBuilder<ReengagementNotificationWork>()
+        val notificationWorkRequest = OneTimeWorkRequestBuilder<ReEngagementNotificationWork>()
             .setInitialDelay(delayInMillis, TimeUnit.MILLISECONDS)
             .build()
         WorkManager.getInstance(this).enqueueUniqueWork(
-            ReengagementNotificationWork.WORK_NAME,
+            ReEngagementNotificationWork.WORK_NAME,
             ExistingWorkPolicy.REPLACE,
             notificationWorkRequest,
         )

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -75,7 +75,7 @@ class SplashActivity : AppCompatActivity() {
 
     private fun enqueueReengagementNotificationWork() {
         val currentTime = System.currentTimeMillis()
-        val afterOneWeek = DateUtil.getCalendar(7, 12, 0, 0)
+        val afterOneWeek = DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0)
         val delayInMillis = afterOneWeek.timeInMillis - currentTime
 
         val notificationWorkRequest = OneTimeWorkRequestBuilder<ReengagementNotificationWork>()

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
@@ -2,7 +2,8 @@ package com.ku_stacks.ku_ring.util
 
 import timber.log.Timber
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Locale
 
 object DateUtil {
 
@@ -65,4 +66,30 @@ object DateUtil {
         val simpleDateFormat = SimpleDateFormat("yyyyMMdd", Locale.KOREA)
         return simpleDateFormat.format(a) == simpleDateFormat.format(b)
     }
+
+    fun getCalendar(dayToAdd: Int, hour: Int, minute: Int, second: Int): Calendar {
+        checkTimeArgument(hour, minute, second)
+
+        return Calendar.getInstance().apply {
+            add(Calendar.DAY_OF_MONTH, dayToAdd)
+            set(Calendar.HOUR_OF_DAY, hour) // Calendar.HOUR는 12시간
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, second)
+        }
+    }
+
+    private fun checkTimeArgument(hour: Int, minute: Int, second: Int) {
+        if (hour !in 0..23 || minute !in 0..59 || second !in 0..59) {
+            val hourMessage = createIllegalArgumentMessage("hour", 0..23, hour)
+            val monthMessage = createIllegalArgumentMessage("minute", 0..59, minute)
+            val secondMessage = createIllegalArgumentMessage("second", 0..59, second)
+            val message = listOf(hourMessage, monthMessage, secondMessage)
+                .filter { it.isNotEmpty() }
+                .joinToString(", ")
+            throw IllegalArgumentException("Time argument is wrong: $message")
+        }
+    }
+
+    private fun createIllegalArgumentMessage(field: String, range: IntRange, actual: Int) =
+        if (actual in range) "" else "$field should be in range of $range but given: $actual"
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
@@ -26,10 +26,12 @@ object DateUtil {
             8 -> {
                 today == str
             }
+
             19 -> {
                 val dateString = str.substring(0, 4) + str.substring(5, 7) + str.substring(8, 10)
                 today == dateString
             }
+
             else -> {
                 Timber.e("DateUtil.isToday() : String length is not normal")
                 false
@@ -67,15 +69,17 @@ object DateUtil {
         return simpleDateFormat.format(a) == simpleDateFormat.format(b)
     }
 
-    fun getCalendar(dayToAdd: Int, hour: Int, minute: Int, second: Int): Calendar {
-        checkTimeArgument(hour, minute, second)
+    fun getCalendar(dayToAdd: Int, hour: Int, minute: Int, second: Int): Calendar? {
+        return runCatching {
+            checkTimeArgument(hour, minute, second)
 
-        return Calendar.getInstance().apply {
-            add(Calendar.DAY_OF_MONTH, dayToAdd)
-            set(Calendar.HOUR_OF_DAY, hour) // Calendar.HOUR는 12시간
-            set(Calendar.MINUTE, minute)
-            set(Calendar.SECOND, second)
-        }
+            Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_MONTH, dayToAdd)
+                set(Calendar.HOUR_OF_DAY, hour) // Calendar.HOUR는 12시간
+                set(Calendar.MINUTE, minute)
+                set(Calendar.SECOND, second)
+            }
+        }.getOrNull()
     }
 
     private fun checkTimeArgument(hour: Int, minute: Int, second: Int) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
@@ -14,7 +14,7 @@ import com.ku_stacks.ku_ring.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.ui.main.MainActivity
 
-class ReengagementNotificationWork(appContext: Context, workerParams: WorkerParameters) :
+class ReEngagementNotificationWork(appContext: Context, workerParams: WorkerParameters) :
     Worker(appContext, workerParams) {
     override fun doWork(): Result {
         val notification = createNotification(applicationContext)

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReengagementNotificationWork.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReengagementNotificationWork.kt
@@ -1,0 +1,51 @@
+package com.ku_stacks.ku_ring.work
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.ku_stacks.ku_ring.MyFireBaseMessagingService
+import com.ku_stacks.ku_ring.R
+import com.ku_stacks.ku_ring.ui.main.MainActivity
+
+class ReengagementNotificationWork(appContext: Context, workerParams: WorkerParameters) :
+    Worker(appContext, workerParams) {
+    override fun doWork(): Result {
+        val notification = createNotification(applicationContext)
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(2, notification)
+        return Result.success()
+    }
+
+    private fun createNotification(context: Context): Notification {
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val resources = context.resources
+        return NotificationCompat.Builder(context, MyFireBaseMessagingService.CHANNEL_ID)
+            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.ic_notification))
+            .setSmallIcon(R.drawable.ic_status_bar)
+            .setContentTitle(resources.getText(R.string.reengagement_title))
+            .setContentText(resources.getText(R.string.reengagement_body))
+            .setSound(defaultSound)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+    }
+
+    companion object {
+        val WORK_NAME = "notification_work"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,10 @@
     <string name="kakao_channel">카카오톡 채널</string>
     <string name="setting_feedback">피드백</string>
 
+    <!-- re-engagement notification -->
+    <string name="reengagement_title">공지를 일주일 이상 확인하지 않았어요!</string>
+    <string name="reengagement_body">놓친 공지가 있는지 확인해보세요 🔔</string>
+
     <!--  campus onBoarding -->
     <string name="kuring_campus">쿠링 캠퍼스</string>
     <string name="kuring_chungsim">쿠링청심대</string>

--- a/app/src/test/java/com/ku_stacks/ku_ring/util/DateUtilTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/util/DateUtilTest.kt
@@ -1,0 +1,44 @@
+package com.ku_stacks.ku_ring.util
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.util.Calendar
+
+class DateUtilTest {
+    @Test
+    fun timeDiff_todayMidnight() {
+        val current = Calendar.getInstance()
+        val actual = DateUtil.getCalendar(0, 0, 0, 0)
+
+        assertEquals(current.get(Calendar.DAY_OF_MONTH), actual.get(Calendar.DAY_OF_MONTH))
+        assertEquals(0, actual.get(Calendar.HOUR_OF_DAY))
+        assertEquals(0, actual.get(Calendar.MINUTE))
+        assertEquals(0, actual.get(Calendar.SECOND))
+    }
+
+    @Test
+    fun timeDiff_oneSecond() {
+        val randomTime = DateUtil.getCalendar(0, 1, 10, 16)
+        val after1Second = DateUtil.getCalendar(0, 1, 10, 17)
+
+        val timeDiff = after1Second.timeInMillis - randomTime.timeInMillis
+        assertEquals(1000L, timeDiff)
+    }
+
+    @Test
+    fun timeDiff_oneHour() {
+        val midnight = DateUtil.getCalendar(0, 0, 0, 0)
+        val am1 = DateUtil.getCalendar(0, 1, 0, 0)
+
+        val timeDiff = am1.timeInMillis - midnight.timeInMillis
+        assertEquals(60 * 60 * 1000L, timeDiff)
+    }
+
+    @Test
+    fun timeDiff_illegalHourArgument() {
+        assertThrows(IllegalArgumentException::class.java) {
+            val actual = DateUtil.getCalendar(0, 27, 0, 1)
+        }
+    }
+}

--- a/app/src/test/java/com/ku_stacks/ku_ring/util/DateUtilTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/util/DateUtilTest.kt
@@ -1,7 +1,8 @@
 package com.ku_stacks.ku_ring.util
 
 import junit.framework.TestCase.assertEquals
-import org.junit.Assert.assertThrows
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.util.Calendar
 
@@ -11,10 +12,10 @@ class DateUtilTest {
         val current = Calendar.getInstance()
         val actual = DateUtil.getCalendar(0, 0, 0, 0)
 
-        assertEquals(current.get(Calendar.DAY_OF_MONTH), actual.get(Calendar.DAY_OF_MONTH))
-        assertEquals(0, actual.get(Calendar.HOUR_OF_DAY))
-        assertEquals(0, actual.get(Calendar.MINUTE))
-        assertEquals(0, actual.get(Calendar.SECOND))
+        assertEquals(current.get(Calendar.DAY_OF_MONTH), actual?.get(Calendar.DAY_OF_MONTH))
+        assertEquals(0, actual?.get(Calendar.HOUR_OF_DAY))
+        assertEquals(0, actual?.get(Calendar.MINUTE))
+        assertEquals(0, actual?.get(Calendar.SECOND))
     }
 
     @Test
@@ -22,7 +23,9 @@ class DateUtilTest {
         val randomTime = DateUtil.getCalendar(0, 1, 10, 16)
         val after1Second = DateUtil.getCalendar(0, 1, 10, 17)
 
-        val timeDiff = after1Second.timeInMillis - randomTime.timeInMillis
+        assertNotNull(randomTime)
+        assertNotNull(after1Second)
+        val timeDiff = after1Second!!.timeInMillis - randomTime!!.timeInMillis
         assertEquals(1000L, timeDiff)
     }
 
@@ -31,14 +34,14 @@ class DateUtilTest {
         val midnight = DateUtil.getCalendar(0, 0, 0, 0)
         val am1 = DateUtil.getCalendar(0, 1, 0, 0)
 
-        val timeDiff = am1.timeInMillis - midnight.timeInMillis
+        assertNotNull(midnight)
+        assertNotNull(am1)
+        val timeDiff = am1!!.timeInMillis - midnight!!.timeInMillis
         assertEquals(60 * 60 * 1000L, timeDiff)
     }
 
     @Test
     fun timeDiff_illegalHourArgument() {
-        assertThrows(IllegalArgumentException::class.java) {
-            val actual = DateUtil.getCalendar(0, 27, 0, 1)
-        }
+        assertNull(DateUtil.getCalendar(0, 27, 0, 1))
     }
 }


### PR DESCRIPTION
# 배경

오랫동안 앱을 실행하지 않았을 때 앱을 실행하도록 권유하는 알림(reengagement notification, 재참여 알림)을 보내는 경우가 있습니다. 시의성이 중요한 앱에서 그런 경우가 많습니다. 쿠링 앱도 공지를 바로바로 전달하는 걸 목표로 하는 만큼 재참여 알림을 보내자는 건의가 나왔고, 다른 팀원들도 동의하여 개발하게 되었습니다.

# 주요 기능

앱을 실행한 후 일주일이 되는 날 오후 12시에 알림을 보냅니다. 
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/572de546-43dd-4d03-a34b-6e9c121fd893)

앱을 실행할 때마다 알림을 보내는 백그라운드 work를 등록하는 방식으로 구현했습니다. 이전에 등록된 work가 있다면 새 work로 교체됩니다.

# 커밋

* https://github.com/ku-ring/KU-Ring-Android/commit/da9201b044432227c1777eaaab0aae3d6fe97e6a: Jetpack WorkManager 의존성을 추가했습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/fbb12a3c004d38dfac3d11b995925af6017fa87b: 알림 제목 및 본문에 사용할 string 리소스를 추가했습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/49de72ca13c66ddea1ee9f4f2f1cce26ce18be33: N일 후의 주어진 시간을 나타내는 `Calendar` 객체를 반환하는 유틸 함수를 추가했습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/c6cfd23ca97411de49b7cf13191cb1166159fb24: 요구 사항대로 알림을 발송하는 Worker를 정의했습니다.
* https://github.com/ku-ring/KU-Ring-Android/commit/c54567243d84d1d580543b051b171b4111061b35: `SplashActivity`에서 Worker를 enqueue하는 코드를 작성했습니다. 