### PR TITLE
kuring-80 의존성을 Gradle Version Catalog에 선언

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,6 @@ plugins {
 def keystorePropertiesFile = rootProject.file("app/signing/keystore.properties")
 def localPropertiesFile = rootProject.file("local.properties")
 
-def composeCompilerVersion = "1.4.7"
-
 android {
     testOptions {
         unitTests {
@@ -108,166 +106,116 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = composeCompilerVersion
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 }
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation 'com.google.firebase:firebase-messaging-ktx:21.0.1'
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.appcompat
+    implementation libs.android.material
+    implementation libs.androidx.constraintlayout
 
     // dagger hilt
-    kapt "androidx.hilt:hilt-compiler:1.0.0"
-    implementation 'com.google.dagger:hilt-android:2.45'
-    kapt 'com.google.dagger:hilt-compiler:2.45'
-    androidTestImplementation  'com.google.dagger:hilt-android-testing:2.45'
-    kaptAndroidTest 'com.google.dagger:hilt-compiler:2.45'
-    testImplementation 'com.google.dagger:hilt-android-testing:2.45'
-    kaptTest 'com.google.dagger:hilt-compiler:2.45'
+    kapt libs.androidx.hilt.compiler
+    implementation libs.hilt.android
+    kapt libs.hilt.compiler
+    androidTestImplementation  libs.hilt.android.testing
+    kaptAndroidTest libs.hilt.compiler
+    testImplementation libs.hilt.android.testing
+    kaptTest libs.hilt.compiler
 
     // start up
-    implementation "androidx.startup:startup-runtime:1.1.0"
+    implementation libs.androidx.startup.runtime
 
     // retrofit
-    def retrofit_version = "2.9.0"
-    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    implementation "com.squareup.retrofit2:adapter-rxjava3:$retrofit_version"
+    implementation libs.bundles.retrofit
 
     // okHttp
-    def okHttp_version = "4.9.0"
-    implementation "com.squareup.okhttp3:okhttp:$okHttp_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$okHttp_version"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp_version"
+    implementation libs.okhttp
+    implementation libs.okhttp.logging.interceptor
+    testImplementation libs.okhttp.mockwebserver
 
-    // coroutine
-    def coroutine_version = "1.6.4"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$coroutine_version"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutine_version"
+    // coroutines
+    implementation libs.bundles.coroutines
+    testImplementation libs.kotlinx.coroutines.test
 
     // rxJava
-    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.7'
+    implementation libs.bundles.rxjava
 
     // viewModel
-    def lifecycle_version = "1.1.1"
-    implementation "android.arch.lifecycle:extensions:$lifecycle_version"
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation "androidx.activity:activity-ktx:1.2.3"
+    implementation libs.bundles.viewmodel.ktx
 
     // Timber
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation libs.timber
 
     // viewPager2
-    implementation "androidx.viewpager2:viewpager2:1.0.0"
+    implementation libs.androidx.viewpager2
 
     // fragment
-    def fragment_version = '1.5.0'
-    implementation "androidx.fragment:fragment-ktx:$fragment_version"
-    debugImplementation "androidx.fragment:fragment-testing:$fragment_version"
+    implementation libs.androidx.fragment.ktx
+    debugImplementation libs.androidx.fragment.testing
 
     // firebase
-    implementation platform('com.google.firebase:firebase-bom:30.1.0')
-    implementation 'com.google.firebase:firebase-messaging-ktx'
-    implementation 'com.google.firebase:firebase-analytics-ktx'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation platform(libs.firebase.bom)
+    implementation libs.bundles.firebase
 
     // open source notices
-    implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
+    implementation libs.play.services.oss.licenses
 
     // soft keyboard listener
-    implementation 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:3.0.0-RC3'
+    implementation libs.keyboardvisibilityevent
 
-    // unit test
-    androidTestImplementation("org.mockito:mockito-android:2.24.5")
-    testImplementation 'org.mockito:mockito-inline:2.21.0'
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation 'org.mockito:mockito-core:3.5.9'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation "org.robolectric:robolectric:4.7"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    // tests
+    testImplementation libs.bundles.unit.test
+    androidTestImplementation libs.bundles.android.test
 
     // paging3
-    def paging_version = "3.0.1"
-    implementation "androidx.paging:paging-runtime-ktx:$paging_version"
-    implementation "androidx.paging:paging-common-ktx:$paging_version"
-    implementation "androidx.paging:paging-rxjava3:$paging_version"
+    implementation libs.bundles.paging
 
     // Room
-    def room_version = "2.4.0-alpha03"
-    implementation "androidx.room:room-runtime:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
-    implementation "androidx.room:room-ktx:$room_version"
-    implementation "androidx.room:room-rxjava3:$room_version"
-    testImplementation "androidx.room:room-testing:$room_version"
+    implementation libs.androidx.room.runtime
+    kapt libs.androidx.room.compiler
+    implementation libs.androidx.room.ktx
+    implementation libs.androidx.room.rxjava3
+    testImplementation libs.androidx.room.testing
 
     // Compose
-    def compose_bom = "2023.05.00"
-    implementation platform("androidx.compose:compose-bom:$compose_bom")
-    implementation "androidx.compose.foundation:foundation"
-    implementation "androidx.compose.material:material"
-    implementation "androidx.compose.material:material-icons-core"
-    implementation "androidx.compose.material:material-icons-extended"
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.ui:ui-test"
-    implementation "androidx.compose.ui:ui-test-junit4"
-    debugImplementation "androidx.compose.ui:ui-test-manifest"
-    implementation "androidx.compose.ui:ui-tooling"
-    implementation "androidx.compose.ui:ui-tooling-preview"
-
-    implementation "androidx.activity:activity-compose:1.7.1"
-    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1"
-    implementation "androidx.paging:paging-compose:1.0.0-alpha19"
-    implementation "androidx.constraintlayout:constraintlayout-compose:1.0.1"
+    implementation platform(libs.compose.bom)
+    implementation libs.bundles.compose
+    implementation libs.bundles.compose.interop
 
     // WorkManager
-    def work_version = '2.7.1'
-    implementation "androidx.work:work-runtime-ktx:$work_version"
-    androidTestImplementation "androidx.work:work-testing:$work_version"
-    implementation "androidx.hilt:hilt-work:1.0.0"
+    implementation libs.bundles.androidx.work
+    androidTestImplementation libs.androidx.work.testing
 
     // Shimmer effect
-    implementation 'com.facebook.shimmer:shimmer:0.5.0'
+    implementation libs.shimmer
 
     // tag library
-    implementation 'com.github.yeon-kyu:AndroidTagView:v1.1.7-alpha1'
-
-    // WebSocket
-    implementation "org.java-websocket:Java-WebSocket:1.5.1"
+    implementation libs.androidtagview
 
     // HoldableSwipeHandler
-    implementation 'com.github.yeon-kyu.HoldableSwipeHandler:HoldableSwipeHandler:1.2.2'
+    implementation libs.holdableswipehandler
 
     // leak canary
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
+    debugImplementation libs.leakcanary.android
 
     // swipeRefreshLayout
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01'
+    implementation libs.androidx.swiperefreshlayout
 
     // appsFlyer
-    implementation 'com.appsflyer:af-android-sdk:6.3.2'
+    implementation libs.af.android.sdk
 
     // indicator
-    implementation 'com.romandanylyk:pageindicatorview:1.0.3'
+    implementation libs.pageindicatorview
 
     // sendbird sdk
-    implementation 'com.sendbird.sdk:sendbird-chat:4.0.0-beta.2'
+    implementation libs.sendbird.chat
 
     // google play-auth
-    implementation 'com.google.android.gms:play-services-auth:20.3.0'
-
-    // google AdMob
-    implementation 'com.google.android.gms:play-services-ads:21.2.0'
+    implementation libs.play.services.auth
 }
 
 kapt {

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21'
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.45'
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.4'
+        classpath libs.android.gradle
+        classpath libs.kotlin.gradle
+        classpath libs.hilt.android.gradle
+        classpath libs.google.services
+        classpath libs.firebase.crashlytics.gradle
+        classpath libs.oss.licenses
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,16 @@
 [versions]
+# project-level dependency
+android-gradle = '7.1.0'
+kotlin = '1.8.21'
+hilt = '2.45'
+google-services = '4.3.10'
+firebase-gradle = '2.7.1'
+oss-licenses-version = '0.10.4'
+
+# app-level dependency
 compose-compiler = '1.4.7'
 compose-bom = '2023.05.00'
 fragment = '1.5.0'
-hilt = '2.45'
 kotlinx-coroutines = '1.6.4'
 okhttp = '4.9.0'
 paging = '3.2.0-alpha05'
@@ -15,6 +23,14 @@ firebase = '30.1.0'
 work = '2.7.1'
 
 [libraries]
+# Project-level dependencies
+android-gradle = { module = 'com.android.tools.build:gradle', version.ref = 'android-gradle' }
+kotlin-gradle = { module = 'org.jetbrains.kotlin:kotlin-gradle-plugin', version.ref = 'kotlin' }
+hilt-android-gradle = { module = 'com.google.dagger:hilt-android-gradle-plugin', version.ref = 'hilt' }
+google-services = { module = 'com.google.gms:google-services', version.ref = 'google-services' }
+firebase-crashlytics-gradle = { module = 'com.google.firebase:firebase-crashlytics-gradle', version.ref = 'firebase-gradle' }
+oss-licenses = { module = 'com.google.android.gms:oss-licenses-plugin', version.ref = 'oss-licenses-version' }
+
 # Android
 android-material = 'com.google.android.material:material:1.4.0'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,205 @@
+[versions]
+compose-compiler = '1.4.7'
+compose-bom = '2023.05.00'
+fragment = '1.5.0'
+hilt = '2.45'
+kotlinx-coroutines = '1.6.4'
+okhttp = '4.9.0'
+paging = '3.2.0-alpha05'
+retrofit = '2.9.0'
+room = '2.4.0-alpha03'
+startup-runtime = '1.1.0'
+swiperefreshlayout = '1.2.0-alpha01'
+viewpager2 = '1.0.0'
+firebase = '30.1.0'
+work = '2.7.1'
+
+[libraries]
+# Android
+android-material = 'com.google.android.material:material:1.4.0'
+
+# AndroidX
+androidx-appcompat = 'androidx.appcompat:appcompat:1.3.1'
+androidx-constraintlayout = 'androidx.constraintlayout:constraintlayout:2.1.1'
+androidx-core-ktx = 'androidx.core:core-ktx:1.6.0'
+androidx-startup-runtime = 'androidx.startup:startup-runtime:1.1.0'
+androidx-swiperefreshlayout = 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-alpha01'
+androidx-viewpager2 = 'androidx.viewpager2:viewpager2:1.0.0'
+
+# AndroidX ViewModel
+android-lifecycle-extensions = 'android.arch.lifecycle:extensions:1.1.1'
+androidx-lifecycle-viewmodel-ktx = 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+androidx-activity-ktx = 'androidx.activity:activity-ktx:1.2.3'
+
+# Firebase
+firebase-bom = { module = 'com.google.firebase:firebase-bom', version.ref = 'firebase' }
+firebase-messaging-ktx = { module = 'com.google.firebase:firebase-messaging-ktx' }
+firebase-analytics-ktx = { module = 'com.google.firebase:firebase-analytics-ktx' }
+firebase-crashlytics-ktx = { module = 'com.google.firebase:firebase-crashlytics-ktx' }
+
+# Fragment
+androidx-fragment-ktx = { module = 'androidx.fragment:fragment-ktx', version.ref = 'fragment' }
+androidx-fragment-testing = { module = 'androidx.fragment:fragment-testing', version.ref = 'fragment' }
+
+# Compose
+compose-bom = { module = 'androidx.compose:compose-bom', version.ref = 'compose-bom' }
+compose-foundation = { module = 'androidx.compose.foundation:foundation' }
+compose-material = { module = 'androidx.compose.material:material' }
+compose-material-icons-core = { module = 'androidx.compose.material:material-icons-core' }
+compose-material-icons-extended = { module = 'androidx.compose.material:material-icons-extended' }
+compose-ui = { module = 'androidx.compose.ui:ui' }
+compose-ui-test = { module = 'androidx.compose.ui:ui-test' }
+compose-ui-test-junit4 = { module = 'androidx.compose.ui:ui-test-junit4' }
+compose-ui-test-manifest = { module = 'androidx.compose.ui:ui-test-manifest' }
+compose-ui-tooling = { module = 'androidx.compose.ui:ui-tooling' }
+compose-ui-tooling-preview = { module = 'androidx.compose.ui:ui-tooling-preview' }
+
+# Compose Interop
+androidx-activity-compose = 'androidx.activity:activity-compose:1.7.1'
+androidx-constraintlayout-compose = 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
+androidx-lifecycle-viewmodel-compose = 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
+androidx-paging-compose = 'androidx.paging:paging-compose:1.0.0-alpha19'
+hilt-navigation-compose = 'androidx.hilt:hilt-navigation-compose:1.0.0'
+
+# Kotlin Coroutines
+kotlinx-coroutines-android = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-android', version.ref = 'kotlinx-coroutines' }
+kotlinx-coroutines-core = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-core', version.ref = 'kotlinx-coroutines' }
+kotlinx-coroutines-reactive = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-reactive', version.ref = 'kotlinx-coroutines' }
+# Test는 bundle로 묶지 말기 (필요한 모듈에서만 별도로 선언)
+kotlinx-coroutines-test = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-test', version.ref = 'kotlinx-coroutines' }
+
+# Hilt
+androidx-hilt-compiler = 'androidx.hilt:hilt-compiler:1.0.0'
+hilt-android = { module = 'com.google.dagger:hilt-android', version.ref = 'hilt' }
+hilt-android-testing = { module = 'com.google.dagger:hilt-android-testing', version.ref = 'hilt' }
+hilt-compiler = { module = 'com.google.dagger:hilt-compiler', version.ref = 'hilt' }
+
+# OkHttp
+okhttp = { module = 'com.squareup.okhttp3:okhttp', version.ref = 'okhttp' }
+okhttp-logging-interceptor = { module = 'com.squareup.okhttp3:logging-interceptor', version.ref = 'okhttp' }
+okhttp-mockwebserver = { module = 'com.squareup.okhttp3:mockwebserver', version.ref = 'okhttp' }
+
+# Paging3
+androidx-paging-rxjava3 = { module = 'androidx.paging:paging-rxjava3', version.ref = 'paging' }
+androidx-paging-common-ktx = { module = 'androidx.paging:paging-common-ktx', version.ref = 'paging' }
+androidx-paging-runtime-ktx = { module = 'androidx.paging:paging-runtime-ktx', version.ref = 'paging' }
+
+# Play Services
+play-services-oss-licenses = 'com.google.android.gms:play-services-oss-licenses:17.0.0'
+play-services-auth = 'com.google.android.gms:play-services-auth:20.3.0'
+
+# Retrofit
+retrofit = { module = 'com.squareup.retrofit2:retrofit', version.ref = 'retrofit' }
+retrofit-converter-gson = { module = 'com.squareup.retrofit2:converter-gson', version.ref = 'retrofit' }
+retrofit-adapter-rxjava3 = { module = 'com.squareup.retrofit2:adapter-rxjava3', version.ref = 'retrofit' }
+
+# Room
+androidx-room-ktx = { module = 'androidx.room:room-ktx', version.ref = 'room' }
+androidx-room-runtime = { module = 'androidx.room:room-runtime', version.ref = 'room' }
+androidx-room-compiler = { module = 'androidx.room:room-compiler', version.ref = 'room' }
+androidx-room-testing = { module = 'androidx.room:room-testing', version.ref = 'room' }
+androidx-room-rxjava3 = { module = 'androidx.room:room-rxjava3', version.ref = 'room' }
+
+# RxJava
+rxandroid = 'io.reactivex.rxjava3:rxandroid:3.0.0'
+rxjava = 'io.reactivex.rxjava3:rxjava:3.0.7'
+
+# WorkManager
+androidx-work-runtime-ktx = { module = 'androidx.work:work-runtime-ktx', version.ref = 'work' }
+androidx-work-testing = { module = 'androidx.work:work-testing', version.ref = 'work' }
+androidx-work-hilt = 'androidx.hilt:hilt-work:1.0.0'
+
+# Unit Test
+androidx-core-testing = 'androidx.arch.core:core-testing:2.1.0'
+androidx-test-core = 'androidx.test:core:1.4.0'
+mockito-core = 'org.mockito:mockito-core:3.5.9'
+mockito-inline = 'org.mockito:mockito-inline:2.21.0'
+mockito-kotlin = 'org.mockito.kotlin:mockito-kotlin:4.0.0'
+junit = 'junit:junit:4.13.2'
+robolectric = 'org.robolectric:robolectric:4.7'
+
+# Android Test
+androidx-espresso-core = 'androidx.test.espresso:espresso-core:3.4.0'
+androidx-junit = 'androidx.test.ext:junit:1.1.3'
+mockito-android = 'org.mockito:mockito-android:2.24.5'
+
+# Other libraries
+af-android-sdk = 'com.appsflyer:af-android-sdk:6.3.2'
+androidtagview = 'com.github.yeon-kyu:AndroidTagView:v1.1.7-alpha1'
+keyboardvisibilityevent = 'net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent:3.0.0-RC3'
+leakcanary-android = 'com.squareup.leakcanary:leakcanary-android:2.8.1'
+pageindicatorview = 'com.romandanylyk:pageindicatorview:1.0.3'
+sendbird-chat = 'com.sendbird.sdk:sendbird-chat:4.0.0-beta.2'
+shimmer = 'com.facebook.shimmer:shimmer:0.5.0'
+timber = 'com.jakewharton.timber:timber:4.7.1'
+holdableswipehandler = 'com.github.yeon-kyu.HoldableSwipeHandler:HoldableSwipeHandler:1.2.2'
+
+[bundles]
+retrofit = [
+    'retrofit',
+    'retrofit-converter-gson',
+    'retrofit-adapter-rxjava3'
+]
+compose = [
+    'compose-foundation',
+    'compose-material',
+    'compose-material-icons-core',
+    'compose-material-icons-extended',
+    'compose-ui',
+    'compose-ui-test',
+    'compose-ui-test-junit4',
+    'compose-ui-test-manifest',
+    'compose-ui-tooling',
+    'compose-ui-tooling-preview',
+]
+compose-interop = [
+    'androidx-activity-compose',
+    'hilt-navigation-compose',
+    'androidx-lifecycle-viewmodel-compose',
+    'androidx-paging-compose',
+    'androidx-constraintlayout-compose',
+]
+coroutines = [
+    'kotlinx-coroutines-android',
+    'kotlinx-coroutines-core',
+    'kotlinx-coroutines-reactive',
+]
+firebase = [
+    'firebase-analytics-ktx',
+    'firebase-messaging-ktx',
+    'firebase-crashlytics-ktx',
+]
+paging = [
+    'androidx-paging-runtime-ktx',
+    'androidx-paging-common-ktx',
+    'androidx-paging-rxjava3',
+]
+rxjava = [
+    'rxandroid',
+    'rxjava',
+]
+viewmodel-ktx = [
+    'android-lifecycle-extensions',
+    'androidx-lifecycle-viewmodel-ktx',
+    'androidx-activity-ktx',
+]
+androidx-work = [
+    'androidx-work-runtime-ktx',
+    'androidx-work-hilt',
+]
+unit-test = [
+    'mockito-core',
+    'mockito-inline',
+    'mockito-kotlin',
+    'junit',
+    'androidx-core-testing',
+    'androidx-test-core',
+    'robolectric',
+]
+android-test = [
+    'mockito-android',
+    'androidx-junit',
+    'androidx-espresso-core',
+]
+
+[plugins]

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,5 @@ dependencyResolutionManagement {
 }
 rootProject.name = "KU Ring"
 include ':app'
+
+enableFeaturePreview("VERSION_CATALOGS")


### PR DESCRIPTION
[Jira 티켓 링크](https://kuring.atlassian.net/browse/KURING-69?atlOrigin=eyJpIjoiOGNhOWY0MjllNmM2NDA4ZWI1YWNmYWQ4MWZkMjhhYWIiLCJwIjoiaiJ9)

# 문제 상황

앱이 여러 모듈로 나눠져 있다면 각 모듈에서 의존성의 버전을 동일하게 맞춰야 하는데요, 지금처럼 라이브러리 버전을 하드코딩하면 버전을 관리하기가 매우 힘듭니다.

# 해결 방법

Gradle Version Catalog에 라이브러리를 선언하면 모든 모듈에서 같은 버전의 라이브러리를 사용할 수 있습니다. 

# 참고 문헌

[Gradle - Sharing dependency versions between projects](https://docs.gradle.org/current/userguide/platforms.html)