### PR TITLE
kuring-120 [수정] 알림 구독 화면의 버그 수정

### DIFF
--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
@@ -355,9 +355,10 @@ private fun DepartmentCategoryList(
     onCallToActionClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier) {
+    Column(modifier = modifier) {
         LazyColumn(
             contentPadding = PaddingValues(vertical = 16.dp),
+            modifier = Modifier.weight(1f, fill = false),
         ) {
             items(
                 items = departments,
@@ -375,8 +376,7 @@ private fun DepartmentCategoryList(
             modifier = Modifier
                 .background(MaterialTheme.colors.surface)
                 .padding(26.dp)
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter),
+                .fillMaxWidth(),
         )
     }
 }

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
@@ -26,12 +26,13 @@ import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material.Text
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,7 +56,6 @@ import com.ku_stacks.ku_ring.edit_subscription.compose.components.DepartmentSubs
 import com.ku_stacks.ku_ring.edit_subscription.compose.components.NormalSubscriptionItem
 import com.ku_stacks.ku_ring.edit_subscription.uimodel.DepartmentSubscriptionUiModel
 import com.ku_stacks.ku_ring.edit_subscription.uimodel.NormalSubscriptionUiModel
-import kotlinx.coroutines.launch
 
 @Composable
 fun Subscriptions(
@@ -146,11 +146,20 @@ private fun SubscriptionTabs(
     onSubscriptionComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(
         initialPage = selectedTab.ordinal,
         pageCount = { EditSubscriptionTab.values().size }
     )
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            onTabClick(EditSubscriptionTab.values()[page])
+        }
+    }
+
+    LaunchedEffect(selectedTab) {
+        pagerState.animateScrollToPage(selectedTab.ordinal)
+    }
 
     val currentPage = pagerState.currentPage
     Column(modifier = modifier) {
@@ -171,9 +180,6 @@ private fun SubscriptionTabs(
                     tab = tab,
                     isSelected = tab == selectedTab,
                     onClick = {
-                        coroutineScope.launch {
-                            pagerState.animateScrollToPage(it.ordinal)
-                        }
                         onTabClick(it)
                     },
                 )

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/Subscriptions.kt
@@ -228,8 +228,8 @@ private fun SubscriptionPager(
     onDepartmentClick: (String) -> Unit,
     onAddDepartmentButtonClick: () -> Unit,
     onSubscriptionComplete: () -> Unit,
-    modifier: Modifier = Modifier,
     pagerState: PagerState,
+    modifier: Modifier = Modifier,
 ) {
     HorizontalPager(
         verticalAlignment = Alignment.Top,

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/components/DepartmentSubscriptionItem.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/components/DepartmentSubscriptionItem.kt
@@ -1,11 +1,13 @@
 package com.ku_stacks.ku_ring.edit_subscription.compose.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -13,7 +15,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -22,7 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.ku_stacks.ku_ring.designsystem.components.LightPreview
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
 import com.ku_stacks.ku_ring.edit_subscription.R
@@ -56,7 +57,7 @@ internal fun DepartmentSubscriptionItem(
                 lineHeight = 24.sp,
                 fontFamily = Pretendard,
                 fontWeight = FontWeight(500),
-                color = Color.Black,
+                color = MaterialTheme.colors.onSurface,
             )
         )
         Spacer(modifier = Modifier.weight(1f))
@@ -81,7 +82,7 @@ private fun getDescription(isSelected: Boolean): String {
     return stringResource(id = descriptionId)
 }
 
-@LightPreview
+@LightAndDarkPreview
 @Composable
 private fun DepartmentSubscriptionItemPreview() {
     var isSelected by remember { mutableStateOf(false) }
@@ -89,7 +90,9 @@ private fun DepartmentSubscriptionItemPreview() {
         DepartmentSubscriptionItem(
             uiModel = DepartmentSubscriptionUiModel("스마트ICT융합공학과", isSelected),
             onClick = { isSelected = !isSelected },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.surface),
         )
     }
 }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-120?atlOrigin=eyJpIjoiMGI2YjZmZmRkMjQ5NGZkZGJjZTM5Y2VhZDI2NTRmMTIiLCJwIjoiaiJ9

이전에 개발한 학과 구독 화면에서 몇 가지 버그가 발견되어 수정하였습니다. 

1. 스와이프로 탭을 전환하면 탭 제목 텍스트의 색깔이 변하지 않는 문제
2. 다크 모드에서 글씨가 보이지 않는 문제
3. `설정 완료` 버튼이 리스트 맨 밑을 가리던 문제

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/1cbb1485-4091-4db0-9ad5-679923f21547)