### PR TITLE
kuring-125 [수정] 알림 구독 화면의 최상위 composable 이름을 컨벤션에 맞게 수정

### DIFF
--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.databinding.DataBindingUtil
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
-import com.ku_stacks.ku_ring.edit_subscription.compose.Subscriptions
+import com.ku_stacks.ku_ring.edit_subscription.compose.EditSubscriptionScreen
 import com.ku_stacks.ku_ring.edit_subscription.databinding.ActivityEditSubscriptionBinding
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -40,7 +40,7 @@ class EditSubscriptionActivity : AppCompatActivity() {
         viewModel.firstRunFlag = intent.getBooleanExtra(FIRST_RUN_FLAG, false)
         binding.composeView.setContent {
             KuringTheme {
-                Subscriptions(
+                EditSubscriptionScreen(
                     viewModel = viewModel,
                     onAddDepartmentButtonClick = { navigator.navigateToEditSubscribedDepartment(this) },
                     onSubscriptionComplete = ::onSubscriptionComplete,

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
@@ -58,14 +58,14 @@ import com.ku_stacks.ku_ring.edit_subscription.uimodel.NormalSubscriptionUiModel
 import kotlinx.coroutines.launch
 
 @Composable
-fun Subscriptions(
+fun EditSubscriptionScreen(
     viewModel: EditSubscriptionViewModel,
     onAddDepartmentButtonClick: () -> Unit,
     onSubscriptionComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    Subscriptions(
+    EditSubscriptionScreen(
         categories = uiState.categories,
         departments = uiState.departments,
         onCategoryClick = viewModel::onNormalSubscriptionItemClick,
@@ -77,7 +77,7 @@ fun Subscriptions(
 }
 
 @Composable
-private fun Subscriptions(
+private fun EditSubscriptionScreen(
     categories: List<NormalSubscriptionUiModel>,
     departments: List<DepartmentSubscriptionUiModel>,
     onCategoryClick: (Int) -> Unit,
@@ -385,7 +385,7 @@ private fun SubscriptionsPreview() {
     var selectedTab by remember { mutableStateOf(EditSubscriptionTab.NORMAL) }
 
     KuringTheme {
-        Subscriptions(
+        EditSubscriptionScreen(
             categories = categories,
             departments = departments,
             onCategoryClick = {},
@@ -401,7 +401,7 @@ private fun SubscriptionsPreview() {
 @Composable
 private fun DepartmentPagePreview_Empty() {
     KuringTheme {
-        Subscriptions(
+        EditSubscriptionScreen(
             categories = emptyList(),
             departments = emptyList(),
             onCategoryClick = {},


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-125?atlOrigin=eyJpIjoiMTRkMzQwNzk0YjBiNDhiZTlkYzQ5NjY4NmYxMzgwNzciLCJwIjoiaiJ9

최상위 composable 네이밍 컨벤션에 맞지 않는 이름을 수정했습니다.

## 네이밍 컨벤션

Feature 모듈의 최상위 composable 네이밍 컨벤션을 다음과 같이 정했습니다.

1. 모듈 이름을 camel case로 적은 문자열 뒤에
2. `Screen`을 접미사로 붙입니다.

예를 들어, `:feature:edit_departments` 모듈의 최상위 composable은 `EditDepartmentsScreen`으로 명명되어야 합니다.

## 변경 사항

* 649f682caf4c22ae211a32e483035d794a7b9da9: `edit_subscription` 모듈의 최상위 composable인 `Subscriptions`의 이름을  `EditSubscriptionScreen`으로 수정했습니다. 

나머지 모듈은 이미 컨벤션을 잘 지키고 있어 수정하지 않았습니다.