### PR TITLE
kuring-139 [수정] 난독화 보호 경로 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.21" />
+    <option name="version" value="1.8.22" />
   </component>
 </project>

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,12 +19,32 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keep class com.ku_stacks.ku_ring.data.api.request.** { *; }
--keep class com.ku_stacks.ku_ring.data.api.response.** { *; }
--keep class com.ku_stacks.ku_ring.data.db.** { *; }
--keep class com.ku_stacks.ku_ring.data.model.** { *; }
--keep class com.ku_stacks.ku_ring.data.websocket.response.** { *; }
--keep class com.ku_stacks.ku_ring.data.websocket.request.** { *; }
+# request, reponse data class which are used with Retrofit
+-keep class com.ku_stacks.ku_ring.remote.department.request.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.department.response.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.notice.request.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.notice.response.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.notice.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.staff.response.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.user.request.** { *; }
+-keep class com.ku_stacks.ku_ring.remote.util.** { *; }
+# Room DAO, entity
+-keep class com.ku_stacks.ku_ring.local.entity.** { *; }
+-keep class com.ku_stacks.ku_ring.local.room.** { *; }
+# domain classes
+-keep class com.ku_stacks.ku_ring.domain.** { *; }
+# rxjava classes
+-keep class io.reactivex.rxjava3.core.Flowable
+-keep class io.reactivex.rxjava3.core.Maybe
+-keep class io.reactivex.rxjava3.core.Observable
+-keep class io.reactivex.rxjava3.core.Single
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+-keep interface retrofit2.Call
+-keep class retrofit2.Response
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep class kotlin.coroutines.Continuation
 -dontwarn com.sendbird.android.shadow.**
 -dontwarn com.google.firebase.messaging.TopicOperation$TopicOperations
 -dontwarn org.bouncycastle.jsse.BCSSLParameters


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-139?atlOrigin=eyJpIjoiMzBjMzViM2JjYmE1NGU0ZmE2MjE4YWY5NWI2ZWRkY2EiLCJwIjoiaiJ9

## 문제 상황

1.3.6 버전에서, 온보딩 화면에서 `공지 알림 설정하기` 화면을 누르면 앱이 강제 종료되는 문제가 있습니다.

```
Unable to create call adapter for class kc.o
```

난독화 해제하고 확인해 보니, RxJava에서 발생하는 문제였습니다.

```
java.lang.IllegalArgumentException: Unable to create call adapter for class io.reactivex.rxjava3.core.Single
```

## 원인

Retrofit에서 사용하는 request, response 클래스는 난독화로부터 보호되어야 합니다. 따라서 지금까지는 다음과 같이 `proguard-rules.pro` 파일에 보호 규칙을 작성하고 있었습니다.

```
-keep class com.ku_stacks.ku_ring.data.api.request.** { *; }
-keep class com.ku_stacks.ku_ring.data.api.response.** { *; }
-keep class com.ku_stacks.ku_ring.data.db.** { *; }
-keep class com.ku_stacks.ku_ring.data.model.** { *; }
-keep class com.ku_stacks.ku_ring.data.websocket.response.** { *; }
-keep class com.ku_stacks.ku_ring.data.websocket.request.** { *; }
```

그런데 모듈화로 인해 request와 response 클래스의 경로가 바뀌었습니다. 따라서 바뀐 경로를 작성해야 합니다.

## 해결 방법

1. Requset, response 파일의 바뀐 경로를 작성했습니다.
2. 일부 RxJava 및 Retrofit, Coroutines 클래스도 같은 문제가 있어서 규칙을 추가했습니다.


## 참고한 자료

https://github.com/square/retrofit/issues/3774#issuecomment-1525677491

https://stackoverflow.com/questions/76532972/java-lang-classcastexception-java-lang-class-cannot-be-cast-to-java-lang-reflec