### PR TITLE
kuring-102 공지 보관함 UI 구현 (1)

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/CenterTitleTopBar.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/CenterTitleTopBar.kt
@@ -48,7 +48,7 @@ import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
 fun CenterTitleTopBar(
     title: String,
     modifier: Modifier = Modifier,
-    navigation: @Composable () -> Unit = {},
+    navigation: @Composable (() -> Unit)? = null,
     onNavigationClick: (() -> Unit)? = null,
     navigationClickLabel: String? = null,
     // 현재 디자인된 Gray600 색깔은 다크 모드에서 거의 보이지 않음
@@ -100,7 +100,7 @@ fun CenterTitleTopBar(
 fun CenterTitleTopBar(
     title: String,
     modifier: Modifier = Modifier,
-    navigation: @Composable () -> Unit = {},
+    navigation: @Composable (() -> Unit)? = null,
     onNavigationClick: (() -> Unit)? = null,
     navigationClickLabel: String? = null,
     // 현재 디자인된 Gray600 색깔은 다크 모드에서 거의 보이지 않음
@@ -188,24 +188,26 @@ private fun TopBarTitle(
 
 @Composable
 private fun Navigation(
-    navigationIcon: @Composable () -> Unit,
+    navigationIcon: @Composable (() -> Unit)?,
     navigationContentColor: Color,
     modifier: Modifier = Modifier,
     onNavigationClick: (() -> Unit)? = null,
     navigationClickLabel: String? = null,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
-    CompositionLocalProvider(LocalContentColor provides navigationContentColor) {
-        LazyColumn(
-            modifier = modifier.clickable(
-                onClick = { onNavigationClick?.invoke() },
-                onClickLabel = navigationClickLabel,
-                enabled = onNavigationClick != null,
-            ),
-            contentPadding = contentPadding,
-        ) {
-            item {
-                navigationIcon()
+    if (navigationIcon != null) {
+        CompositionLocalProvider(LocalContentColor provides navigationContentColor) {
+            LazyColumn(
+                modifier = modifier.clickable(
+                    onClick = { onNavigationClick?.invoke() },
+                    onClickLabel = navigationClickLabel,
+                    enabled = onNavigationClick != null,
+                ),
+                contentPadding = contentPadding,
+            ) {
+                item {
+                    navigationIcon()
+                }
             }
         }
     }

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
@@ -38,6 +38,7 @@ import com.ku_stacks.ku_ring.domain.Notice
  * @param notice 보여줄 공지 객체
  * @param modifier 적용할 [Modifier]
  * @param onClick 공지를 클릭했을 때의 콜백
+ * @param contentVerticalAlignment [content]의 수직 정렬 위치이다. 북마크 아이콘은 이 값과 상관없이 항상 [Alignment.Top]으로 정렬된다.
  * @param content 컴포넌트 오른쪽에 보여줄 slot이다. [content]가 주어지면 북마크 아이콘이 보이지 않는다.
  */
 @Composable
@@ -45,6 +46,7 @@ fun NoticeItem(
     notice: Notice,
     modifier: Modifier = Modifier,
     onClick: (Notice) -> Unit = {},
+    contentVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     content: @Composable (() -> Unit)? = null,
 ) {
     // TODO: 중요 공지일 경우 배경색을 초록색으로 바꾸고, [중요] 태그 보여주기
@@ -54,6 +56,7 @@ fun NoticeItem(
             .fillMaxWidth()
             .background(MaterialTheme.colors.surface)
             .padding(horizontal = 20.dp),
+        verticalAlignment = contentVerticalAlignment,
     ) {
         NoticeItemContent(
             notice = notice,

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
@@ -18,6 +18,8 @@ val MainPrimarySelected: Color
     @Composable get() = Color(0xFFE2F5EC)
 val KuringSub: Color
     @Composable get() = Color(0xFFECF9F3)
+val TextBody: Color
+    @Composable get() = Color(0xFF353C49)
 val TextCaption1: Color
     @Composable get() = Color(0xFF868A92)
 val CaptionGray2: Color

--- a/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/preview_data/Notice.kt
+++ b/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/preview_data/Notice.kt
@@ -1,0 +1,19 @@
+package com.ku_stacks.ku_ring.ui_util.preview_data
+
+import com.ku_stacks.ku_ring.domain.Notice
+
+val previewNotices = (1..10).map {
+    Notice(
+        articleId = "5b4a11b$it",
+        category = "bachelor",
+        subject = "2023학년도 전과 선발자 안내",
+        postedDate = "2023.02.08",
+        url = "http://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?forum=notice&sort=6&id=5b4f972&cat=0000300001",
+        isNew = false,
+        isRead = false,
+        isSubscribing = false,
+        isSaved = false,
+        isReadOnStorage = false,
+        tag = listOf("장학", "취창업"),
+    )
+}

--- a/feature/notice_storage/build.gradle
+++ b/feature/notice_storage/build.gradle
@@ -35,9 +35,16 @@ android {
     dataBinding {
         enabled = true
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
+    }
 }
 
 dependencies {
+    implementation project(":common:designsystem")
     implementation project(":common:ui_util")
     implementation project(":data:domain")
     implementation project(":data:notice")
@@ -46,6 +53,11 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.android.material
     implementation libs.androidx.constraintlayout
+
+    // Compose
+    implementation platform(libs.compose.bom)
+    implementation libs.bundles.compose
+    implementation libs.bundles.compose.interop
 
     // dagger hilt
     kapt libs.androidx.hilt.compiler

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageAdapter.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageAdapter.kt
@@ -8,6 +8,7 @@ import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.notice_storage.databinding.ItemSavedNoticeBinding
 import com.ku_stacks.ku_ring.ui_util.adapter.NoticeDiffCallback
 
+@Deprecated("Compose migration 이후 삭제할 예정")
 class NoticeStorageAdapter(
     private val onItemClick: (Notice) -> Unit
 ) : ListAdapter<Notice, ViewHolder>(NoticeDiffCallback) {

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/SavedNoticeViewHolder.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/SavedNoticeViewHolder.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.notice_storage.databinding.ItemSavedNoticeBinding
 
+@Deprecated("Compose migration 이후 삭제할 예정")
 class SavedNoticeViewHolder(
     private val binding: ItemSavedNoticeBinding,
     private val onClick: (Notice) -> Unit

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -95,9 +95,7 @@ private fun NoticeStorageTopBar(
     CenterTitleTopBar(
         title = "",
         navigation = if (isSelectModeEnabled) {
-            {
-                TopBarNavigation()
-            }
+            { TopBarNavigation() }
         } else {
             null
         },

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -1,0 +1,110 @@
+package com.ku_stacks.ku_ring.notice_storage.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
+import com.ku_stacks.ku_ring.designsystem.theme.TextBody
+import com.ku_stacks.ku_ring.notice_storage.R
+
+@Composable
+private fun NoticeStorageScreen(
+    isSelectModeEnabled: Boolean,
+    onSelectModeEnabled: () -> Unit,
+    onSelectModeDisabled: () -> Unit,
+    onSelectAllNotices: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(MaterialTheme.colors.surface)
+            .fillMaxSize(),
+    ) {
+        NoticeStorageTopBar(
+            isSelectModeEnabled = isSelectModeEnabled,
+            onSelectModeEnabled = onSelectModeEnabled,
+            onSelectModeDisabled = onSelectModeDisabled,
+            onSelectAllNotices = onSelectAllNotices,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun NoticeStorageTopBar(
+    isSelectModeEnabled: Boolean,
+    onSelectModeEnabled: () -> Unit,
+    onSelectModeDisabled: () -> Unit,
+    onSelectAllNotices: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val actionId =
+        if (isSelectModeEnabled) R.string.top_app_bar_action_select_all else R.string.top_app_bar_action_edit
+    val onActionClick = if (isSelectModeEnabled) onSelectAllNotices else onSelectModeEnabled
+
+    CenterTitleTopBar(
+        title = "",
+        navigation = if (isSelectModeEnabled) {
+            {
+                TopBarNavigation()
+            }
+        } else {
+            null
+        },
+        onNavigationClick = onSelectModeDisabled,
+        action = stringResource(id = actionId),
+        onActionClick = onActionClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun TopBarNavigation(
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = stringResource(id = R.string.top_app_bar_navigation),
+        style = TextStyle(
+            fontSize = 18.sp,
+            lineHeight = 27.sp,
+            fontFamily = Pretendard,
+            fontWeight = FontWeight(500),
+            color = TextBody,
+        ),
+        modifier = modifier,
+    )
+}
+
+
+@LightAndDarkPreview
+@Composable
+private fun NoticeStorageScreenPreview() {
+    var isSelectModeEnabled by remember { mutableStateOf(false) }
+    KuringTheme {
+        NoticeStorageScreen(
+            isSelectModeEnabled = isSelectModeEnabled,
+            onSelectModeEnabled = {
+                isSelectModeEnabled = true
+            },
+            onSelectModeDisabled = {
+                isSelectModeEnabled = false
+            },
+            onSelectAllNotices = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -1,8 +1,15 @@
 package com.ku_stacks.ku_ring.notice_storage.compose
 
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -10,16 +17,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.components.NoticeItem
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
 import com.ku_stacks.ku_ring.designsystem.theme.TextBody
+import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.notice_storage.R
+import com.ku_stacks.ku_ring.ui_util.preview_data.previewNotices
 
 @Composable
 private fun NoticeStorageScreen(
@@ -27,6 +38,10 @@ private fun NoticeStorageScreen(
     onSelectModeEnabled: () -> Unit,
     onSelectModeDisabled: () -> Unit,
     onSelectAllNotices: () -> Unit,
+    notices: List<Notice>,
+    onNoticeClick: (Notice) -> Unit,
+    selectedNoticeIds: Set<String>,
+    toggleNoticeSelection: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -39,6 +54,14 @@ private fun NoticeStorageScreen(
             onSelectModeEnabled = onSelectModeEnabled,
             onSelectModeDisabled = onSelectModeDisabled,
             onSelectAllNotices = onSelectAllNotices,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        StoredNotices(
+            notices = notices,
+            onNoticeClick = onNoticeClick,
+            isSelectModeEnabled = isSelectModeEnabled,
+            selectedNoticeIds = selectedNoticeIds,
+            toggleNoticeSelection = toggleNoticeSelection,
             modifier = Modifier.fillMaxWidth(),
         )
     }
@@ -89,11 +112,83 @@ private fun TopBarNavigation(
     )
 }
 
+@Composable
+private fun StoredNotices(
+    notices: List<Notice>,
+    onNoticeClick: (Notice) -> Unit,
+    selectedNoticeIds: Set<String>,
+    isSelectModeEnabled: Boolean,
+    toggleNoticeSelection: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        items(
+            items = notices,
+            key = { it.articleId },
+        ) { notice ->
+            SelectedNotice(
+                notice = notice,
+                isSelectModeEnabled = isSelectModeEnabled,
+                toggleNoticeSelection = toggleNoticeSelection,
+                onNoticeClick = onNoticeClick,
+                selectedNoticeIds = selectedNoticeIds,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectedNotice(
+    notice: Notice,
+    isSelectModeEnabled: Boolean,
+    toggleNoticeSelection: (String) -> Unit,
+    onNoticeClick: (Notice) -> Unit,
+    selectedNoticeIds: Set<String>,
+    modifier: Modifier = Modifier,
+) {
+    NoticeItem(
+        notice = notice,
+        onClick = {
+            if (isSelectModeEnabled) {
+                toggleNoticeSelection(notice.articleId)
+            } else {
+                onNoticeClick(notice)
+            }
+        },
+        modifier = modifier,
+    ) {
+        if (isSelectModeEnabled) {
+            NoticeSelectionStateImage(
+                isSelected = notice.articleId in selectedNoticeIds,
+                modifier = Modifier.fillMaxHeight(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NoticeSelectionStateImage(
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Crossfade(
+        targetState = isSelected,
+        label = "notice selection icon",
+    ) {
+        val imageId = if (it) R.drawable.ic_check_checked else R.drawable.ic_check_unchecked
+        Image(
+            painter = painterResource(id = imageId),
+            contentDescription = null,
+            modifier = modifier,
+        )
+    }
+}
 
 @LightAndDarkPreview
 @Composable
 private fun NoticeStorageScreenPreview() {
     var isSelectModeEnabled by remember { mutableStateOf(false) }
+    var selectedNoticeIds by remember { mutableStateOf(emptySet<String>()) }
     KuringTheme {
         NoticeStorageScreen(
             isSelectModeEnabled = isSelectModeEnabled,
@@ -102,8 +197,19 @@ private fun NoticeStorageScreenPreview() {
             },
             onSelectModeDisabled = {
                 isSelectModeEnabled = false
+                selectedNoticeIds = emptySet()
             },
             onSelectAllNotices = {},
+            notices = previewNotices,
+            onNoticeClick = {},
+            selectedNoticeIds = selectedNoticeIds,
+            toggleNoticeSelection = { noticeId ->
+                selectedNoticeIds = if (noticeId in selectedNoticeIds) {
+                    selectedNoticeIds.minus(noticeId)
+                } else {
+                    selectedNoticeIds.plus(noticeId)
+                }
+            },
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
+import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.NoticeItem
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
@@ -42,6 +43,7 @@ private fun NoticeStorageScreen(
     onNoticeClick: (Notice) -> Unit,
     selectedNoticeIds: Set<String>,
     toggleNoticeSelection: (String) -> Unit,
+    onDeleteNotices: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -62,8 +64,19 @@ private fun NoticeStorageScreen(
             isSelectModeEnabled = isSelectModeEnabled,
             selectedNoticeIds = selectedNoticeIds,
             toggleNoticeSelection = toggleNoticeSelection,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
         )
+        if (isSelectModeEnabled) {
+            KuringCallToAction(
+                text = stringResource(id = R.string.cta_text),
+                onClick = onDeleteNotices,
+                enabled = selectedNoticeIds.isNotEmpty(),
+                blur = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 
@@ -210,6 +223,7 @@ private fun NoticeStorageScreenPreview() {
                     selectedNoticeIds.plus(noticeId)
                 }
             },
+            onDeleteNotices = {},
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/feature/notice_storage/src/main/res/values/string.xml
+++ b/feature/notice_storage/src/main/res/values/string.xml
@@ -3,4 +3,5 @@
     <string name="top_app_bar_navigation">취소</string>
     <string name="top_app_bar_action_edit">편집</string>
     <string name="top_app_bar_action_select_all">전체 선택</string>
+    <string name="cta_text">삭제하기</string>
 </resources>

--- a/feature/notice_storage/src/main/res/values/string.xml
+++ b/feature/notice_storage/src/main/res/values/string.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="top_app_bar_navigation">취소</string>
+    <string name="top_app_bar_action_edit">편집</string>
+    <string name="top_app_bar_action_select_all">전체 선택</string>
+</resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-102?atlOrigin=eyJpIjoiNjg2ODUyMGFkOWNiNDMyMjhmY2QyYjQyY2NhZGRjODIiLCJwIjoiaiJ9

## 요약

공지 보관함 화면의 메인 UI를 구현하였습니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/7fbfc20c-71ba-498a-b617-fc4290abce77)

## 이후 작업

* 삭제 alert 구현
* ViewModel 로직 구현
* Activity와 연결

## Bottom Navigation?

현재 `화면 삭제` 버튼이 보일 때 bottom navigation이 보이지 않도록 디자인되어 있습니다. 이건 나중에 bottom navigation을 compose로 구현할 때 작업할 예정입니다.