### PR TITLE
kuring-74 화면 전환만을 담당하는 KuringNavigator 정의

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -3,15 +3,13 @@ package com.ku_stacks.ku_ring
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ku_stacks.ku_ring.data.db.PushDao
-import com.ku_stacks.ku_ring.ui.main.MainActivity
-import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
@@ -31,6 +29,9 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
 
     @Inject
     lateinit var fcmUtil: FcmUtil
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     override fun onNewToken(token: String) {
         Timber.e("refreshed token : $token")
@@ -88,7 +89,7 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         articleId: String?,
         category: String?
     ) {
-        val intent = NoticeWebActivity.createIntent(
+        val intent = navigator.createNoticeWebIntent(
             this,
             url,
             articleId,
@@ -117,7 +118,7 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
     }
 
     private fun showCustomNotification(type: String, title: String, body: String) {
-        val intent = Intent(this, MainActivity::class.java)
+        val intent = navigator.createMainIntent(this)
         val pendingIntent = PendingIntent.getActivity(
             this,
             0,

--- a/app/src/main/java/com/ku_stacks/ku_ring/di/NavigatorModule.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/di/NavigatorModule.kt
@@ -1,0 +1,15 @@
+package com.ku_stacks.ku_ring.di
+
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
+import com.ku_stacks.ku_ring.navigator.KuringNavigatorImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class NavigatorModule {
+    @Binds
+    abstract fun bindKuringNavigator(kuringNavigatorImpl: KuringNavigatorImpl): KuringNavigator
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigator.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigator.kt
@@ -1,0 +1,32 @@
+package com.ku_stacks.ku_ring.navigator
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import com.ku_stacks.ku_ring.data.model.Notice
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
+
+interface KuringNavigator {
+    fun navigateToChat(activity: Activity)
+    fun createEditSubscriptionIntent(context: Context, isFirstRun: Boolean = false): Intent
+    fun navigateToEditSubscription(activity: Activity, isFirstRun: Boolean = false)
+    fun navigateToFeedback(activity: Activity)
+    fun createMainIntent(context: Context): Intent
+    fun navigateToMain(activity: Activity)
+    fun navigateToMain(activity: Activity, url: String, articleId: String, category: String)
+    fun navigateToNotification(activity: Activity)
+    fun navigateToNoticeStorage(activity: Activity)
+    fun createNoticeWebIntent(
+        context: Context,
+        url: String?,
+        articleId: String?,
+        category: String?
+    ): Intent
+    fun navigateToNoticeWeb(activity: Activity, notice: Notice)
+    fun navigateToNoticeWeb(activity: Activity, webViewNotice: WebViewNotice)
+    fun navigateToNoticeWeb(activity: Activity, url: String?, articleId: String?, category: String?)
+    fun navigateToNotionView(activity: Activity, notionUrl: String)
+    fun navigateToOnboarding(activity: Activity)
+    fun navigateToSplash(activity: Activity)
+    fun navigateToOssLicensesMenu(activity: Activity)
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
@@ -1,0 +1,109 @@
+package com.ku_stacks.ku_ring.navigator
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import com.ku_stacks.ku_ring.R
+import com.ku_stacks.ku_ring.data.model.Notice
+import com.ku_stacks.ku_ring.data.model.WebViewNotice
+import com.ku_stacks.ku_ring.ui.chat.ChatActivity
+import com.ku_stacks.ku_ring.ui.edit_subscription.EditSubscriptionActivity
+import com.ku_stacks.ku_ring.ui.feedback.FeedbackActivity
+import com.ku_stacks.ku_ring.ui.main.MainActivity
+import com.ku_stacks.ku_ring.ui.my_notification.NotificationActivity
+import com.ku_stacks.ku_ring.ui.notice_storage.NoticeStorageActivity
+import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
+import com.ku_stacks.ku_ring.ui.notion.NotionViewActivity
+import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
+import com.ku_stacks.ku_ring.ui.splash.SplashActivity
+import javax.inject.Inject
+
+class KuringNavigatorImpl @Inject constructor(): KuringNavigator {
+    override fun navigateToChat(activity: Activity) {
+        ChatActivity.start(activity)
+    }
+
+    override fun createEditSubscriptionIntent(context: Context, isFirstRun: Boolean): Intent {
+        return Intent(context, EditSubscriptionActivity::class.java).apply {
+            putExtra(EditSubscriptionActivity.FIRST_RUN_FLAG, isFirstRun)
+        }
+    }
+
+    override fun navigateToEditSubscription(activity: Activity, isFirstRun: Boolean) {
+        EditSubscriptionActivity.start(activity, isFirstRun)
+    }
+
+    override fun navigateToFeedback(activity: Activity) {
+        FeedbackActivity.start(activity)
+    }
+
+    override fun createMainIntent(context: Context): Intent {
+        return MainActivity.createIntent(context)
+    }
+
+    override fun navigateToMain(activity: Activity) {
+        MainActivity.start(activity)
+    }
+
+    override fun navigateToMain(
+        activity: Activity,
+        url: String,
+        articleId: String,
+        category: String
+    ) {
+        MainActivity.start(activity, url, articleId, category)
+    }
+
+    override fun navigateToNotification(activity: Activity) {
+        NotificationActivity.start(activity)
+    }
+
+    override fun navigateToNoticeStorage(activity: Activity) {
+        NoticeStorageActivity.start(activity)
+    }
+
+    override fun createNoticeWebIntent(
+        context: Context,
+        url: String?,
+        articleId: String?,
+        category: String?
+    ): Intent {
+        return NoticeWebActivity.createIntent(context, url, articleId, category)
+    }
+
+    override fun navigateToNoticeWeb(activity: Activity, notice: Notice) {
+        NoticeWebActivity.start(activity, notice)
+    }
+
+    override fun navigateToNoticeWeb(activity: Activity, webViewNotice: WebViewNotice) {
+        NoticeWebActivity.start(activity, webViewNotice)
+    }
+
+    override fun navigateToNoticeWeb(
+        activity: Activity,
+        url: String?,
+        articleId: String?,
+        category: String?
+    ) {
+        NoticeWebActivity.start(activity, url, articleId, category)
+    }
+
+    override fun navigateToNotionView(activity: Activity, notionUrl: String) {
+        NotionViewActivity.start(activity, notionUrl)
+    }
+
+    override fun navigateToOnboarding(activity: Activity) {
+        OnboardingActivity.start(activity)
+    }
+
+    override fun navigateToSplash(activity: Activity) {
+        SplashActivity.start(activity)
+    }
+
+    override fun navigateToOssLicensesMenu(activity: Activity) {
+        val intent = Intent(activity, OssLicensesMenuActivity::class.java)
+        activity.startActivity(intent)
+        OssLicensesMenuActivity.setActivityTitle(activity.getString(R.string.open_source_license))
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatActivity.kt
@@ -1,7 +1,9 @@
 package com.ku_stacks.ku_ring.ui.chat
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.Editable
@@ -177,5 +179,12 @@ class ChatActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, ChatActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
@@ -1,5 +1,7 @@
 package com.ku_stacks.ku_ring.ui.edit_subscription
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
@@ -13,8 +15,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.databinding.DataBindingUtil
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivityEditSubscriptionBinding
-import com.ku_stacks.ku_ring.ui.edit_subscription.compose.Subscriptions
 import com.ku_stacks.ku_ring.ui.compose.theme.KuringTheme
+import com.ku_stacks.ku_ring.ui.edit_subscription.compose.Subscriptions
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -93,5 +95,9 @@ class EditSubscriptionActivity : AppCompatActivity() {
 
     companion object {
         const val FIRST_RUN_FLAG = "firstRunFlag"
+        fun start(activity: Activity) {
+            val intent = Intent(activity, EditSubscriptionActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
@@ -95,8 +95,10 @@ class EditSubscriptionActivity : AppCompatActivity() {
 
     companion object {
         const val FIRST_RUN_FLAG = "firstRunFlag"
-        fun start(activity: Activity) {
-            val intent = Intent(activity, EditSubscriptionActivity::class.java)
+        fun start(activity: Activity, isFirstRun: Boolean) {
+            val intent = Intent(activity, EditSubscriptionActivity::class.java).apply {
+                putExtra(FIRST_RUN_FLAG, isFirstRun)
+            }
             activity.startActivity(intent)
         }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/feedback/FeedbackActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/feedback/FeedbackActivity.kt
@@ -1,5 +1,7 @@
 package com.ku_stacks.ku_ring.ui.feedback
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -86,5 +88,12 @@ class FeedbackActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, FeedbackActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -87,9 +87,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun navToNoticeActivity(webViewNotice: WebViewNotice) {
         Timber.d("Notification received: $webViewNotice")
-        val intent = NoticeWebActivity.createIntent(this, webViewNotice)
-        startActivity(intent)
-        overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        NoticeWebActivity.start(this, webViewNotice)
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.ui.main
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
@@ -106,18 +107,25 @@ class MainActivity : AppCompatActivity() {
     }
 
     companion object {
+        fun createIntent(context: Context) = Intent(context, MainActivity::class.java)
+
         fun start(
             activity: Activity,
             url: String,
             articleId: String,
             category: String,
         ) {
-            val intent = Intent(activity, MainActivity::class.java).apply {
+            val intent = createIntent(activity).apply {
                 putExtra(
                     NoticeWebActivity.WEB_VIEW_NOTICE,
                     WebViewNotice(url, articleId, category),
                 )
             }
+            activity.startActivity(intent)
+        }
+
+        fun start(activity: Activity) {
+            val intent = createIntent(activity)
             activity.startActivity(intent)
         }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusFragment.kt
@@ -1,6 +1,5 @@
 package com.ku_stacks.ku_ring.ui.main.campus_onboarding
 
-import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -16,7 +15,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.FragmentCampusBinding
-import com.ku_stacks.ku_ring.ui.chat.ChatActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import com.ku_stacks.ku_ring.util.makeDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,6 +33,9 @@ class CampusFragment : Fragment() {
 
     @Inject
     lateinit var pref: PreferenceUtil
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     private val loginFinishResult = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -183,8 +185,7 @@ class CampusFragment : Fragment() {
     private fun startChatActivity() {
         changeState(CampusState.AUTO_LOGIN_STATE)
 
-        val intent = Intent(requireActivity(), ChatActivity::class.java)
-        startActivity(intent)
+        navigator.navigateToChat(requireActivity())
         requireActivity().overridePendingTransition(
             R.anim.anim_slide_right_enter,
             R.anim.anim_stay_exit

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticesParentFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticesParentFragment.kt
@@ -1,6 +1,5 @@
 package com.ku_stacks.ku_ring.ui.main.notice
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,8 +11,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.google.firebase.messaging.FirebaseMessaging
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.FragmentNoticeBinding
-import com.ku_stacks.ku_ring.ui.my_notification.NotificationActivity
-import com.ku_stacks.ku_ring.ui.notice_storage.NoticeStorageActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -28,6 +26,9 @@ class NoticesParentFragment : Fragment() {
 
     @Inject
     lateinit var firebaseMessaging: FirebaseMessaging
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     private var _binding: FragmentNoticeBinding? = null
     private val binding
@@ -75,8 +76,7 @@ class NoticesParentFragment : Fragment() {
         }.attach()
 
         binding.mainHeader.inventoryImg.setOnClickListener {
-            val intent = Intent(requireActivity(), NoticeStorageActivity::class.java)
-            startActivity(intent)
+            navigator.navigateToNoticeStorage(requireActivity())
             requireActivity().overridePendingTransition(
                 R.anim.anim_slide_right_enter,
                 R.anim.anim_stay_exit
@@ -84,8 +84,7 @@ class NoticesParentFragment : Fragment() {
         }
 
         binding.mainHeader.bellImg.setOnClickListener {
-            val intent = Intent(requireActivity(), NotificationActivity::class.java)
-            startActivity(intent)
+            navigator.navigateToNotification(requireActivity())
             requireActivity().overridePendingTransition(
                 R.anim.anim_slide_right_enter,
                 R.anim.anim_stay_exit
@@ -99,10 +98,12 @@ class NoticesParentFragment : Fragment() {
                 0 -> {
                     binding.mainHeader.notiCountBt.visibility = View.GONE
                 }
+
                 in 1..99 -> {
                     binding.mainHeader.notiCountBt.visibility = View.VISIBLE
                     binding.mainHeader.notiCountBt.text = it.toString()
                 }
+
                 else -> {
                     binding.mainHeader.notiCountBt.visibility = View.VISIBLE
                     binding.mainHeader.notiCountBt.text =

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/NoticesChildFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/NoticesChildFragment.kt
@@ -119,12 +119,7 @@ class NoticesChildFragment : Fragment() {
     }
 
     private fun startNoticeActivity(notice: Notice) {
-        val intent = NoticeWebActivity.createIntent(requireActivity(), notice)
-        startActivity(intent)
-        requireActivity().overridePendingTransition(
-            R.anim.anim_slide_right_enter,
-            R.anim.anim_stay_exit
-        )
+        NoticeWebActivity.start(requireActivity(), notice)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/department/DepartmentNoticeFragment.kt
@@ -110,12 +110,7 @@ class DepartmentNoticeFragment : Fragment() {
     }
 
     private fun startNoticeActivity(notice: Notice) {
-        val intent = NoticeWebActivity.createIntent(requireActivity(), notice)
-        startActivity(intent)
-        requireActivity().overridePendingTransition(
-            R.anim.anim_slide_right_enter,
-            R.anim.anim_stay_exit
-        )
+        NoticeWebActivity.start(requireActivity(), notice)
     }
 
     private fun observeLoadingState() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_notice/SearchNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_notice/SearchNoticeFragment.kt
@@ -63,11 +63,6 @@ class SearchNoticeFragment : Fragment() {
     }
 
     private fun startNoticeActivity(notice: Notice) {
-        val intent = NoticeWebActivity.createIntent(requireContext(), notice)
-        startActivity(intent)
-        requireActivity().overridePendingTransition(
-            R.anim.anim_slide_right_enter,
-            R.anim.anim_stay_exit
-        )
+        NoticeWebActivity.start(requireActivity(), notice)
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/setting/SettingFragment.kt
@@ -1,22 +1,22 @@
 package com.ku_stacks.ku_ring.ui.main.setting
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.FragmentSettingBinding
-import com.ku_stacks.ku_ring.ui.edit_subscription.EditSubscriptionActivity
-import com.ku_stacks.ku_ring.ui.feedback.FeedbackActivity
-import com.ku_stacks.ku_ring.ui.notion.NotionViewActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class SettingFragment : Fragment() {
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     private var _binding: FragmentSettingBinding? = null
     private val binding
@@ -43,8 +43,7 @@ class SettingFragment : Fragment() {
     private fun setupView() {
         /** subscribe layout */
         binding.subscribeLayout.subscribeNoticeLayout.setOnClickListener {
-            val intent = Intent(requireContext(), EditSubscriptionActivity::class.java)
-            startActivity(intent)
+            navigator.navigateToEditSubscription(requireActivity())
             requireActivity().overridePendingTransition(
                 R.anim.anim_slide_right_enter,
                 R.anim.anim_stay_exit
@@ -68,10 +67,9 @@ class SettingFragment : Fragment() {
             startWebViewActivity(getString(R.string.notion_terms_of_service_url))
         }
         binding.informationLayout.openSourceLayout.setOnClickListener {
-            val intent = Intent(requireContext(), OssLicensesMenuActivity::class.java)
-            startActivity(intent)
-            OssLicensesMenuActivity.setActivityTitle(getString(R.string.open_source_license))
-            requireActivity().overridePendingTransition(
+            val activity = requireActivity()
+            navigator.navigateToOssLicensesMenu(activity)
+            activity.overridePendingTransition(
                 R.anim.anim_slide_right_enter,
                 R.anim.anim_stay_exit
             )
@@ -79,8 +77,7 @@ class SettingFragment : Fragment() {
 
         /** feedback layout */
         binding.feedbackLayout.feedbackSendLayout.setOnClickListener {
-            val intent = Intent(requireContext(), FeedbackActivity::class.java)
-            startActivity(intent)
+            navigator.navigateToFeedback(requireActivity())
             requireActivity().overridePendingTransition(
                 R.anim.anim_slide_right_enter,
                 R.anim.anim_stay_exit
@@ -89,9 +86,7 @@ class SettingFragment : Fragment() {
     }
 
     private fun startWebViewActivity(url: String) {
-        val intent = Intent(requireContext(), NotionViewActivity::class.java)
-        intent.putExtra(NotionViewActivity.NOTION_URL, url)
-        startActivity(intent)
+        navigator.navigateToNotionView(requireActivity(), url)
         requireActivity().overridePendingTransition(
             R.anim.anim_slide_right_enter,
             R.anim.anim_stay_exit

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -11,8 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.databinding.ActivityNotificationBinding
-import com.ku_stacks.ku_ring.ui.edit_subscription.EditSubscriptionActivity
-import com.ku_stacks.ku_ring.ui.main.MainActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import com.ku_stacks.ku_ring.util.makeDialog
@@ -27,6 +26,9 @@ class NotificationActivity : AppCompatActivity() {
 
     @Inject
     lateinit var analytics: EventAnalytics
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     private lateinit var binding: ActivityNotificationBinding
     private val viewModel by viewModels<NotificationViewModel>()
@@ -55,8 +57,7 @@ class NotificationActivity : AppCompatActivity() {
 
         binding.notificationSetNotiBtn.setOnClickListener {
             analytics.click("set_notification btn", "NotificationActivity")
-            val intent = Intent(this, EditSubscriptionActivity::class.java)
-            startActivity(intent)
+            navigator.navigateToEditSubscription(this)
             overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
         }
 
@@ -124,8 +125,7 @@ class NotificationActivity : AppCompatActivity() {
     }
 
     private fun startMainActivity() {
-        val intent = Intent(this, MainActivity::class.java)
-        startActivity(intent)
+        navigator.navigateToMain(this)
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
         finish()
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -120,9 +120,7 @@ class NotificationActivity : AppCompatActivity() {
     }
 
     private fun startNoticeActivity(pushContent: PushContentUiModel) {
-        val intent = NoticeWebActivity.createIntent(this, pushContent)
-        startActivity(intent)
-        overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        NoticeWebActivity.start(this, pushContent)
     }
 
     private fun startMainActivity() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.ui.my_notification
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -134,5 +135,12 @@ class NotificationActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         startMainActivity()
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, NotificationActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_storage/NoticeStorageActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_storage/NoticeStorageActivity.kt
@@ -86,9 +86,7 @@ class NoticeStorageActivity : AppCompatActivity() {
     }
 
     private fun startNoticeActivity(notice: Notice) {
-        val intent = NoticeWebActivity.createIntent(this, notice)
-        startActivity(intent)
-        overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        NoticeWebActivity.start(this, notice)
     }
 
     override fun finish() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_storage/NoticeStorageActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_storage/NoticeStorageActivity.kt
@@ -1,5 +1,7 @@
 package com.ku_stacks.ku_ring.ui.notice_storage
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -92,5 +94,12 @@ class NoticeStorageActivity : AppCompatActivity() {
     override fun finish() {
         super.finish()
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, NoticeStorageActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.ui.notice_webview
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -119,11 +120,29 @@ class NoticeWebActivity : AppCompatActivity() {
     companion object {
         const val WEB_VIEW_NOTICE = "webview_notice"
 
-        fun createIntent(context: Context, notice: Notice) =
-            createIntent(context, notice.toWebViewNotice())
+        fun start(activity: Activity, notice: Notice) {
+            start(activity, notice.toWebViewNotice())
+        }
 
-        fun createIntent(context: Context, pushContent: PushContentUiModel) =
-            createIntent(context, pushContent.toWebViewNotice())
+        fun start(activity: Activity, pushContent: PushContentUiModel) {
+            start(activity, pushContent.toWebViewNotice())
+        }
+
+        fun start(activity: Activity, url: String?, articleId: String?, category: String?) {
+            if (url == null || articleId == null || category == null) {
+                throw IllegalArgumentException("intent parameters shouldn't be null: $url, $articleId, $category")
+            }
+            start(activity, WebViewNotice(url, articleId, category))
+        }
+
+        fun start(activity: Activity, webViewNotice: WebViewNotice) {
+            val (url, articleId, category) = webViewNotice
+            val intent = createIntent(activity, url, articleId, category)
+            activity.apply {
+                startActivity(intent)
+                overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            }
+        }
 
         fun createIntent(
             context: Context,
@@ -134,13 +153,10 @@ class NoticeWebActivity : AppCompatActivity() {
             if (url == null || articleId == null || category == null) {
                 throw IllegalArgumentException("intent parameters shouldn't be null: $url, $articleId, $category")
             }
-            return createIntent(context, WebViewNotice(url, articleId, category))
-        }
-
-        fun createIntent(context: Context, webViewNotice: WebViewNotice) =
-            Intent(context, NoticeWebActivity::class.java).apply {
-                Timber.d("WebViewNotice: $webViewNotice")
-                putExtra(WEB_VIEW_NOTICE, webViewNotice)
+            Timber.d("url: $url, articleId: $articleId, category: $category")
+            return Intent(context, NoticeWebActivity::class.java).apply {
+                putExtra(WEB_VIEW_NOTICE, WebViewNotice(url, articleId, category))
             }
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notion/NotionViewActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notion/NotionViewActivity.kt
@@ -1,6 +1,8 @@
 package com.ku_stacks.ku_ring.ui.notion
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebChromeClient
@@ -49,5 +51,11 @@ class NotionViewActivity : AppCompatActivity() {
 
     companion object {
         const val NOTION_URL = "notion_url"
+        fun start(activity: Activity, notionUrl: String) {
+            val intent = Intent(activity, NotionViewActivity::class.java).apply {
+                putExtra(NOTION_URL, notionUrl)
+            }
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
@@ -8,8 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
-import com.ku_stacks.ku_ring.ui.edit_subscription.EditSubscriptionActivity
-import com.ku_stacks.ku_ring.ui.main.MainActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -22,12 +21,14 @@ class OnboardingActivity : AppCompatActivity() {
     @Inject
     lateinit var pref: PreferenceUtil
 
+    @Inject
+    lateinit var navigator: KuringNavigator
+
     private val getOnboardingFinishResult = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == RESULT_OK) {
-            startActivity(Intent(this, MainActivity::class.java))
-            finish()
+            navigator.navigateToMain(this)
             overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
         }
     }
@@ -39,9 +40,7 @@ class OnboardingActivity : AppCompatActivity() {
         val subscribeNoticeButton = findViewById<Button>(R.id.on_boarding_subscribe_noti_btn)
 
         subscribeNoticeButton.setOnClickListener {
-            val intent = Intent(this, EditSubscriptionActivity::class.java).apply {
-                putExtra(EditSubscriptionActivity.FIRST_RUN_FLAG, true)
-            }
+            val intent = navigator.createEditSubscriptionIntent(this, isFirstRun = true)
             getOnboardingFinishResult.launch(intent)
 
             overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/onboarding/OnboardingActivity.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.ui.onboarding
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
@@ -45,6 +46,13 @@ class OnboardingActivity : AppCompatActivity() {
 
             overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
             analytics.click("start first Subscription Notification", "OnboardingActivity")
+        }
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, OnboardingActivity::class.java)
+            activity.startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.ui.splash
 
+import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
@@ -75,7 +76,8 @@ class SplashActivity : AppCompatActivity() {
 
     private fun enqueueReengagementNotificationWork() {
         val currentTime = System.currentTimeMillis()
-        val afterOneWeek = DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0) ?: return
+        val afterOneWeek =
+            DateUtil.getCalendar(dayToAdd = 7, hour = 12, minute = 0, second = 0) ?: return
         val delayInMillis = afterOneWeek.timeInMillis - currentTime
 
         val notificationWorkRequest = OneTimeWorkRequestBuilder<ReEngagementNotificationWork>()
@@ -163,5 +165,12 @@ class SplashActivity : AppCompatActivity() {
     override fun finish() {
         overridePendingTransition(0, 0)
         super.finish()
+    }
+
+    companion object {
+        fun start(activity: Activity) {
+            val intent = Intent(activity, SplashActivity::class.java)
+            activity.startActivity(intent)
+        }
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/splash/SplashActivity.kt
@@ -16,8 +16,8 @@ import androidx.work.WorkManager
 import com.ku_stacks.ku_ring.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ActivitySplashBinding
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import com.ku_stacks.ku_ring.ui.main.MainActivity
-import com.ku_stacks.ku_ring.ui.onboarding.OnboardingActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.FcmUtil
 import com.ku_stacks.ku_ring.util.PreferenceUtil
@@ -37,6 +37,9 @@ class SplashActivity : AppCompatActivity() {
 
     @Inject
     lateinit var fcmUtil: FcmUtil
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     private lateinit var binding: ActivitySplashBinding
 
@@ -62,11 +65,11 @@ class SplashActivity : AppCompatActivity() {
 
                 onboardingRequired() -> {
                     createNotificationChannel()
-                    startActivity(Intent(this@SplashActivity, OnboardingActivity::class.java))
+                    navigator.navigateToOnboarding(this@SplashActivity)
                 }
 
                 else -> {
-                    startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+                    navigator.navigateToMain(this@SplashActivity)
                 }
             }
 
@@ -140,8 +143,7 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun handleCustomNotification() {
-        val intent = Intent(this@SplashActivity, MainActivity::class.java)
-        startActivity(intent)
+        navigator.navigateToMain(this)
     }
 
     private fun onboardingRequired(): Boolean {

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
@@ -4,7 +4,6 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
@@ -12,10 +11,15 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.ku_stacks.ku_ring.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.R
-import com.ku_stacks.ku_ring.ui.main.MainActivity
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
+import javax.inject.Inject
 
 class ReEngagementNotificationWork(appContext: Context, workerParams: WorkerParameters) :
     Worker(appContext, workerParams) {
+
+    @Inject
+    lateinit var navigator: KuringNavigator
+
     override fun doWork(): Result {
         val notification = createNotification(applicationContext)
         val notificationManager =
@@ -25,7 +29,7 @@ class ReEngagementNotificationWork(appContext: Context, workerParams: WorkerPara
     }
 
     private fun createNotification(context: Context): Notification {
-        val intent = Intent(context, MainActivity::class.java)
+        val intent = navigator.createMainIntent(context)
         val pendingIntent = PendingIntent.getActivity(
             context,
             0,


### PR DESCRIPTION
[Jira 티켓 링크](https://kuring.atlassian.net/browse/KURING-74?atlOrigin=eyJpIjoiNTgwOTczOTAxNTk2NDFlMmFiMDRkZjViZWJkYjY0ZmQiLCJwIjoiaiJ9)

## 문제 상황

`Activity`를 launch하는 코드가 앱 이곳저곳에 너무 광범위하게 퍼져 있어 모듈화에 큰 방해 요소가 되고 있습니다. 깔끔한 모듈화를 위해 화면 전환 코드를 한 곳으로 모아야 합니다.

## 변경 사항
https://github.com/ku-ring/KU-Ring-Android/pull/67/commits/f57e737677ec5f1e48028389993361516c6d8b42 PR에서 제시하신 대로, `Intent` 생성 및 화면 전환을 담당하는 `KuringNavigator` 인터페이스 및 구현체를 정의했습니다. 앞으로 모든 화면 전환은 `KuringNavigator`를 통해서만 이루어져야 합니다.