### PR TITLE
kuring-102 공지 보관함 로직 구현

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringAlertDialog.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringAlertDialog.kt
@@ -34,14 +34,64 @@ import com.ku_stacks.ku_ring.designsystem.theme.Gray2
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
 
+/**
+ * 사용자에게 특정 행동의 수행 여부를 물어보는 [Dialog]이다.
+ *
+ * 작업을 취소할 때와 팝업을 무시할 때의 행동이 **같을 때** 사용하는 오버로딩이다.
+ *
+ * @param text 사용자에게 보여줄 메인 테스트
+ * @param onConfirm 사용자가 작업을 수행하기로 결정했을 때 호출할 콜백
+ * @param onCancel 사용자가 작업을 취소하거나 팝업을 무시할 때 호출할 콜백
+ * @param modifier 적용할 [Modifier]
+ * @param confirmText 하단 오른쪽의 작업 수행 버튼에 보여줄 텍스트
+ * @param cancelText 하단 왼쪽의 작업 취소 버튼에 보여줄 텍스트
+ * @param confirmTextColor 작업 수행 버튼에 적용할 텍스트 색깔
+ */
 @Composable
 fun KuringAlertDialog(
     text: String,
     onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+    confirmText: String = stringResource(id = R.string.confirm),
+    cancelText: String = stringResource(id = R.string.cancel),
+    confirmTextColor: Color = MaterialTheme.colors.primary,
+) {
+    KuringAlertDialog(
+        text = text,
+        onConfirm = onConfirm,
+        onCancel = onCancel,
+        onDismiss = onCancel,
+        modifier = modifier,
+        confirmText = confirmText,
+        cancelText = cancelText,
+        confirmTextColor = confirmTextColor,
+    )
+}
+
+/**
+ * 사용자에게 특정 행동의 수행 여부를 물어보는 [Dialog]이다.
+ *
+ * 작업을 취소할 때와 팝업을 무시할 때의 행동이 **다를 때** 사용하는 오버로딩이다.
+ *
+ * @param text 사용자에게 보여줄 메인 테스트
+ * @param onConfirm 사용자가 작업을 수행하기로 결정했을 때 호출할 콜백
+ * @param onCancel 사용자가 작업을 취소할 때 호출할 콜백
+ * @param onDismiss 사용자가 팝업을 무시할 때 호출할 콜백
+ * @param modifier 적용할 [Modifier]
+ * @param confirmText 하단 오른쪽의 작업 수행 버튼에 보여줄 텍스트
+ * @param cancelText 하단 왼쪽의 작업 취소 버튼에 보여줄 텍스트
+ * @param confirmTextColor 작업 수행 버튼에 적용할 텍스트 색깔
+ */
+@Composable
+fun KuringAlertDialog(
+    text: String,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     confirmText: String = stringResource(id = R.string.confirm),
-    dismissText: String = stringResource(id = R.string.cancel),
+    cancelText: String = stringResource(id = R.string.cancel),
     confirmTextColor: Color = MaterialTheme.colors.primary,
 ) {
     Dialog(
@@ -52,8 +102,8 @@ fun KuringAlertDialog(
             text = text,
             confirmText = confirmText,
             onConfirm = onConfirm,
-            dismissText = dismissText,
-            onDismiss = onDismiss,
+            cancelText = cancelText,
+            onCancel = onCancel,
             modifier = modifier,
             confirmTextColor = confirmTextColor,
         )
@@ -65,8 +115,8 @@ private fun KuringAlertDialogContents(
     text: String,
     confirmText: String,
     onConfirm: () -> Unit,
-    dismissText: String,
-    onDismiss: () -> Unit,
+    cancelText: String,
+    onCancel: () -> Unit,
     modifier: Modifier = Modifier,
     confirmTextColor: Color = MaterialTheme.colors.primary,
 ) {
@@ -91,8 +141,8 @@ private fun KuringAlertDialogContents(
         KuringAlertDialogButtons(
             confirmText = confirmText,
             onConfirm = onConfirm,
-            dismissText = dismissText,
-            onDismiss = onDismiss,
+            cancelText = cancelText,
+            onCancel = onCancel,
             confirmTextColor = confirmTextColor,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -122,15 +172,15 @@ private fun KuringAlertDialogText(
 private fun KuringAlertDialogButtons(
     confirmText: String,
     onConfirm: () -> Unit,
-    dismissText: String,
-    onDismiss: () -> Unit,
+    cancelText: String,
+    onCancel: () -> Unit,
     modifier: Modifier = Modifier,
     confirmTextColor: Color = Gray2,
 ) {
     Row(modifier = modifier.height(IntrinsicSize.Min)) {
         KuringAlertDialogButton(
-            text = dismissText,
-            onClick = onDismiss,
+            text = cancelText,
+            onClick = onCancel,
             modifier = Modifier.weight(1f),
         )
         Divider(
@@ -181,7 +231,7 @@ private fun KuringAlertDialogPreview() {
         KuringAlertDialog(
             text = "스마트ICT융합공학과를\n내 학과 목록에 추가할까요?",
             onConfirm = {},
-            onDismiss = {},
+            onCancel = {},
             modifier = Modifier.padding(16.dp),
         )
     }

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
@@ -34,6 +34,8 @@ val Gray600: Color
     @Composable get() = Color(0xFF262626)
 val BoxBackgroundColor2: Color
     @Composable get() = Color(0xFFF2F3F5)
+val Warning: Color
+    @Composable get() = Color(0xFFFF4848)
 
 val lightColorPalette: Colors
     @Composable get() = lightColors(

--- a/feature/edit_departments/src/main/java/com/ku_stacks/ku_ring/edit_departments/compose/EditDepartmentsPopup.kt
+++ b/feature/edit_departments/src/main/java/com/ku_stacks/ku_ring/edit_departments/compose/EditDepartmentsPopup.kt
@@ -30,10 +30,10 @@ internal fun DepartmentPopup(
     KuringAlertDialog(
         text = stringResource(id = popupUiModel.stringResId, popupUiModel.departmentKoreanName),
         onConfirm = { onConfirm(popupUiModel) },
-        onDismiss = onDismiss,
+        onCancel = onDismiss,
         modifier = modifier,
         confirmTextColor = confirmTextColor,
-        dismissText = stringResource(id = R.string.department_popup_dismiss),
+        cancelText = stringResource(id = R.string.department_popup_dismiss),
         confirmText = stringResource(id = popupUiModel.confirmStringRes),
     )
 }

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageActivity.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageActivity.kt
@@ -3,20 +3,15 @@ package com.ku_stacks.ku_ring.notice_storage
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.viewModels
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.content.res.AppCompatResources
-import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.domain.Notice
-import com.ku_stacks.ku_ring.notice_storage.databinding.ActivityNoticeStorageBinding
+import com.ku_stacks.ku_ring.notice_storage.compose.NoticeStorageScreen
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
-import com.ku_stacks.ku_ring.ui_util.makeDialog
-import com.yeonkyu.HoldableSwipeHelper.HoldableSwipeHandler
-import com.yeonkyu.HoldableSwipeHelper.SwipeButtonAction
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,65 +20,14 @@ class NoticeStorageActivity : AppCompatActivity() {
     @Inject
     lateinit var navigator: KuringNavigator
 
-    private lateinit var binding: ActivityNoticeStorageBinding
-    private val viewModel by viewModels<NoticeStorageViewModel>()
-    private lateinit var storageAdapter: NoticeStorageAdapter
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        setBinding()
-        setView()
-        setListAdapter()
-        collectData()
-    }
-
-    private fun setBinding() {
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_notice_storage)
-        binding.lifecycleOwner = this
-        binding.viewModel = viewModel
-    }
-
-    private fun setView() {
-        binding.backImage.setOnClickListener {
-            finish()
-        }
-        binding.clearNoticesImage.setOnClickListener {
-            makeDialog(title = "모두 삭제할까요?").setOnConfirmClickListener { viewModel.clearNotices() }
-        }
-    }
-
-    private fun setListAdapter() {
-        storageAdapter = NoticeStorageAdapter {
-            startNoticeActivity(it)
-            viewModel.updateNoticeAsReadOnStorage(it.articleId, it.category)
-        }
-        binding.notificationStorageRecyclerview.apply {
-            layoutManager = LinearLayoutManager(this@NoticeStorageActivity)
-            adapter = storageAdapter
-        }
-
-        val removeDrawable =
-            AppCompatResources.getDrawable(this, R.drawable.ic_bookmark_remove)!!
-        HoldableSwipeHandler.Builder(this)
-            .setSwipeButtonAction(object : SwipeButtonAction {
-                override fun onClickFirstButton(absoluteAdapterPosition: Int) {
-                    val notice = storageAdapter.currentList[absoluteAdapterPosition]
-                    viewModel.deleteNotice(notice.articleId, notice.category)
-                }
-            })
-            .setDirectionAsRightToLeft(false)
-            .setBackgroundColor(getColor(R.color.kus_green))
-            .setFirstItemDrawable(removeDrawable)
-            .setDismissOnClickFirstItem(true)
-            .setOnRecyclerView(binding.notificationStorageRecyclerview)
-            .build()
-    }
-
-    private fun collectData() {
-        lifecycleScope.launchWhenResumed {
-            viewModel.savedNotices.collectLatest {
-                storageAdapter.submitList(it)
+        setContent {
+            KuringTheme {
+                NoticeStorageScreen(
+                    onNoticeClick = ::startNoticeActivity,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
         }
     }

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageViewModel.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageViewModel.kt
@@ -36,6 +36,10 @@ class NoticeStorageViewModel @Inject constructor(
         selectedNotices.keys
     }
 
+    val isAllNoticesSelected by derivedStateOf {
+        selectedNotices.size == savedNotices.value.size
+    }
+
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageViewModel.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/NoticeStorageViewModel.kt
@@ -1,5 +1,9 @@
 package com.ku_stacks.ku_ring.notice_storage
 
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.domain.Notice
@@ -20,6 +24,18 @@ class NoticeStorageViewModel @Inject constructor(
     val savedNotices: StateFlow<List<Notice>>
         get() = _savedNotices
 
+    var isSelectedModeEnabled by mutableStateOf(false)
+        private set
+
+    /**
+     * key: [Notice.articleId], value: [Notice.category]
+     */
+    private var selectedNotices by mutableStateOf<Map<String, String>>(emptyMap())
+
+    val selectedNoticeIds by derivedStateOf {
+        selectedNotices.keys
+    }
+
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->
@@ -28,17 +44,58 @@ class NoticeStorageViewModel @Inject constructor(
         }
     }
 
-    fun updateNoticeAsReadOnStorage(articleId: String, category: String) {
-        viewModelScope.launch {
-            noticeRepository.updateNoticeToBeReadOnStorage(articleId, category)
+    fun setSelectedMode(value: Boolean) {
+        isSelectedModeEnabled = value
+        if (!value) {
+            updateSelectedNotices {
+                emptyMap()
+            }
         }
     }
 
-    fun deleteNotice(articleId: String, category: String) {
-        viewModelScope.launch {
-            noticeRepository.updateSavedStatus(articleId, category, false)
-            Timber.d("Notice $articleId deleted.")
+    fun selectAllNotices() {
+        val allNoticesPair = savedNotices.value.map { notice ->
+            Pair(notice.articleId, notice.category)
         }
+        updateSelectedNotices {
+            selectedNotices.plus(allNoticesPair)
+        }
+    }
+
+    fun updateNoticeAsReadOnStorage(notice: Notice) {
+        viewModelScope.launch {
+            noticeRepository.updateNoticeToBeReadOnStorage(notice.articleId, notice.category)
+        }
+    }
+
+    fun toggleNoticeSelection(notice: Notice) {
+        val articleId = notice.articleId
+        updateSelectedNotices {
+            if (articleId in selectedNotices) {
+                selectedNotices.minus(articleId)
+            } else {
+                selectedNotices.plus(articleId to notice.category)
+            }
+        }
+    }
+
+    fun deleteNotices() {
+        isSelectedModeEnabled = false
+        viewModelScope.launch {
+            var deletedNotices = 0
+            selectedNotices.forEach { (articleId, category) ->
+                noticeRepository.updateSavedStatus(articleId, category, false)
+                deletedNotices++
+            }
+            Timber.d("$deletedNotices notice(s) were deleted.")
+            updateSelectedNotices {
+                emptyMap()
+            }
+        }
+    }
+
+    private fun updateSelectedNotices(block: Map<String, String>.() -> Map<String, String>) {
+        selectedNotices = block(selectedNotices)
     }
 
     fun clearNotices() {

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -33,6 +33,8 @@ fun NoticeStorageScreen(
     viewModel: NoticeStorageViewModel = hiltViewModel(),
 ) {
     val notices by viewModel.savedNotices.collectAsState()
+    val selectedNoticeIds by viewModel.selectedNoticeIds.collectAsState()
+    val isAllNoticesSelected by viewModel.isAllNoticesSelected.collectAsState()
     var isDeleteDialogVisible by rememberSaveable { mutableStateOf(false) }
 
     NoticeStorageScreen(
@@ -49,15 +51,15 @@ fun NoticeStorageScreen(
             viewModel.updateNoticeAsReadOnStorage(notice)
             onNoticeClick(notice)
         },
-        selectedNoticeIds = viewModel.selectedNoticeIds,
+        selectedNoticeIds = selectedNoticeIds,
         toggleNoticeSelection = viewModel::toggleNoticeSelection,
         onShowDeleteAlertDialog = {
-            if (viewModel.selectedNoticeIds.isNotEmpty()) {
+            if (selectedNoticeIds.isNotEmpty()) {
                 isDeleteDialogVisible = true
             }
         },
         isDeletePopupVisible = isDeleteDialogVisible,
-        isDeleteAllNotices = viewModel.isAllNoticesSelected,
+        isDeleteAllNotices = isAllNoticesSelected,
         onDeleteNotices = {
             viewModel.deleteNotices()
             isDeleteDialogVisible = false

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
@@ -22,6 +23,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
@@ -203,7 +205,9 @@ private fun SelectedNotice(
         if (isSelectModeEnabled) {
             NoticeSelectionStateImage(
                 isSelected = notice.articleId in selectedNoticeIds,
-                modifier = Modifier.fillMaxHeight(),
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .padding(start = 8.dp),
             )
         }
     }

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -1,18 +1,10 @@
 package com.ku_stacks.ku_ring.notice_storage.compose
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.Crossfade
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -21,25 +13,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
-import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
-import com.ku_stacks.ku_ring.designsystem.components.NoticeItem
 import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
-import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
-import com.ku_stacks.ku_ring.designsystem.theme.TextBody
-import com.ku_stacks.ku_ring.designsystem.theme.Warning
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.notice_storage.NoticeStorageViewModel
 import com.ku_stacks.ku_ring.notice_storage.R
+import com.ku_stacks.ku_ring.notice_storage.compose.components.DeleteSelectedNoticesAlertDialog
+import com.ku_stacks.ku_ring.notice_storage.compose.components.NoticeStorageTopBar
+import com.ku_stacks.ku_ring.notice_storage.compose.components.StoredNotices
 import com.ku_stacks.ku_ring.ui_util.preview_data.previewNotices
 
 @Composable
@@ -141,148 +125,6 @@ private fun NoticeStorageScreen(
         onDelete = onDeleteNotices,
         onDismiss = onDismissDeleteAlertDialog,
     )
-}
-
-@Composable
-private fun NoticeStorageTopBar(
-    isSelectModeEnabled: Boolean,
-    onSelectModeEnabled: () -> Unit,
-    onSelectModeDisabled: () -> Unit,
-    onSelectAllNotices: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val actionId =
-        if (isSelectModeEnabled) R.string.top_app_bar_action_select_all else R.string.top_app_bar_action_edit
-    val onActionClick = if (isSelectModeEnabled) onSelectAllNotices else onSelectModeEnabled
-
-    CenterTitleTopBar(
-        title = "",
-        navigation = if (isSelectModeEnabled) {
-            { TopBarNavigation() }
-        } else {
-            null
-        },
-        onNavigationClick = onSelectModeDisabled,
-        action = stringResource(id = actionId),
-        onActionClick = onActionClick,
-        modifier = modifier,
-    )
-}
-
-@Composable
-private fun TopBarNavigation(
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = stringResource(id = R.string.top_app_bar_navigation),
-        style = TextStyle(
-            fontSize = 18.sp,
-            lineHeight = 27.sp,
-            fontFamily = Pretendard,
-            fontWeight = FontWeight(500),
-            color = TextBody,
-        ),
-        modifier = modifier,
-    )
-}
-
-@Composable
-private fun StoredNotices(
-    notices: List<Notice>,
-    onNoticeClick: (Notice) -> Unit,
-    selectedNoticeIds: Set<String>,
-    isSelectModeEnabled: Boolean,
-    toggleNoticeSelection: (Notice) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(modifier = modifier) {
-        items(
-            items = notices,
-            key = { it.articleId },
-        ) { notice ->
-            SelectedNotice(
-                notice = notice,
-                isSelectModeEnabled = isSelectModeEnabled,
-                toggleNoticeSelection = toggleNoticeSelection,
-                onNoticeClick = onNoticeClick,
-                selectedNoticeIds = selectedNoticeIds,
-            )
-        }
-    }
-}
-
-@Composable
-private fun SelectedNotice(
-    notice: Notice,
-    isSelectModeEnabled: Boolean,
-    toggleNoticeSelection: (Notice) -> Unit,
-    onNoticeClick: (Notice) -> Unit,
-    selectedNoticeIds: Set<String>,
-    modifier: Modifier = Modifier,
-) {
-    NoticeItem(
-        notice = notice,
-        onClick = {
-            if (isSelectModeEnabled) {
-                toggleNoticeSelection(notice)
-            } else {
-                onNoticeClick(notice)
-            }
-        },
-        modifier = modifier,
-    ) {
-        if (isSelectModeEnabled) {
-            NoticeSelectionStateImage(
-                isSelected = notice.articleId in selectedNoticeIds,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .padding(start = 8.dp),
-            )
-        }
-    }
-}
-
-@Composable
-private fun NoticeSelectionStateImage(
-    isSelected: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    Crossfade(
-        targetState = isSelected,
-        label = "notice selection icon",
-    ) {
-        val imageId = if (it) R.drawable.ic_check_checked else R.drawable.ic_check_unchecked
-        Image(
-            painter = painterResource(id = imageId),
-            contentDescription = null,
-            modifier = modifier,
-        )
-    }
-}
-
-@Composable
-private fun DeleteSelectedNoticesAlertDialog(
-    isDeletePopupVisible: Boolean,
-    isDeleteAllNotices: Boolean,
-    onDelete: () -> Unit,
-    onDismiss: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AnimatedVisibility(
-        visible = isDeletePopupVisible,
-        modifier = modifier,
-    ) {
-        val textId =
-            if (isDeleteAllNotices) R.string.alert_dialog_delete_all_notices else R.string.alert_dialog_delete_notices
-        KuringAlertDialog(
-            text = stringResource(id = textId),
-            onConfirm = onDelete,
-            confirmText = stringResource(id = R.string.alert_dialog_delete_text),
-            onCancel = onDismiss,
-            cancelText = stringResource(id = R.string.alert_dialog_cancel_text),
-            confirmTextColor = Warning,
-        )
-    }
 }
 
 @LightAndDarkPreview

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
@@ -30,8 +32,38 @@ import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
 import com.ku_stacks.ku_ring.designsystem.theme.TextBody
 import com.ku_stacks.ku_ring.domain.Notice
+import com.ku_stacks.ku_ring.notice_storage.NoticeStorageViewModel
 import com.ku_stacks.ku_ring.notice_storage.R
 import com.ku_stacks.ku_ring.ui_util.preview_data.previewNotices
+
+@Composable
+fun NoticeStorageScreen(
+    onNoticeClick: (Notice) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NoticeStorageViewModel = hiltViewModel(),
+) {
+    val notices by viewModel.savedNotices.collectAsState()
+
+    NoticeStorageScreen(
+        isSelectModeEnabled = viewModel.isSelectedModeEnabled,
+        onSelectModeEnabled = {
+            viewModel.setSelectedMode(true)
+        },
+        onSelectModeDisabled = {
+            viewModel.setSelectedMode(false)
+        },
+        onSelectAllNotices = viewModel::selectAllNotices,
+        notices = notices,
+        onNoticeClick = { notice ->
+            viewModel.updateNoticeAsReadOnStorage(notice)
+            onNoticeClick(notice)
+        },
+        selectedNoticeIds = viewModel.selectedNoticeIds,
+        toggleNoticeSelection = viewModel::toggleNoticeSelection,
+        onDeleteNotices = viewModel::deleteNotices,
+        modifier = modifier,
+    )
+}
 
 @Composable
 private fun NoticeStorageScreen(

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -42,7 +42,7 @@ private fun NoticeStorageScreen(
     notices: List<Notice>,
     onNoticeClick: (Notice) -> Unit,
     selectedNoticeIds: Set<String>,
-    toggleNoticeSelection: (String) -> Unit,
+    toggleNoticeSelection: (Notice) -> Unit,
     onDeleteNotices: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -129,7 +129,7 @@ private fun StoredNotices(
     onNoticeClick: (Notice) -> Unit,
     selectedNoticeIds: Set<String>,
     isSelectModeEnabled: Boolean,
-    toggleNoticeSelection: (String) -> Unit,
+    toggleNoticeSelection: (Notice) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
@@ -152,7 +152,7 @@ private fun StoredNotices(
 private fun SelectedNotice(
     notice: Notice,
     isSelectModeEnabled: Boolean,
-    toggleNoticeSelection: (String) -> Unit,
+    toggleNoticeSelection: (Notice) -> Unit,
     onNoticeClick: (Notice) -> Unit,
     selectedNoticeIds: Set<String>,
     modifier: Modifier = Modifier,
@@ -161,7 +161,7 @@ private fun SelectedNotice(
         notice = notice,
         onClick = {
             if (isSelectModeEnabled) {
-                toggleNoticeSelection(notice.articleId)
+                toggleNoticeSelection(notice)
             } else {
                 onNoticeClick(notice)
             }
@@ -214,11 +214,12 @@ private fun NoticeStorageScreenPreview() {
             notices = previewNotices,
             onNoticeClick = {},
             selectedNoticeIds = selectedNoticeIds,
-            toggleNoticeSelection = { noticeId ->
-                selectedNoticeIds = if (noticeId in selectedNoticeIds) {
-                    selectedNoticeIds.minus(noticeId)
+            toggleNoticeSelection = { notice ->
+                val articleId = notice.articleId
+                selectedNoticeIds = if (articleId in selectedNoticeIds) {
+                    selectedNoticeIds.minus(articleId)
                 } else {
-                    selectedNoticeIds.plus(noticeId)
+                    selectedNoticeIds.plus(articleId)
                 }
             },
             onDeleteNotices = {},

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/NoticeStorageScreen.kt
@@ -68,7 +68,9 @@ fun NoticeStorageScreen(
         selectedNoticeIds = viewModel.selectedNoticeIds,
         toggleNoticeSelection = viewModel::toggleNoticeSelection,
         onShowDeleteAlertDialog = {
-            isDeleteDialogVisible = true
+            if (viewModel.selectedNoticeIds.isNotEmpty()) {
+                isDeleteDialogVisible = true
+            }
         },
         isDeletePopupVisible = isDeleteDialogVisible,
         isDeleteAllNotices = viewModel.isAllNoticesSelected,

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/DeleteSelectedNoticesAlertDialog.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/DeleteSelectedNoticesAlertDialog.kt
@@ -1,0 +1,49 @@
+package com.ku_stacks.ku_ring.notice_storage.compose.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.theme.Warning
+import com.ku_stacks.ku_ring.notice_storage.R
+
+@Composable
+internal fun DeleteSelectedNoticesAlertDialog(
+    isDeletePopupVisible: Boolean,
+    isDeleteAllNotices: Boolean,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = isDeletePopupVisible,
+        modifier = modifier,
+    ) {
+        val textId =
+            if (isDeleteAllNotices) R.string.alert_dialog_delete_all_notices else R.string.alert_dialog_delete_notices
+        KuringAlertDialog(
+            text = stringResource(id = textId),
+            onConfirm = onDelete,
+            confirmText = stringResource(id = R.string.alert_dialog_delete_text),
+            onCancel = onDismiss,
+            cancelText = stringResource(id = R.string.alert_dialog_cancel_text),
+            confirmTextColor = Warning,
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun DeleteSelectedNoticesAlertDialogPreview() {
+    KuringTheme {
+        DeleteSelectedNoticesAlertDialog(
+            isDeletePopupVisible = true,
+            isDeleteAllNotices = true,
+            onDelete = { },
+            onDismiss = { },
+        )
+    }
+}

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeSelectionStateImage.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeSelectionStateImage.kt
@@ -1,0 +1,41 @@
+package com.ku_stacks.ku_ring.notice_storage.compose.components
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.notice_storage.R
+
+@Composable
+internal fun NoticeSelectionStateImage(
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Crossfade(
+        targetState = isSelected,
+        label = "notice selection icon",
+        modifier = modifier,
+    ) {
+        val imageId = if (it) R.drawable.ic_check_checked else R.drawable.ic_check_unchecked
+        Image(
+            painter = painterResource(id = imageId),
+            contentDescription = null,
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun NoticeSelectionStateImagePreview() {
+    KuringTheme {
+        NoticeSelectionStateImage(
+            isSelected = false,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeStorageTopBar.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeStorageTopBar.kt
@@ -33,9 +33,7 @@ internal fun NoticeStorageTopBar(
     CenterTitleTopBar(
         title = "",
         navigation = if (isSelectModeEnabled) {
-            {
-                TopBarNavigation()
-            }
+            { TopBarNavigation() }
         } else {
             null
         },

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeStorageTopBar.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/NoticeStorageTopBar.kt
@@ -1,0 +1,78 @@
+package com.ku_stacks.ku_ring.notice_storage.compose.components
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
+import com.ku_stacks.ku_ring.designsystem.theme.TextBody
+import com.ku_stacks.ku_ring.notice_storage.R
+
+@Composable
+internal fun NoticeStorageTopBar(
+    isSelectModeEnabled: Boolean,
+    onSelectModeEnabled: () -> Unit,
+    onSelectModeDisabled: () -> Unit,
+    onSelectAllNotices: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val actionId =
+        if (isSelectModeEnabled) R.string.top_app_bar_action_select_all else R.string.top_app_bar_action_edit
+    val onActionClick = if (isSelectModeEnabled) onSelectAllNotices else onSelectModeEnabled
+
+    CenterTitleTopBar(
+        title = "",
+        navigation = if (isSelectModeEnabled) {
+            {
+                TopBarNavigation()
+            }
+        } else {
+            null
+        },
+        onNavigationClick = onSelectModeDisabled,
+        action = stringResource(id = actionId),
+        onActionClick = onActionClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun TopBarNavigation(
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = stringResource(id = R.string.top_app_bar_navigation),
+        style = TextStyle(
+            fontSize = 18.sp,
+            lineHeight = 27.sp,
+            fontFamily = Pretendard,
+            fontWeight = FontWeight(500),
+            color = TextBody,
+        ),
+        modifier = modifier,
+    )
+}
+
+@LightAndDarkPreview
+@Composable
+private fun NoticeStorageTopBarPreview() {
+    var isSelectedModeEnabled by remember { mutableStateOf(false) }
+    KuringTheme {
+        NoticeStorageTopBar(
+            isSelectModeEnabled = isSelectedModeEnabled,
+            onSelectModeEnabled = { isSelectedModeEnabled = true },
+            onSelectModeDisabled = { isSelectedModeEnabled = false },
+            onSelectAllNotices = { },
+        )
+    }
+}

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/StoredNotice.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/StoredNotice.kt
@@ -1,0 +1,56 @@
+package com.ku_stacks.ku_ring.notice_storage.compose.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.components.NoticeItem
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.domain.Notice
+import com.ku_stacks.ku_ring.ui_util.preview_data.previewNotices
+
+@Composable
+internal fun StoredNotice(
+    notice: Notice,
+    isSelectModeEnabled: Boolean,
+    toggleNoticeSelection: (Notice) -> Unit,
+    onNoticeClick: (Notice) -> Unit,
+    selectedNoticeIds: Set<String>,
+    modifier: Modifier = Modifier,
+) {
+    NoticeItem(
+        notice = notice,
+        onClick = {
+            if (isSelectModeEnabled) {
+                toggleNoticeSelection(notice)
+            } else {
+                onNoticeClick(notice)
+            }
+        },
+        modifier = modifier,
+    ) {
+        if (isSelectModeEnabled) {
+            NoticeSelectionStateImage(
+                isSelected = notice.articleId in selectedNoticeIds,
+                modifier = Modifier
+                    .padding(start = 8.dp),
+            )
+        }
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun StoredNoticePreview() {
+    val notice = previewNotices.first()
+    KuringTheme {
+        StoredNotice(
+            notice = notice,
+            isSelectModeEnabled = true,
+            toggleNoticeSelection = { },
+            onNoticeClick = { },
+            selectedNoticeIds = setOf(notice.articleId),
+        )
+    }
+}

--- a/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/StoredNotices.kt
+++ b/feature/notice_storage/src/main/java/com/ku_stacks/ku_ring/notice_storage/compose/components/StoredNotices.kt
@@ -1,0 +1,49 @@
+package com.ku_stacks.ku_ring.notice_storage.compose.components
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.domain.Notice
+import com.ku_stacks.ku_ring.ui_util.preview_data.previewNotices
+
+@Composable
+internal fun StoredNotices(
+    notices: List<Notice>,
+    onNoticeClick: (Notice) -> Unit,
+    selectedNoticeIds: Set<String>,
+    isSelectModeEnabled: Boolean,
+    toggleNoticeSelection: (Notice) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        items(
+            items = notices,
+            key = { it.articleId },
+        ) { notice ->
+            StoredNotice(
+                notice = notice,
+                isSelectModeEnabled = isSelectModeEnabled,
+                toggleNoticeSelection = toggleNoticeSelection,
+                onNoticeClick = onNoticeClick,
+                selectedNoticeIds = selectedNoticeIds,
+            )
+        }
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun StoredNoticesPreview() {
+    KuringTheme {
+        StoredNotices(
+            notices = previewNotices,
+            onNoticeClick = {},
+            selectedNoticeIds = emptySet(),
+            isSelectModeEnabled = false,
+            toggleNoticeSelection = {},
+        )
+    }
+}

--- a/feature/notice_storage/src/main/res/values/string.xml
+++ b/feature/notice_storage/src/main/res/values/string.xml
@@ -4,4 +4,9 @@
     <string name="top_app_bar_action_edit">편집</string>
     <string name="top_app_bar_action_select_all">전체 선택</string>
     <string name="cta_text">삭제하기</string>
+
+    <string name="alert_dialog_delete_notices">선택된 공지를\n보관함에서 삭제할까요?</string>
+    <string name="alert_dialog_delete_all_notices">보관함에 저장된\n모든 공지를 삭제할까요?</string>
+    <string name="alert_dialog_cancel_text">취소하기</string>
+    <string name="alert_dialog_delete_text">삭제하기</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-102?atlOrigin=eyJpIjoiNDUyYTYzM2Q1NjMyNGQ2MjlmY2Q4NzViMTE1ODI1NGUiLCJwIjoiaiJ9

## 요약

* 공지 보관함 로직을 구현했습니다. 기존 ViewModel 코드를 일부 재활용하고, 바뀐 UI에 맞는 로직을 추가했습니다.
* 68ea71448cc02c558853cf58367c741bf54d3276: 일부 디자인 변경점을 적용했습니다.
* acc64a918c0f95bb8e304f2162e37226f39c9ce0: `:common:designsystem` 중 `KuringAlertDialog`의 오버로딩을 추가했습니다. Dialog를 단순히 무시할 때와(dismiss) 작업을 아예 취소할 때(cancel) 실행할 작업이 같은지 다른지에 따라 오버로딩이 나뉘게 됩니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/fcfc0375-4f75-4c56-9064-ad6a2a478731)

## 공지 보관함 작업 완료

입니다! 다른 화면도 계속 작업중입니다.