### PR TITLE
kuring-69 데이터 접근 경로를 repository로 일원화

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     implementation project(":data:department")
     implementation project(":data:local")
     testImplementation testFixtures(project(":data:local"))
+    // SendbirdRepository 삭제되면 :data:remote 의존성 제거하기
     implementation project(":data:remote")
     testImplementation testFixtures(project(":data:remote"))
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatViewModel.kt
@@ -5,9 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.ku_stacks.ku_ring.BuildConfig
 import com.ku_stacks.ku_ring.R
-import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.remote.user.FeedbackClient
-import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.ui.chat.ui_model.ChatUiModel
 import com.ku_stacks.ku_ring.ui.chat.ui_model.ReceivedMessageUiModel
 import com.ku_stacks.ku_ring.ui.chat.ui_model.SentMessageUiModel
@@ -35,8 +32,6 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChatViewModel @Inject constructor(
-    private val pref: PreferenceUtil,
-    private val feedbackClient: FeedbackClient,
     private val repository: UserRepository
 ) : ViewModel() {
 
@@ -268,10 +263,7 @@ class ChatViewModel @Inject constructor(
 
         // send to Kuring server
         disposable.add(
-            feedbackClient.sendFeedback(
-                token = pref.fcmToken ?: "",
-                feedbackRequest = FeedbackRequest(content = feedbackContent),
-            )
+            repository.sendFeedback(feedbackContent)
                 .subscribeOn(Schedulers.io())
                 .subscribe({
                     if (it.isSuccess) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -8,7 +8,6 @@ import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.domain.Department
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.remote.notice.request.SubscribeRequest
 import com.ku_stacks.ku_ring.util.WordConverter
 import com.ku_stacks.ku_ring.util.modifyMap
 import com.ku_stacks.ku_ring.util.modifySet
@@ -131,9 +130,9 @@ class EditSubscriptionViewModel @Inject constructor(
             preferenceUtil.saveSubscriptionFromKorean(notificationEnabledCategories)
             noticeRepository.saveSubscriptionToRemote(
                 token = fcmToken,
-                subscribeRequest = SubscribeRequest(notificationEnabledCategories.map { category ->
+                subscribeCategories = notificationEnabledCategories.map { category ->
                     WordConverter.convertKoreanToEnglish(category)
-                })
+                }
             )
         }
         viewModelScope.launch {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/feedback/FeedbackViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/feedback/FeedbackViewModel.kt
@@ -6,9 +6,8 @@ import androidx.lifecycle.ViewModel
 import com.google.firebase.messaging.FirebaseMessaging
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
-import com.ku_stacks.ku_ring.remote.user.FeedbackClient
-import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.ui_util.SingleLiveEvent
+import com.ku_stacks.ku_ring.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
@@ -18,7 +17,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FeedbackViewModel @Inject constructor(
-    private val feedbackClient: FeedbackClient,
+    private val userRepository: UserRepository,
     private val analytics: EventAnalytics,
     private val firebaseMessaging: FirebaseMessaging
 ) : ViewModel() {
@@ -70,10 +69,7 @@ class FeedbackViewModel @Inject constructor(
                 return@addOnCompleteListener
             }
 
-            feedbackClient.sendFeedback(
-                token = fcmToken,
-                feedbackRequest = FeedbackRequest(content = content),
-            )
+            userRepository.sendFeedback(content)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
@@ -5,13 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.domain.Staff
-import com.ku_stacks.ku_ring.notice.mapper.toNoticeList
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
-import com.ku_stacks.ku_ring.remote.notice.NoticeClient
 import com.ku_stacks.ku_ring.staff.repository.StaffRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.schedulers.Schedulers
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -19,7 +16,6 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val noticeRepository: NoticeRepository,
     private val staffRepository: StaffRepository,
-    private val noticeClient: NoticeClient,
 ) : ViewModel() {
 
     private val disposable = CompositeDisposable()
@@ -50,10 +46,7 @@ class SearchViewModel @Inject constructor(
     fun searchNotice(keyword: String) {
         Timber.e("search notice $keyword")
         disposable.add(
-            noticeClient.fetchNoticeList(keyword)
-                .subscribeOn(Schedulers.io())
-                .filter { it.isSuccess }
-                .map { noticeResponse -> noticeResponse.toNoticeList() }
+            noticeRepository.searchNotice(keyword)
                 .map { noticeList -> markSavedNotices(noticeList) }
                 .subscribe(
                     { _noticeList.postValue(it) },

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
@@ -8,8 +8,7 @@ import com.ku_stacks.ku_ring.domain.Staff
 import com.ku_stacks.ku_ring.notice.mapper.toNoticeList
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
 import com.ku_stacks.ku_ring.remote.notice.NoticeClient
-import com.ku_stacks.ku_ring.remote.staff.StaffClient
-import com.ku_stacks.ku_ring.staff.mapper.toStaffList
+import com.ku_stacks.ku_ring.staff.repository.StaffRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -19,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val noticeRepository: NoticeRepository,
-    private val staffClient: StaffClient,
+    private val staffRepository: StaffRepository,
     private val noticeClient: NoticeClient,
 ) : ViewModel() {
 
@@ -40,10 +39,7 @@ class SearchViewModel @Inject constructor(
     fun searchStaff(keyword: String) {
         Timber.e("search staff $keyword")
         disposable.add(
-            staffClient.fetchStaffList(keyword)
-                .subscribeOn(Schedulers.io())
-                .filter { it.isSuccess }
-                .map { staffResponse -> staffResponse.toStaffList() }
+            staffRepository.searchStaff(keyword)
                 .subscribe(
                     { _staffList.postValue(it) },
                     { Timber.e("search staff error: $it") }

--- a/data/department/build.gradle
+++ b/data/department/build.gradle
@@ -37,6 +37,7 @@ android {
 }
 
 dependencies {
+    implementation project(":common:util")
     implementation project(":common:preferences")
     implementation project(":data:domain")
     implementation testFixtures(project(":data:domain"))

--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/di/RepositoryModule.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/di/RepositoryModule.kt
@@ -2,23 +2,16 @@ package com.ku_stacks.ku_ring.department.di
 
 import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.department.repository.DepartmentRepositoryImpl
-import com.ku_stacks.ku_ring.local.room.DepartmentDao
-import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.remote.department.DepartmentClient
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RepositoryModule {
-    @Provides
+abstract class RepositoryModule {
+    @Binds
     @Singleton
-    fun provideDepartmentRepository(
-        departmentDao: DepartmentDao,
-        departmentClient: DepartmentClient,
-        pref: PreferenceUtil,
-    ): DepartmentRepository = DepartmentRepositoryImpl(departmentDao, departmentClient, pref)
+    abstract fun provideDepartmentRepository(repositoryImpl: DepartmentRepositoryImpl): DepartmentRepository
 }

--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.ku_stacks.ku_ring.domain.Department
 import com.ku_stacks.ku_ring.local.room.DepartmentDao
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.remote.department.DepartmentClient
+import com.ku_stacks.ku_ring.util.IODispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -20,7 +21,7 @@ class DepartmentRepositoryImpl @Inject constructor(
     private val departmentDao: DepartmentDao,
     private val departmentClient: DepartmentClient,
     private val pref: PreferenceUtil,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DepartmentRepository {
     // not null: 최신 데이터가 캐시됨
     // null: 데이터가 업데이트되어 새 데이터를 가져와야 함

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/di/RepositoryModule.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/di/RepositoryModule.kt
@@ -1,29 +1,17 @@
 package com.ku_stacks.ku_ring.notice.di
 
-import com.ku_stacks.ku_ring.local.room.NoticeDao
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepositoryImpl
-import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.remote.notice.NoticeClient
-import com.ku_stacks.ku_ring.util.IODispatcher
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RepositoryModule {
-    @Provides
+abstract class RepositoryModule {
+    @Binds
     @Singleton
-    fun provideNoticeRepository(
-        noticeClient: NoticeClient,
-        noticeDao: NoticeDao,
-        pref: PreferenceUtil,
-        @IODispatcher ioDispatcher: CoroutineDispatcher,
-    ): NoticeRepository {
-        return NoticeRepositoryImpl(noticeClient, noticeDao, pref, ioDispatcher)
-    }
+    abstract fun provideNoticeRepository(repositoryImpl: NoticeRepositoryImpl): NoticeRepository
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepository.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepository.kt
@@ -2,7 +2,6 @@ package com.ku_stacks.ku_ring.notice.repository
 
 import androidx.paging.PagingData
 import com.ku_stacks.ku_ring.domain.Notice
-import com.ku_stacks.ku_ring.remote.notice.request.SubscribeRequest
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Single
@@ -22,6 +21,6 @@ interface NoticeRepository {
     fun deleteSharedPreference()
     fun getDepartmentNotices(shortName: String): Flow<PagingData<Notice>>
     fun fetchSubscriptionFromRemote(token: String): Single<List<String>>
-    fun saveSubscriptionToRemote(token: String, subscribeRequest: SubscribeRequest)
+    fun saveSubscriptionToRemote(token: String, subscribeCategories: List<String>)
     fun searchNotice(query: String): Single<List<Notice>>
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepository.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepository.kt
@@ -23,4 +23,5 @@ interface NoticeRepository {
     fun getDepartmentNotices(shortName: String): Flow<PagingData<Notice>>
     fun fetchSubscriptionFromRemote(token: String): Single<List<String>>
     fun saveSubscriptionToRemote(token: String, subscribeRequest: SubscribeRequest)
+    fun searchNotice(query: String): Single<List<Notice>>
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
@@ -229,6 +229,14 @@ class NoticeRepositoryImpl @Inject constructor(
             })
     }
 
+    override fun searchNotice(query: String): Single<List<Notice>> {
+        return noticeClient.fetchNoticeList(query)
+            .subscribeOn(Schedulers.io())
+            .filter { it.isSuccess }
+            .map { it.toNoticeList() }
+            .toSingle()
+    }
+
     companion object {
         private const val pageSize = 20
     }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
@@ -214,7 +214,8 @@ class NoticeRepositoryImpl @Inject constructor(
             }
     }
 
-    override fun saveSubscriptionToRemote(token: String, subscribeRequest: SubscribeRequest) {
+    override fun saveSubscriptionToRemote(token: String, subscribeCategories: List<String>) {
+        val subscribeRequest = SubscribeRequest(subscribeCategories)
         noticeClient.saveSubscribe(token, subscribeRequest)
             .subscribeOn(Schedulers.io())
             .subscribe({ response ->

--- a/data/notice/src/test/java/com/ku_stacks/ku_ring/notice/NoticeRepositoryTest.kt
+++ b/data/notice/src/test/java/com/ku_stacks/ku_ring/notice/NoticeRepositoryTest.kt
@@ -103,7 +103,7 @@ class NoticeRepositoryTest {
             .thenReturn(Single.just(mockResponse))
 
         // when
-        repository.saveSubscriptionToRemote(mockToken, mockRequest)
+        repository.saveSubscriptionToRemote(mockToken, mockRequest.categories)
 
         // then
         Mockito.verify(client, times(1)).saveSubscribe(mockToken, mockRequest)

--- a/data/push/src/main/java/com/ku_stacks/ku_ring/push/di/RepositoryModule.kt
+++ b/data/push/src/main/java/com/ku_stacks/ku_ring/push/di/RepositoryModule.kt
@@ -1,22 +1,17 @@
 package com.ku_stacks.ku_ring.push.di
 
-import com.ku_stacks.ku_ring.local.room.PushDao
 import com.ku_stacks.ku_ring.push.repository.PushRepository
 import com.ku_stacks.ku_ring.push.repository.PushRepositoryImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RepositoryModule {
-    @Provides
+abstract class RepositoryModule {
+    @Binds
     @Singleton
-    fun providePushRepository(
-        pushDao: PushDao
-    ): PushRepository {
-        return PushRepositoryImpl(pushDao)
-    }
+    abstract fun providePushRepository(repositoryImpl: PushRepositoryImpl): PushRepository
 }

--- a/data/staff/build.gradle
+++ b/data/staff/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     testImplementation libs.hilt.android.testing
     kaptTest libs.hilt.compiler
 
+    // rxJava
+    implementation libs.bundles.rxjava
+
     // tests
     testImplementation libs.bundles.unit.test
 }

--- a/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/di/RepositoryModule.kt
+++ b/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/di/RepositoryModule.kt
@@ -1,0 +1,15 @@
+package com.ku_stacks.ku_ring.staff.di
+
+import com.ku_stacks.ku_ring.staff.repository.StaffRepository
+import com.ku_stacks.ku_ring.staff.repository.StaffRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    abstract fun bindStaffRepository(repositoryImpl: StaffRepositoryImpl): StaffRepository
+}

--- a/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/repository/StaffRepository.kt
+++ b/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/repository/StaffRepository.kt
@@ -1,0 +1,8 @@
+package com.ku_stacks.ku_ring.staff.repository
+
+import com.ku_stacks.ku_ring.domain.Staff
+import io.reactivex.rxjava3.core.Single
+
+interface StaffRepository {
+    fun searchStaff(query: String): Single<List<Staff>>
+}

--- a/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/repository/StaffRepositoryImpl.kt
+++ b/data/staff/src/main/java/com/ku_stacks/ku_ring/staff/repository/StaffRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.ku_stacks.ku_ring.staff.repository
+
+import com.ku_stacks.ku_ring.domain.Staff
+import com.ku_stacks.ku_ring.remote.staff.StaffClient
+import com.ku_stacks.ku_ring.staff.mapper.toStaffList
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Inject
+
+class StaffRepositoryImpl @Inject constructor(
+    private val staffClient: StaffClient,
+) : StaffRepository {
+    override fun searchStaff(query: String): Single<List<Staff>> {
+        return staffClient.fetchStaffList(query)
+            .subscribeOn(Schedulers.io())
+            .filter { it.isSuccess }
+            .map { it.toStaffList() }
+            .toSingle()
+    }
+}

--- a/data/user/build.gradle
+++ b/data/user/build.gradle
@@ -33,6 +33,7 @@ android {
 
 dependencies {
     implementation project(":common:util")
+    implementation project(":common:preferences")
     implementation project(":data:local")
     implementation project(":data:remote")
 

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/di/RepositoryModule.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/di/RepositoryModule.kt
@@ -1,22 +1,15 @@
 package com.ku_stacks.ku_ring.user.di
 
-import com.ku_stacks.ku_ring.local.room.BlackUserDao
 import com.ku_stacks.ku_ring.user.repository.UserRepository
 import com.ku_stacks.ku_ring.user.repository.UserRepositoryImpl
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RepositoryModule {
-    @Provides
-    @Singleton
-    fun provideUserRepository(
-        blackUserDao: BlackUserDao
-    ): UserRepository {
-        return UserRepositoryImpl(blackUserDao)
-    }
+abstract class RepositoryModule {
+    @Binds
+    abstract fun bindUserRepository(userRepositoryImpl: UserRepositoryImpl): UserRepository
 }

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepository.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepository.kt
@@ -1,9 +1,11 @@
 package com.ku_stacks.ku_ring.user.repository
 
+import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Single
 
 interface UserRepository {
     fun blockUser(userId: String, nickname: String): Completable
     fun getBlackUserList(): Single<List<String>>
+    fun sendFeedback(feedback: String): Single<DefaultResponse>
 }

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -2,12 +2,18 @@ package com.ku_stacks.ku_ring.user.repository
 
 import com.ku_stacks.ku_ring.local.entity.BlackUserEntity
 import com.ku_stacks.ku_ring.local.room.BlackUserDao
+import com.ku_stacks.ku_ring.preferences.PreferenceUtil
+import com.ku_stacks.ku_ring.remote.user.FeedbackClient
+import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
+import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
-    private val dao: BlackUserDao
+    private val dao: BlackUserDao,
+    private val feedbackClient: FeedbackClient,
+    private val pref: PreferenceUtil,
 ) : UserRepository {
     override fun blockUser(userId: String, nickname: String): Completable {
         return dao.blockUser(
@@ -24,5 +30,12 @@ class UserRepositoryImpl @Inject constructor(
             .map { blackList ->
                 blackList.map { user -> user.userId }
             }
+    }
+
+    override fun sendFeedback(feedback: String): Single<DefaultResponse> {
+        return feedbackClient.sendFeedback(
+            token = pref.fcmToken ?: "",
+            feedbackRequest = FeedbackRequest(feedback)
+        )
     }
 }


### PR DESCRIPTION
# 문제 상황

현재 몇몇 `ViewModel`에서는 비즈니스 로직을 `...Client`에 접근하여 처리합니다. 그러나 모듈화된 쿠링 앱에서는 모든 비즈니스 로직 접근은 repository를 통해서만 가능합니다. `:feature` 모듈이나 `:app` 모듈에서는 테스트 코드 같은 예외적인 경우를 제외하면 `...Client`나 `...Service`에 접근해서는 안 됩니다. 

사실 테스트에서도 접근하지 않는 게 좋은데, 향후 테스트 코드 리팩토링 때 다시 살펴보겠습니다.

# 수정 내용

따라서 모든 비즈니스 및 데이터 로직은 각 도메인 객체별로 정의된 `...Repository` 클래스를 통해서만 처리하도록 수정했습니다. `Repository` 클래스가 없던 몇몇 모듈에 `Repository` 및 hilt 코드를 추가했고, `ViewModel`에서 `Repository`에만 접근하도록 객체 참조를 바꾸었습니다.

## 커밋 설명
* https://github.com/ku-ring/KU-Ring-Android/commit/e9a514e8cdf230cc73dbb208ae726f0149d7d0ea, aa7693fd081fcdd0c4eb08af5d6de600e6b0146a, 1db639d233923a40d205809472f8b0f8bb1bcf4e: `UserRepository`에 피드백 전송 함수를 추가하고, `ChatViewModel`과 `FeedbackViewModel`에서 `FeedbackClient` 대신 `UserRepository`의 함수를 호출하도록 수정했습니다.
* fe57d015e52cbc15fa79c39f81ca6160faf5e7e0, d24f1218443281a7ff41273d6d90d74772159a89: `StaffRepository`를 새로 정의하고, 교직원 검색 API를 `StaffClient`가 아닌 `StaffRepository`를 통해 호출하도록 수정했습니다.
* 99b3d5e916583c4768ff2eb96d71ba9383a1417c, b39c58ff1119d41c81fbecbbcaf1237f20701eed, f8f999f131b6dca4242df6e5507727ddfeabb521: `NoticeRepository`에 공지 검색 함수를 추가하고, 공지 검색 API를 `NoticeClient`가 아닌 `NoticeRepository`를 통해 호출하도록 수정했습니다. 

## `:data` 모듈화 완료

이제 일부 `:common`과 `:feature`만 분리하면 끝입니다. 체감상 55% 정도 온 것 같습니다. 화이팅!