### PR TITLE
kuring-64 Target SDK level을 33으로 상향

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         applicationId "com.ku_stacks.ku_ring"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 22
         versionName "1.2.10"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         applicationId "com.ku_stacks.ku_ring"
         minSdk 24
-        targetSdk 31
+        targetSdk 32
         versionCode 22
         versionName "1.2.10"
 


### PR DESCRIPTION
[Jira 티켓 링크](https://kuring.atlassian.net/browse/KURING-64?atlOrigin=eyJpIjoiMzE2NmE3MjQxYWM5NGYwNDhlZTczMDYyOWE3NTllMDUiLCJwIjoiaiJ9)

## 문제 상황

[Google Play 정책](https://developer.android.com/google/play/requirements/target-sdk)에 의해 2023년 8월 31일 이후에 게시되는 업데이트는 Android 13 이상을 target해야 합니다.

> Starting on August 31, 2023: App updates must target Android 13 or higher and adjust for behavioral changes in Android 13

## 해결 방법

따라서 현재 31인 target SDK를 33으로 상향했습니다. 공식 문서를 참고한 결과 target SDK를 상향해도 쿠링 앱에 미치는 영향은 없는 것으로 확인했습니다.

이 PR까지 누적된 변경사항을 출시할 예정입니다.