### PR TITLE
kuring-122 compose 키보드 이슈 업데이트 및 모듈간 sdk 의존성 통합

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,12 +30,12 @@ android {
             }
         }
     }
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
         applicationId "com.ku_stacks.ku_ring"
-        minSdk 24
-        targetSdk 33
+        minSdk libs.versions.minSdk.get().toInteger()
+        targetSdk libs.versions.targetSdk.get().toInteger()
         versionCode 22
         versionName "1.2.10"
 

--- a/common/preferences/build.gradle
+++ b/common/preferences/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.preferences'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/common/thirdparty/build.gradle
+++ b/common/thirdparty/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.thirdparty'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/common/ui_util/build.gradle
+++ b/common/ui_util/build.gradle
@@ -6,10 +6,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.ui_util'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/common/util/build.gradle
+++ b/common/util/build.gradle
@@ -8,10 +8,10 @@ def localPropertiesFile = rootProject.file("local.properties")
 
 android {
     namespace 'com.ku_stacks.ku_ring.util'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/common/work/build.gradle
+++ b/common/work/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.work'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/department/build.gradle
+++ b/data/department/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.department'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/domain/build.gradle
+++ b/data/domain/build.gradle
@@ -6,10 +6,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.domain'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/local/build.gradle
+++ b/data/local/build.gradle
@@ -8,10 +8,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.local'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/notice/build.gradle
+++ b/data/notice/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.notice'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/push/build.gradle
+++ b/data/push/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.push'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/remote/build.gradle
+++ b/data/remote/build.gradle
@@ -8,10 +8,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.remote'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/staff/build.gradle
+++ b/data/staff/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.staff'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/data/user/build.gradle
+++ b/data/user/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.user'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/edit_subscription/build.gradle
+++ b/feature/edit_subscription/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.edit_subscription'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
@@ -149,6 +149,7 @@ private fun SubscriptionTabs(
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(
         initialPage = selectedTab.ordinal,
+        pageCount = { EditSubscriptionTab.values().size }
     )
 
     val currentPage = pagerState.currentPage
@@ -228,10 +229,9 @@ private fun SubscriptionPager(
     onAddDepartmentButtonClick: () -> Unit,
     onSubscriptionComplete: () -> Unit,
     modifier: Modifier = Modifier,
-    pagerState: PagerState = rememberPagerState(),
+    pagerState: PagerState,
 ) {
     HorizontalPager(
-        pageCount = EditSubscriptionTab.values().size,
         verticalAlignment = Alignment.Top,
         state = pagerState,
         modifier = modifier,

--- a/feature/feedback/build.gradle
+++ b/feature/feedback/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.feedback'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/my_notification/build.gradle
+++ b/feature/my_notification/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.my_notification'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/feature/notice_storage/build.gradle
+++ b/feature/notice_storage/build.gradle
@@ -7,10 +7,10 @@ plugins {
 
 android {
     namespace 'com.ku_stacks.ku_ring.notice_storage'
-    compileSdk 33
+    compileSdk libs.versions.compileSdk.get().toInteger()
 
     defaultConfig {
-        minSdk 24
+        minSdk libs.versions.minSdk.get().toInteger()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,13 +6,13 @@ hilt = '2.45'
 google-services = '4.3.10'
 firebase-gradle = '2.7.1'
 oss-licenses-version = '0.10.4'
-compileSdk = "33"
+compileSdk = "34"
 targetSdk = "33"
 minSdk = "24"
 
 # app-level dependency
 compose-compiler = '1.4.7'
-compose-bom = '2023.05.00'
+compose-bom = '2024.01.00'
 fragment = '1.5.0'
 kotlinx-coroutines = '1.6.4'
 okhttp = '4.9.0'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,9 @@ hilt = '2.45'
 google-services = '4.3.10'
 firebase-gradle = '2.7.1'
 oss-licenses-version = '0.10.4'
+compileSdk = "33"
+targetSdk = "33"
+minSdk = "24"
 
 # app-level dependency
 compose-compiler = '1.4.7'


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-122

### 배경
- compose에서는 textField 에 요상한 버그가 있어서 수정합니다 (View의 EditText가 벌써부터 그리워지네요😫)
  - 사용자가 텍스트 중간에 한글을 입력하려 하면 커서가 맨뒤로 가지는 이슈(영어는 이슈 재현안됨)
  - 관련 [Issue Tracker 링크](https://issuetracker.google.com/issues/195231205?source=post_page-----5866bdae33e7--------------------------------)
- 피드백 화면 뿐만 아니라 검색화면에서도 지장이 있어, 사용자에게 안좋은 경험을 줄 수 있어 라이브러리 업데이트를 진행했습니다.

### 변경사항
- 각 모듈별 compileSdk, targetSdk, minSdk 를 Gradle Version Catalog에 의존하도록 합니다
- compose-bom 을 2024.01.00 으로 업데이트합니다. 이 과정에서 아래의 추가 업데이트/대응이 필요
  - targetSdk를 34로 업데이트
  - Subscriptions.kt 에서 HorizontalPager 사용처 업데이트 대응 [84cd311](https://github.com/ku-ring/KU-Ring-Android/pull/89/commits/84cd3119ae68219a408e285d275b9917af14f069)

### Screen Shot
#### as-is
https://github.com/ku-ring/KU-Ring-Android/assets/45001093/af5b47fa-1fa9-4fb4-808c-3cb0ab5ca672

#### to-be
https://github.com/ku-ring/KU-Ring-Android/assets/45001093/c005c69d-94c0-448c-90b9-0f47f7626dc1




