### PR TITLE
kuring-123 [수정] DateUtilTest가 간헐적으로 실패하던 문제 해결

### DIFF
--- a/common/util/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
+++ b/common/util/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
@@ -78,6 +78,7 @@ object DateUtil {
                 set(Calendar.HOUR_OF_DAY, hour) // Calendar.HOUR는 12시간
                 set(Calendar.MINUTE, minute)
                 set(Calendar.SECOND, second)
+                set(Calendar.MILLISECOND, 0)
             }
         }.getOrNull()
     }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-123

## 배경

CI 과정에서 `DateUtilTest`가 간헐적으로 실패하는 문제가 있었습니다. 해당 테스트는 두 `java.util.Calendar` 객체 간의 epoch의 차이를 계산하는 테스트입니다.

## 수정 내용

`DateUtil.getCalendar()` 함수에서 대부분의 필드를 주어진 값으로 설정하지만, `Calendar.MILLISECOND` 필드는 설정하지 않고 있었습니다. 따라서 `getCalendar()` 함수에서 `Calendar` 객체를 만들 때 MILLISECOND 필드를 0으로 설정하도록 수정했습니다.