### PR TITLE
kuring-140 테스트, 프로덕션 서버 URL을 바뀐 URL로 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,8 @@ android {
                     appName : "@string/app_name_debug",
                     appIcon : "@drawable/ic_ku_ring_launcher_dev"
             ]
-            // 서버 URL은 :data:remote 모듈에 선언되어 있음
+            buildConfigField "String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\""
+            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
 
             applicationIdSuffix '.debug'
         }
@@ -94,6 +95,8 @@ android {
                     appName : "@string/app_name",
                     appIcon : "@drawable/ic_kuring_launcher"
             ]
+            buildConfigField "String", "API_BASE_URL", "\"https://www.ku-ring.com\""
+            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_campus_main_anonymous\""
         }
     }
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,15 +73,13 @@ android {
     }
 
     buildTypes {
+        // 서버 URL은 :data:remote에 선언되어 있음
         debug {
             minifyEnabled false
             manifestPlaceholders = [
                     appName : "@string/app_name_debug",
                     appIcon : "@drawable/ic_ku_ring_launcher_dev"
             ]
-            buildConfigField "String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\""
-            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
-
             applicationIdSuffix '.debug'
         }
 
@@ -95,8 +93,6 @@ android {
                     appName : "@string/app_name",
                     appIcon : "@drawable/ic_kuring_launcher"
             ]
-            buildConfigField "String", "API_BASE_URL", "\"https://www.ku-ring.com\""
-            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_campus_main_anonymous\""
         }
     }
     compileOptions {

--- a/data/remote/build.gradle
+++ b/data/remote/build.gradle
@@ -22,8 +22,8 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            buildConfigField "String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\""
             buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_campus_main_anonymous\""
+            buildConfigField "String", "API_BASE_URL", "\"https://ku-ring.com/api/\""
         }
         debug {
             buildConfigField "String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\""

--- a/data/remote/build.gradle
+++ b/data/remote/build.gradle
@@ -22,12 +22,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
-            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_campus_main_anonymous\""
             buildConfigField "String", "API_BASE_URL", "\"https://ku-ring.com/api/\""
         }
         debug {
             buildConfigField "String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\""
-            buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
         }
     }
     compileOptions {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-140?atlOrigin=eyJpIjoiMjQwNDNhMjcxM2FjNDNmMGFlZWYwOTBkYWExNzI2ZTUiLCJwIjoiaiJ9

## 변경 사항

서버 인스턴스 위치가 다음과 같이 변경되었습니다.

* 기존 테스트 서버: 폐쇄 예정
* 기존 프로덕션 서버(헤로쿠): 테스트 서버로 변경
* 새 프로덕션 서버 신설

## 향후 브랜치 작업

* `develop`을 `release`에 머지한 후 출시
* `develop`을 `2.0/base`에 머지