### PR TITLE
kuring-76 Android 기본 WorkerFactory 대신 커스텀 팩토리를 사용하도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,22 +6,22 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
 
     <application
-        tools:replace="icon, label"
         android:name="com.ku_stacks.ku_ring.KuRingApplication"
         android:allowBackup="false"
         android:icon="${appIcon}"
         android:label="${appName}"
         android:roundIcon="@drawable/ic_ku_ring_launcher_round"
-        android:usesCleartextTraffic="true"
         android:supportsRtl="true"
-        android:theme="@style/Theme.KURing">
+        android:theme="@style/Theme.KURing"
+        android:usesCleartextTraffic="true"
+        tools:replace="icon, label">
 
         <activity
             android:name=".ui.splash.SplashActivity"
@@ -45,7 +45,8 @@
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize" />
 
-        <activity android:name=".ui.my_notification.NotificationActivity"
+        <activity
+            android:name=".ui.my_notification.NotificationActivity"
             android:exported="true"
             android:launchMode="singleTask" />
         <activity
@@ -60,20 +61,20 @@
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:exported="true"
-            android:theme="@style/OpenSourceItemTheme"/>
+            android:theme="@style/OpenSourceItemTheme" />
 
         <activity
             android:name=".ui.notice_webview.NoticeWebActivity"
-            android:exported="true"
-            />
+            android:exported="true" />
 
         <activity
             android:name=".ui.edit_subscription.EditSubscriptionActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/EditSubscriptionTheme"/>
+            android:theme="@style/EditSubscriptionTheme" />
 
-        <activity android:name=".ui.notion.NotionViewActivity"
+        <activity
+            android:name=".ui.notion.NotionViewActivity"
             android:exported="true" />
 
         <activity
@@ -100,6 +101,10 @@
             <meta-data
                 android:name="com.ku_stacks.ku_ring.initializer.SendbirdInitializer"
                 android:value="androidx.startup" />
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
 
         <service android:name="com.ku_stacks.ku_ring.MyFireBaseMessagingService"
@@ -107,8 +112,8 @@
             android:exported="false"
             android:stopWithTask="false">
             <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
-                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
             </intent-filter>
         </service>
 
@@ -118,8 +123,7 @@
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
-            android:resource="@drawable/ic_status_bar"
-            />
+            android:resource="@drawable/ic_status_bar" />
 
     </application>
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/KuRingApplication.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/KuRingApplication.kt
@@ -1,7 +1,21 @@
 package com.ku_stacks.ku_ring
 
 import android.app.Application
+import android.util.Log
+import androidx.work.Configuration
+import com.ku_stacks.ku_ring.navigator.KuringNavigator
+import com.ku_stacks.ku_ring.work.ReEngagementNotificationWorkerFactory
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class KuRingApplication : Application()
+class KuRingApplication : Application(), Configuration.Provider {
+    @Inject
+    lateinit var navigator: KuringNavigator
+    override fun getWorkManagerConfiguration(): Configuration {
+        return Configuration.Builder()
+            .setMinimumLoggingLevel(Log.INFO)
+            .setWorkerFactory(ReEngagementNotificationWorkerFactory(navigator::createMainIntent))
+            .build()
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import androidx.core.app.NotificationCompat
@@ -14,8 +15,11 @@ import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.navigator.KuringNavigator
 import javax.inject.Inject
 
-class ReEngagementNotificationWork(appContext: Context, workerParams: WorkerParameters) :
-    Worker(appContext, workerParams) {
+class ReEngagementNotificationWork(
+    appContext: Context,
+    workerParams: WorkerParameters,
+    private val createIntent: (Context) -> Intent
+) : Worker(appContext, workerParams) {
 
     @Inject
     lateinit var navigator: KuringNavigator
@@ -29,7 +33,8 @@ class ReEngagementNotificationWork(appContext: Context, workerParams: WorkerPara
     }
 
     private fun createNotification(context: Context): Notification {
-        val intent = navigator.createMainIntent(context)
+//        val intent = navigator.createMainIntent(context)
+        val intent = createIntent(context)
         val pendingIntent = PendingIntent.getActivity(
             context,
             0,

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
@@ -33,7 +33,6 @@ class ReEngagementNotificationWork(
     }
 
     private fun createNotification(context: Context): Notification {
-//        val intent = navigator.createMainIntent(context)
         val intent = createIntent(context)
         val pendingIntent = PendingIntent.getActivity(
             context,

--- a/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWorkerFactory.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWorkerFactory.kt
@@ -1,0 +1,18 @@
+package com.ku_stacks.ku_ring.work
+
+import android.content.Context
+import android.content.Intent
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+
+class ReEngagementNotificationWorkerFactory(private val createIntent: (Context) -> Intent) :
+    WorkerFactory() {
+    override fun createWorker(
+        appContext: Context,
+        workerClassName: String,
+        workerParameters: WorkerParameters
+    ): ListenableWorker {
+        return ReEngagementNotificationWork(appContext, workerParameters, createIntent)
+    }
+}


### PR DESCRIPTION
[Jira 티켓 링크](https://kuring.atlassian.net/browse/KURING-76?atlOrigin=eyJpIjoiMzllNmQwYWI0ZTQ3NGRlMWIyMTUyZTFlNjk5MjRjMGMiLCJwIjoiaiJ9)

# 문제 상황

현재 `ReEngagementNotificationWorker`에서 `Intent`를 만들기 위해 `MainActivity.createIntent`에 접근하고 있는데, 모듈화 계획대로라면 `core:worker`에서 `feature:main`에 의존하는 잘못된 의존성 관계가 만들어집니다. 따라서 `Intent`를 `feature` 모듈에 의존하지 않는 방법으로 만들어야 합니다.

# 해결 방법

Worker의 파라미터로 `Intent`를 반환하는 람다를 받으면 됩니다. 

그런데 Worker에 기본 매개변수 외의 매개변수가 추가되었기 때문에 더 이상 Android 기본 `WorkerFactory`로는 Worker를 만들 수 없습니다. 따라서 Worker를 만드는 커스텀 `WorkerFactory`를 정의하였습니다.

커스텀 `WorkerFactory`를 만드는 방법은 [Android 공식 문서를 참고했습니다.](https://developer.android.com/guide/background/persistent/configuration/custom-configuration#on-demand)

# 주요 커밋

* https://github.com/ku-ring/KU-Ring-Android/commit/ffc2383615d50994df4ddfa98407977207eb26b4: Worker가 람다 함수를 호출하여 `Intent`를 만들도록 수정
* https://github.com/ku-ring/KU-Ring-Android/commit/4044214e35c65536575142fb0451b8f3b54de3da: Worker를 생성하는 커스텀 `WorkerFactory` 정의
* https://github.com/ku-ring/KU-Ring-Android/commit/2d3fa8036aa435b5f812471ff08a9ef15f37b679: 위에서 정의한 커스텀 `WorkerFactory`를 사용하도록 수정

이 PR만 merge되면 모듈화에 필요한 사전 작업은 얼추 마무리됩니다. (제발 마무리되었길 ㅠㅠ)