### PR TITLE
kuring-136 바뀐 학과별 공지 날짜 포맷 대응

### DIFF
--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToEntity.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToEntity.kt
@@ -2,8 +2,6 @@ package com.ku_stacks.ku_ring.notice.mapper
 
 import com.ku_stacks.ku_ring.local.entity.NoticeEntity
 import com.ku_stacks.ku_ring.remote.notice.response.DepartmentNoticeResponse
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 
 fun List<DepartmentNoticeResponse>.toEntityList(shortName: String, startDate: String) =
@@ -14,24 +12,16 @@ fun List<DepartmentNoticeResponse>.toEntityList(shortName: String, startDate: St
  * TODO: NPE 대신 빈 문자열을 넣도록 수정
  */
 fun DepartmentNoticeResponse.toNoticeEntity(shortName: String, startDate: String): NoticeEntity {
-    val dashRemovedPostedDate = removeDashFromDate(postedDate!!)
     return NoticeEntity(
         articleId = articleId!!,
         category = category!!,
         department = shortName,
         subject = subject!!,
-        postedDate = dashRemovedPostedDate,
+        postedDate = postedDate!!,
         url = url!!,
-        isNew = (dashRemovedPostedDate >= startDate),
+        isNew = (postedDate!! >= startDate),
         isRead = false,
         isSaved = false,
         isReadOnStorage = false,
     )
-}
-
-private fun removeDashFromDate(dashSeparatedDate: String): String {
-    val inputFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-    val outputFormatter = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
-    val date = inputFormatter.parse(dashSeparatedDate)
-    return outputFormatter.format(date)
 }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-136?atlOrigin=eyJpIjoiNWRiZGZmYTRjZmRiNGQyY2FkNDQyN2NiNDAyOGZiNjEiLCJwIjoiaiJ9

## 문제 상황

학교 홈페이지가 업데이트되면서, 서버에서 내려주는 학과별 공지의 날짜 포맷이 바뀌었습니다.

* 기존: `yyyy-MM-dd`
* 현재: `yyyy.MM.dd`

## 해결 방법

현재 학사 공지에서는 `yyyy.MM.dd` 포맷으로 보여주고 있으므로, 학과별 공지에서도 서버에서 내려주는 형식 그대로 보여주면 됩니다.

추후 형식이 바뀌면 다시 수정할 예정입니다.

## 출시 관련

이 PR은 즉시 출시해야 할 것 같습니다. 만약 현재 `develop`을 출시한다면, 이 PR 외에 함께 출시되는 PR은 다음과 같습니다.

* v2 `:common:designsystem` 리소스
* 앱 모듈화 (일부)

2.0 UI가 함께 출시되지는 않으므로, develop 브랜치를 즉시 출시해도 문제가 없다고 판단했습니다. PR 확인하시는 대로 즉시 출시할게요.