### PR TITLE
kuring-41 온보딩 composable 구조 완성

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
@@ -30,6 +30,8 @@ val Gray300: Color
     @Composable get() = Color(0xFF999999)
 val Gray600: Color
     @Composable get() = Color(0xFF262626)
+val Background: Color
+    get() = Color(0xFFFFFFFF)
 val BoxBackgroundColor2: Color
     @Composable get() = Color(0xFFF2F3F5)
 

--- a/feature/onboarding/build.gradle
+++ b/feature/onboarding/build.gradle
@@ -29,17 +29,29 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
+    }
 }
 
 dependencies {
     implementation project(":common:ui_util")
     implementation project(":common:thirdparty")
     implementation project(":common:preferences")
+    implementation project(":common:designsystem")
 
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
     implementation libs.android.material
     implementation libs.androidx.constraintlayout
+
+    // Compose
+    implementation platform(libs.compose.bom)
+    implementation libs.bundles.compose
+    implementation libs.bundles.compose.interop
 
     // dagger hilt
     kapt libs.androidx.hilt.compiler

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/OnboardingActivity.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/OnboardingActivity.kt
@@ -3,9 +3,10 @@ package com.ku_stacks.ku_ring.onboarding
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Button
-import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.onboarding.compose.OnboardingScreen
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.thirdparty.firebase.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
@@ -23,28 +24,24 @@ class OnboardingActivity : AppCompatActivity() {
     @Inject
     lateinit var navigator: KuringNavigator
 
-    private val getOnboardingFinishResult = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == RESULT_OK) {
-            navigator.navigateToMain(this)
-            overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            KuringTheme {
+                OnboardingScreen(onNavigateToMain = ::onNavigateToMain)
+            }
         }
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_on_boarding)
-
-        val subscribeNoticeButton = findViewById<Button>(R.id.on_boarding_subscribe_noti_btn)
-
-        subscribeNoticeButton.setOnClickListener {
-            val intent = navigator.createEditSubscriptionIntent(this, isFirstRun = true)
-            getOnboardingFinishResult.launch(intent)
-
-            overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
-            analytics.click("start first Subscription Notification", "OnboardingActivity")
-        }
+    private fun onNavigateToMain() {
+        navigator.navigateToMain(this)
+        analytics.click(
+            screenName = "start first Subscription Notification",
+            screenClass = "OnboardingActivity",
+        )
+        pref.firstRunFlag = false
+        finish()
     }
 
     companion object {

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
@@ -22,7 +22,7 @@ import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.OnboardingComplete
 import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.SetDepartment
 
 @Composable
-private fun OnboardingScreen(
+internal fun OnboardingScreen(
     onNavigateToMain: () -> Unit,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
@@ -1,0 +1,133 @@
+package com.ku_stacks.ku_ring.onboarding.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.Background
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.ConfirmDepartment
+import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.FeatureTabs
+import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.OnboardingComplete
+import com.ku_stacks.ku_ring.onboarding.compose.inner_screen.SetDepartment
+
+@Composable
+private fun OnboardingScreen(
+    onNavigateToMain: () -> Unit,
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController(),
+) {
+    val navigationSpec = tween<IntOffset>(
+        durationMillis = 200,
+    )
+
+    NavHost(
+        navController = navController,
+        startDestination = featureTabs,
+        modifier = modifier,
+        enterTransition = {
+            slideIntoContainer(
+                towards = animationDirection(initialState, targetState),
+                animationSpec = navigationSpec,
+            )
+        },
+        exitTransition = {
+            slideOutOfContainer(
+                towards = animationDirection(initialState, targetState),
+                animationSpec = navigationSpec,
+            )
+        }
+    ) {
+        onboardingNavGraph(
+            navHostController = navController,
+            onNavigateToMain = onNavigateToMain,
+        )
+    }
+}
+
+private fun NavGraphBuilder.onboardingNavGraph(
+    navHostController: NavHostController,
+    onNavigateToMain: () -> Unit,
+) {
+    val modifier = Modifier
+        .background(Background)
+        .fillMaxSize()
+    composable(featureTabs) {
+        FeatureTabs(
+            onNavigateToSetDepartment = {
+                navHostController.navigate(setDepartment)
+            },
+            modifier = modifier,
+        )
+    }
+    composable(setDepartment) {
+        SetDepartment(
+            onSetDepartmentComplete = {
+                // TODO: 학과 이름 넘겨주기 (viewModel을 navHost에 선언?)
+                navHostController.navigate(confirmDepartment)
+            },
+            modifier = modifier,
+        )
+    }
+    composable(confirmDepartment) {
+        ConfirmDepartment(
+            onConfirm = {
+                navHostController.navigate(onboardingComplete)
+            },
+            onCancel = {
+                navHostController.navigate(setDepartment)
+            },
+            modifier = modifier,
+        )
+    }
+    composable(onboardingComplete) {
+        OnboardingComplete(
+            onStartKuring = onNavigateToMain,
+            modifier = modifier,
+        )
+    }
+}
+
+private const val featureTabs = "feature_tabs"
+private const val setDepartment = "set_department"
+private const val confirmDepartment = "confirm_department"
+private const val onboardingComplete = "onboarding_complete"
+
+private val NavBackStackEntry.route: String?
+    get() = destination.route
+
+private fun screenOrder(state: NavBackStackEntry) = when (state.route) {
+    featureTabs -> 0
+    setDepartment -> 1
+    confirmDepartment -> 2
+    onboardingComplete -> 3
+    else -> 4
+}
+
+private fun animationDirection(initialState: NavBackStackEntry, targetState: NavBackStackEntry) =
+    if (screenOrder(initialState) < screenOrder(targetState)) {
+        AnimatedContentTransitionScope.SlideDirection.Left
+    } else {
+        AnimatedContentTransitionScope.SlideDirection.Right
+    }
+
+@LightAndDarkPreview
+@Composable
+private fun OnboardingScreenPreview() {
+    KuringTheme {
+        OnboardingScreen(
+            onNavigateToMain = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
@@ -98,18 +98,15 @@ private fun NavGraphBuilder.onboardingNavGraph(
     }
 }
 
-private val NavBackStackEntry.route: String?
-    get() = destination.route
-
-private fun screenOrder(state: NavBackStackEntry) =
-    OnboardingScreenDestinations.getOrder(state.route)
-
 private fun animationDirection(initialState: NavBackStackEntry, targetState: NavBackStackEntry) =
-    if (screenOrder(initialState) < screenOrder(targetState)) {
+    if (initialState.screenOrder < targetState.screenOrder) {
         AnimatedContentTransitionScope.SlideDirection.Left
     } else {
         AnimatedContentTransitionScope.SlideDirection.Right
     }
+
+private val NavBackStackEntry.screenOrder: Int
+    get() = OnboardingScreenDestinations.getOrder(this.destination.route)
 
 @LightAndDarkPreview
 @Composable

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
@@ -33,7 +33,7 @@ internal fun OnboardingScreen(
 
     NavHost(
         navController = navController,
-        startDestination = featureTabs,
+        startDestination = OnboardingScreenDestinations.FEATURE_TABS,
         modifier = modifier,
         enterTransition = {
             slideIntoContainer(
@@ -62,35 +62,35 @@ private fun NavGraphBuilder.onboardingNavGraph(
     val modifier = Modifier
         .background(Background)
         .fillMaxSize()
-    composable(featureTabs) {
+    composable(OnboardingScreenDestinations.FEATURE_TABS) {
         FeatureTabs(
             onNavigateToSetDepartment = {
-                navHostController.navigate(setDepartment)
+                navHostController.navigate(OnboardingScreenDestinations.SET_DEPARTMENT)
             },
             modifier = modifier,
         )
     }
-    composable(setDepartment) {
+    composable(OnboardingScreenDestinations.SET_DEPARTMENT) {
         SetDepartment(
             onSetDepartmentComplete = {
                 // TODO: 학과 이름 넘겨주기 (viewModel을 navHost에 선언?)
-                navHostController.navigate(confirmDepartment)
+                navHostController.navigate(OnboardingScreenDestinations.CONFIRM_DEPARTMENT)
             },
             modifier = modifier,
         )
     }
-    composable(confirmDepartment) {
+    composable(OnboardingScreenDestinations.CONFIRM_DEPARTMENT) {
         ConfirmDepartment(
             onConfirm = {
-                navHostController.navigate(onboardingComplete)
+                navHostController.navigate(OnboardingScreenDestinations.ONBOARDING_COMPLETE)
             },
             onCancel = {
-                navHostController.navigate(setDepartment)
+                navHostController.navigate(OnboardingScreenDestinations.SET_DEPARTMENT)
             },
             modifier = modifier,
         )
     }
-    composable(onboardingComplete) {
+    composable(OnboardingScreenDestinations.ONBOARDING_COMPLETE) {
         OnboardingComplete(
             onStartKuring = onNavigateToMain,
             modifier = modifier,
@@ -98,21 +98,11 @@ private fun NavGraphBuilder.onboardingNavGraph(
     }
 }
 
-private const val featureTabs = "feature_tabs"
-private const val setDepartment = "set_department"
-private const val confirmDepartment = "confirm_department"
-private const val onboardingComplete = "onboarding_complete"
-
 private val NavBackStackEntry.route: String?
     get() = destination.route
 
-private fun screenOrder(state: NavBackStackEntry) = when (state.route) {
-    featureTabs -> 0
-    setDepartment -> 1
-    confirmDepartment -> 2
-    onboardingComplete -> 3
-    else -> 4
-}
+private fun screenOrder(state: NavBackStackEntry) =
+    OnboardingScreenDestinations.getOrder(state.route)
 
 private fun animationDirection(initialState: NavBackStackEntry, targetState: NavBackStackEntry) =
     if (screenOrder(initialState) < screenOrder(targetState)) {

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreenDestinations.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreenDestinations.kt
@@ -1,0 +1,16 @@
+package com.ku_stacks.ku_ring.onboarding.compose
+
+object OnboardingScreenDestinations {
+    const val FEATURE_TABS = "feature_tabs"
+    const val SET_DEPARTMENT = "set_department"
+    const val CONFIRM_DEPARTMENT = "confirm_department"
+    const val ONBOARDING_COMPLETE = "onboarding_complete"
+
+    fun getOrder(destination: String?) = when (destination) {
+        FEATURE_TABS -> 0
+        SET_DEPARTMENT -> 1
+        CONFIRM_DEPARTMENT -> 2
+        ONBOARDING_COMPLETE -> 3
+        else -> 4
+    }
+}

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/ConfirmDepartment.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/ConfirmDepartment.kt
@@ -1,0 +1,42 @@
+package com.ku_stacks.ku_ring.onboarding.compose.inner_screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+
+@Composable
+internal fun ConfirmDepartment(
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text("영상영화학과를 내 전공학과로 설정할까요?")
+        Row {
+            TextButton(onClick = onConfirm) {
+                Text("예")
+            }
+            TextButton(onClick = onCancel) {
+                Text("아니오")
+            }
+        }
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun ConfirmDepartmentPreview() {
+    KuringTheme {
+        ConfirmDepartment(
+            onConfirm = { },
+            onCancel = { },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/FeatureTabs.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/FeatureTabs.kt
@@ -1,0 +1,33 @@
+package com.ku_stacks.ku_ring.onboarding.compose.inner_screen
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+
+@Composable
+internal fun FeatureTabs(
+    onNavigateToSetDepartment: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onNavigateToSetDepartment,
+        modifier = modifier,
+    ) {
+        Text(text = "우리 대학 공지 쿠링이 알려줄게!")
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun FeatureTabsPreview() {
+    KuringTheme {
+        FeatureTabs(
+            onNavigateToSetDepartment = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/OnboardingComplete.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/OnboardingComplete.kt
@@ -1,0 +1,33 @@
+package com.ku_stacks.ku_ring.onboarding.compose.inner_screen
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+
+@Composable
+internal fun OnboardingComplete(
+    onStartKuring: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onStartKuring,
+        modifier = modifier,
+    ) {
+        Text(text = "학과 설정이 완료되었어요!")
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun OnboardingCompletePreview() {
+    KuringTheme {
+        OnboardingComplete(
+            onStartKuring = { },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/SetDepartment.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/inner_screen/SetDepartment.kt
@@ -1,0 +1,34 @@
+package com.ku_stacks.ku_ring.onboarding.compose.inner_screen
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+
+@Composable
+internal fun SetDepartment(
+    onSetDepartmentComplete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextButton(
+        onClick = onSetDepartmentComplete,
+        modifier = modifier,
+    ) {
+        Text(text = "전공학과를 설정해 주세요")
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SetDepartmentPreview() {
+    KuringTheme {
+        SetDepartment(
+            onSetDepartmentComplete = { },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ androidx-constraintlayout-compose = 'androidx.constraintlayout:constraintlayout-
 androidx-lifecycle-viewmodel-compose = 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
 androidx-paging-compose = 'androidx.paging:paging-compose:1.0.0-alpha19'
 hilt-navigation-compose = 'androidx.hilt:hilt-navigation-compose:1.0.0'
+androidx-navigation-compose = 'androidx.navigation:navigation-compose:2.7.7'
 
 # Kotlin Coroutines
 kotlinx-coroutines-android = { module = 'org.jetbrains.kotlinx:kotlinx-coroutines-android', version.ref = 'kotlinx-coroutines' }
@@ -168,6 +169,7 @@ compose = [
     'compose-ui-test-manifest',
     'compose-ui-tooling',
     'compose-ui-tooling-preview',
+    'androidx-navigation-compose',
 ]
 compose-interop = [
     'androidx-activity-compose',


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-41?atlOrigin=eyJpIjoiNzVmZjE3ZDM0YmNjNGY2ZGEyZGQ4M2U4NWNiMWFiYWEiLCJwIjoiaiJ9

## 요약

온보딩 화면의 composable 구조를 정의했습니다. 이번 PR은 이전과 다르게 구조를 먼저 만든 후, 개별 UI를 구현합니다.

`OnboardingScreen`에서 compose navigation을 사용했는데, 궁금하신 점이 있으면 코멘트로 남겨주세요.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/f93f14a9-cc52-4be6-97eb-d5a4fb7c71a7)

## 이후 작업

* 온보딩 UI 구현
* 온보딩 비즈니스 로직 구현 (`ViewModel` 등)
  * `ViewModel`은 아마 `OnboardingScreen` 전체를 대상으로 만들 것 같습니다. UI끼리 공유해야 할 데이터가 몇 개 있기도 하고(선택한 학과 등), 로직이 많지는 않아서 그냥 하나로 합칠까 생각하고 있어요
![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/9f987f43-3015-4054-8da3-505fd9c163ff)


