### PR TITLE
kuring-101 FeedbackViewModel unit test 수정, MainDispatcherRule 추가

### DIFF
--- a/feature/feedback/src/test/java/com/ku_stacks/ku_ring/feedback/util/MainDispatcherRule.kt
+++ b/feature/feedback/src/test/java/com/ku_stacks/ku_ring/feedback/util/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.ku_stacks.ku_ring.feedback.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
kuring-101 작업의 연장선에서 FeedbackViewModelTest 가 fail 나는것을 수정합니다.

#### 변경 사항
- FeedbackViewModelTest 수정
- Feedback Feature 모듈에 MainDispatcherRule 을 추가합니다. (테스트에 코루틴 dispatcher가 1개만 있도록 세팅해주는 rule)
 
#### 추후 대응
testFixture 가 kotlin을 지원할수 있게 되면 MainDispatcherRule을 util 모듈로 이동합니다. (다른 방안으로는 test-util 모듈을 따로 만들거나 이 클래스만 util 모듈의 실제코드로 이동하여 해결하는것도 가능할듯 합니다)