### PR TITLE
kuring-79 [수정] 학과별 공지가 날짜의 내림차순으로 보이도록 수정

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -55,8 +55,8 @@ interface NoticeDao {
     suspend fun insertDepartmentNotices(notices: List<NoticeEntity>)
 
     @Query(
-        "SELECT * FROM NoticeEntity WHERE department LIKE :shortName " /*+
-            "ORDER BY postedDate DESC, articleId DESC"*/
+        "SELECT * FROM NoticeEntity WHERE department LIKE :shortName " +
+            "ORDER BY postedDate DESC, articleId DESC"
     )
     fun getDepartmentNotices(shortName: String): PagingSource<Int, NoticeEntity>
 


### PR DESCRIPTION
[Jira 티켓 링크](https://kuring.atlassian.net/browse/KURING-79?atlOrigin=eyJpIjoiOWViZjA0NWQwYzRkNDNhOWE1ZGJlMjI0YTkxNDgxYjUiLCJwIjoiaiJ9)

## 문제 상황

학과별 공지가 날짜 순서대로 보이지 않고 있습니다.

![KakaoTalk_20230902_181237406](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/dfd088d7-05c1-4dbf-9d59-ea7a21cb57e9)

## 해결 방법

SQL 구문에 `postedDate` 내림차순 정렬 옵션을 추가하면 됩니다.

## 테스트할 때 주의사항

API base url을 다음의 주소로 바꿔야 합니다. 현재 DNS 문제로 https가 작동하지 않고 있어 IP로 접속해야 합니다.
```Kotlin
http://13.113.178.212:8080/api/
```