### PR TITLE
kuring-41 사용자 등록 API 추가

### DIFF
--- a/common/thirdparty/build.gradle
+++ b/common/thirdparty/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(":common:util")
     implementation project(":common:ui_util")
     implementation project(":common:preferences")
+    implementation project(":common:work")
 
     // dagger hilt
     kapt libs.androidx.hilt.compiler

--- a/common/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
+++ b/common/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
@@ -1,11 +1,7 @@
 package com.ku_stacks.ku_ring.thirdparty.firebase
 
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.content.Context
-import android.graphics.BitmapFactory
-import android.media.RingtoneManager
-import androidx.core.app.NotificationCompat
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ku_stacks.ku_ring.local.room.PushDao
@@ -14,6 +10,7 @@ import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.KuringNotificationManager
 import com.ku_stacks.ku_ring.util.WordConverter
+import com.ku_stacks.ku_ring.work.RegisterUserWork
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import javax.inject.Inject
@@ -37,7 +34,17 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         Timber.e("refreshed token : $token")
         if (pref.fcmToken != token) {
             pref.fcmToken = token
+            enqueueRegisterUserWork(token)
         }
+    }
+
+    private fun enqueueRegisterUserWork(token: String) {
+        val workerData = RegisterUserWork.createData(token)
+        val registerUserWorkRequest = OneTimeWorkRequestBuilder<RegisterUserWork>()
+            .setInputData(workerData)
+            .build()
+        WorkManager.getInstance(baseContext)
+            .enqueue(registerUserWorkRequest)
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/common/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
+++ b/common/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
@@ -10,9 +10,9 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ku_stacks.ku_ring.local.room.PushDao
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.thirdparty.R
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import com.ku_stacks.ku_ring.util.DateUtil
+import com.ku_stacks.ku_ring.util.KuringNotificationManager
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
@@ -89,60 +89,12 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         articleId: String?,
         category: String?
     ) {
-        val intent = navigator.createNoticeWebIntent(
-            this,
-            url,
-            articleId,
-            category,
-        )
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-        val channelId = CHANNEL_ID
-        val notificationBuilder = NotificationCompat.Builder(this, channelId)
-            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.ic_notification))
-            .setSmallIcon(R.drawable.ic_status_bar)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setSound(defaultSound)
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-
-        val notificationManager =
-            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(0, notificationBuilder.build())
+        val intent = navigator.createNoticeWebIntent(this, url, articleId, category)
+        KuringNotificationManager.showNotificationWithUrl(this, intent, title, body)
     }
 
     private fun showCustomNotification(type: String, title: String, body: String) {
         val intent = navigator.createMainIntent(this)
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-        val channelId = CHANNEL_ID
-        val notificationBuilder = NotificationCompat.Builder(this, channelId)
-            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.ic_notification))
-            .setSmallIcon(R.drawable.ic_status_bar)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setSound(defaultSound)
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-
-        val notificationManager =
-            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(1, notificationBuilder.build())
-    }
-
-    companion object {
-        const val CHANNEL_ID = "ku_stack_channel_id"
-        const val CHANNEL_NAME = "쿠링"
+        KuringNotificationManager.showCustomNotification(this, intent, type, title, body)
     }
 }

--- a/common/util/build.gradle
+++ b/common/util/build.gradle
@@ -53,6 +53,8 @@ android {
 }
 
 dependencies {
+    implementation project(":common:ui_util")
+
     implementation libs.androidx.core.ktx
 
     // coroutines

--- a/common/util/src/main/java/com/ku_stacks/ku_ring/util/KuringNotificationManager.kt
+++ b/common/util/src/main/java/com/ku_stacks/ku_ring/util/KuringNotificationManager.kt
@@ -1,0 +1,106 @@
+package com.ku_stacks.ku_ring.util
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.media.RingtoneManager
+import androidx.core.app.NotificationCompat
+
+object KuringNotificationManager {
+
+    fun showNotificationWithUrl(
+        context: Context,
+        intent: Intent,
+        title: String?,
+        body: String?,
+    ) {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val channelId = CHANNEL_ID
+        val notificationBuilder = NotificationCompat.Builder(context, channelId)
+            .setLargeIcon(
+                BitmapFactory.decodeResource(
+                    context.resources,
+                    R.drawable.ic_notification
+                )
+            )
+            .setSmallIcon(R.drawable.ic_status_bar)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setSound(defaultSound)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(0, notificationBuilder.build())
+    }
+
+    fun showCustomNotification(
+        context: Context,
+        intent: Intent,
+        type: String,
+        title: String,
+        body: String,
+    ) {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val channelId = CHANNEL_ID
+        val notificationBuilder = NotificationCompat.Builder(context, channelId)
+            .setLargeIcon(
+                BitmapFactory.decodeResource(
+                    context.resources,
+                    R.drawable.ic_notification
+                )
+            )
+            .setSmallIcon(R.drawable.ic_status_bar)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setSound(defaultSound)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(1, notificationBuilder.build())
+    }
+
+    fun showReengagementNotification(context: Context, intent: Intent) {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val resources = context.resources
+        val notification = NotificationCompat.Builder(context, KuringNotificationManager.CHANNEL_ID)
+            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.ic_notification))
+            .setSmallIcon(R.drawable.ic_status_bar)
+            .setContentTitle(resources.getText(R.string.reengagement_title))
+            .setContentText(resources.getText(R.string.reengagement_body))
+            .setSound(defaultSound)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(2, notification)
+    }
+
+    const val CHANNEL_ID = "ku_stack_channel_id"
+    const val CHANNEL_NAME = "쿠링"
+}

--- a/common/work/build.gradle
+++ b/common/work/build.gradle
@@ -32,8 +32,9 @@ android {
 }
 
 dependencies {
+    implementation project(":common:util")
     implementation project(":common:ui_util")
-    implementation project(":common:thirdparty")
+    implementation project(":data:user")
 
     // dagger hilt
     kapt libs.androidx.hilt.compiler
@@ -45,6 +46,9 @@ dependencies {
     kaptTest libs.hilt.compiler
 
     // WorkManager
-    implementation libs.bundles.androidx.work
+    api libs.bundles.androidx.work
     androidTestImplementation libs.androidx.work.testing
+
+    // Timber
+    implementation libs.timber
 }

--- a/common/work/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
+++ b/common/work/src/main/java/com/ku_stacks/ku_ring/work/ReEngagementNotificationWork.kt
@@ -1,17 +1,11 @@
 package com.ku_stacks.ku_ring.work
 
-import android.app.Notification
-import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.Context
-import android.graphics.BitmapFactory
-import android.media.RingtoneManager
-import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import com.ku_stacks.ku_ring.thirdparty.firebase.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
+import com.ku_stacks.ku_ring.util.KuringNotificationManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 
@@ -23,32 +17,9 @@ class ReEngagementNotificationWork @AssistedInject constructor(
 ) : Worker(appContext, workerParams) {
 
     override fun doWork(): Result {
-        val notification = createNotification(applicationContext)
-        val notificationManager =
-            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.notify(2, notification)
+        val intent = navigator.createMainIntent(applicationContext)
+        KuringNotificationManager.showReengagementNotification(applicationContext, intent)
         return Result.success()
-    }
-
-    private fun createNotification(context: Context): Notification {
-        val intent = navigator.createMainIntent(context)
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        val defaultSound = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-        val resources = context.resources
-        return NotificationCompat.Builder(context, MyFireBaseMessagingService.CHANNEL_ID)
-            .setLargeIcon(BitmapFactory.decodeResource(resources, R.drawable.ic_notification))
-            .setSmallIcon(R.drawable.ic_status_bar)
-            .setContentTitle(resources.getText(R.string.reengagement_title))
-            .setContentText(resources.getText(R.string.reengagement_body))
-            .setSound(defaultSound)
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-            .build()
     }
 
     companion object {

--- a/common/work/src/main/java/com/ku_stacks/ku_ring/work/RegisterUserWork.kt
+++ b/common/work/src/main/java/com/ku_stacks/ku_ring/work/RegisterUserWork.kt
@@ -1,0 +1,39 @@
+package com.ku_stacks.ku_ring.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import com.ku_stacks.ku_ring.user.repository.UserRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+@HiltWorker
+class RegisterUserWork @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val userRepository: UserRepository,
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        val token = getToken() ?: return Result.failure()
+        userRepository.registerUser(token)
+        Timber.d("registered token successfully")
+        return Result.success()
+    }
+
+    private fun getToken(): String? {
+        return inputData.getString(TOKEN_KEY)
+    }
+
+    companion object {
+        fun createData(token: String): Data {
+            return Data.Builder()
+                .putString(TOKEN_KEY, token)
+                .build()
+        }
+
+        private const val TOKEN_KEY = "token-key"
+    }
+}

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.remote.user
 
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
+import com.ku_stacks.ku_ring.remote.user.request.RegisterUserRequest
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
@@ -17,4 +18,7 @@ class UserClient @Inject constructor(
             feedbackRequest = feedbackRequest
         )
     }
+
+    suspend fun registerUser(token: String): DefaultResponse =
+        userService.registerUser(RegisterUserRequest(token))
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -5,14 +5,14 @@ import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
-class FeedbackClient @Inject constructor(
-    private val feedbackService: FeedbackService
+class UserClient @Inject constructor(
+    private val userService: UserService
 ) {
     fun sendFeedback(
         token: String,
         feedbackRequest: FeedbackRequest,
     ): Single<DefaultResponse> {
-        return feedbackService.sendFeedback(
+        return userService.sendFeedback(
             token = token,
             feedbackRequest = feedbackRequest
         )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Body
 import retrofit2.http.Header
 import retrofit2.http.POST
 
-interface FeedbackService {
+interface UserService {
     @POST("v2/users/feedbacks")
     fun sendFeedback(
         @Header("User-Token") token: String,

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.remote.user
 
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
+import com.ku_stacks.ku_ring.remote.user.request.RegisterUserRequest
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.Body
@@ -13,4 +14,7 @@ interface UserService {
         @Header("User-Token") token: String,
         @Body feedbackRequest: FeedbackRequest,
     ): Single<DefaultResponse>
+
+    @POST("v2/users")
+    suspend fun registerUser(@Body registerUserRequest: RegisterUserRequest): DefaultResponse
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/di/UserModule.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/di/UserModule.kt
@@ -1,7 +1,7 @@
 package com.ku_stacks.ku_ring.remote.user.di
 
-import com.ku_stacks.ku_ring.remote.user.FeedbackClient
-import com.ku_stacks.ku_ring.remote.user.FeedbackService
+import com.ku_stacks.ku_ring.remote.user.UserClient
+import com.ku_stacks.ku_ring.remote.user.UserService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,13 +15,13 @@ import javax.inject.Singleton
 object UserModule {
     @Provides
     @Singleton
-    fun provideFeedbackService(@Named("Default") retrofit: Retrofit): FeedbackService {
-        return retrofit.create(FeedbackService::class.java)
+    fun provideFeedbackService(@Named("Default") retrofit: Retrofit): UserService {
+        return retrofit.create(UserService::class.java)
     }
 
     @Provides
     @Singleton
-    fun provideFeedbackClient(feedbackService: FeedbackService): FeedbackClient {
-        return FeedbackClient(feedbackService)
+    fun provideFeedbackClient(userService: UserService): UserClient {
+        return UserClient(userService)
     }
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/request/RegisterUserRequest.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/request/RegisterUserRequest.kt
@@ -1,0 +1,3 @@
+package com.ku_stacks.ku_ring.remote.user.request
+
+data class RegisterUserRequest(val token: String)

--- a/data/remote/src/test/java/com/ku_stacks/ku_ring/remote/UserServiceTest.kt
+++ b/data/remote/src/test/java/com/ku_stacks/ku_ring/remote/UserServiceTest.kt
@@ -1,20 +1,20 @@
 package com.ku_stacks.ku_ring.remote
 
-import com.ku_stacks.ku_ring.remote.user.FeedbackService
+import com.ku_stacks.ku_ring.remote.user.UserService
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-class FeedbackServiceTest : ApiAbstract<FeedbackService>() {
+class UserServiceTest : ApiAbstract<UserService>() {
 
-    private lateinit var service: FeedbackService
+    private lateinit var service: UserService
 
     @Before
     fun initService() {
         super.createMockServer()
-        service = createService(FeedbackService::class.java)
+        service = createService(UserService::class.java)
     }
 
     @After

--- a/data/user/build.gradle
+++ b/data/user/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation project(":common:util")
     implementation project(":common:preferences")
     implementation project(":data:local")
-    implementation project(":data:remote")
+    api project(":data:remote")
 
     // dagger hilt
     kapt libs.androidx.hilt.compiler

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepository.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepository.kt
@@ -8,4 +8,5 @@ interface UserRepository {
     fun blockUser(userId: String, nickname: String): Completable
     fun getBlackUserList(): Single<List<String>>
     fun sendFeedback(feedback: String): Single<DefaultResponse>
+    suspend fun registerUser(token: String): DefaultResponse
 }

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.ku_stacks.ku_ring.user.repository
 import com.ku_stacks.ku_ring.local.entity.BlackUserEntity
 import com.ku_stacks.ku_ring.local.room.BlackUserDao
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.remote.user.FeedbackClient
+import com.ku_stacks.ku_ring.remote.user.UserClient
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
 import io.reactivex.rxjava3.core.Completable
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val dao: BlackUserDao,
-    private val feedbackClient: FeedbackClient,
+    private val userClient: UserClient,
     private val pref: PreferenceUtil,
 ) : UserRepository {
     override fun blockUser(userId: String, nickname: String): Completable {
@@ -33,7 +33,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override fun sendFeedback(feedback: String): Single<DefaultResponse> {
-        return feedbackClient.sendFeedback(
+        return userClient.sendFeedback(
             token = pref.fcmToken ?: "",
             feedbackRequest = FeedbackRequest(feedback)
         )

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -38,4 +38,8 @@ class UserRepositoryImpl @Inject constructor(
             feedbackRequest = FeedbackRequest(feedback)
         )
     }
+
+    override suspend fun registerUser(token: String): DefaultResponse {
+        return userClient.registerUser(token)
+    }
 }

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
@@ -16,10 +16,10 @@ import androidx.work.WorkManager
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.splash.databinding.ActivitySplashBinding
 import com.ku_stacks.ku_ring.thirdparty.firebase.FcmUtil
-import com.ku_stacks.ku_ring.thirdparty.firebase.MyFireBaseMessagingService
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import com.ku_stacks.ku_ring.ui_util.getAppVersionName
 import com.ku_stacks.ku_ring.util.DateUtil
+import com.ku_stacks.ku_ring.util.KuringNotificationManager
 import com.ku_stacks.ku_ring.work.ReEngagementNotificationWork
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -160,8 +160,8 @@ class SplashActivity : AppCompatActivity() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                MyFireBaseMessagingService.CHANNEL_ID,
-                MyFireBaseMessagingService.CHANNEL_NAME,
+                KuringNotificationManager.CHANNEL_ID,
+                KuringNotificationManager.CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             notificationManager.createNotificationChannel(channel)


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-41?atlOrigin=eyJpIjoiNjJlYWM4ZjliNjk2NGNlN2E4ZTVlYmU3NDZjNDBmMGYiLCJwIjoiaiJ9

## 요약

* v2 사용자 등록 API를 추가하고, 새 FCM 토큰을 받았을 때 사용자 등록 API를 호출합니다. 온보딩 task에서 구현한 이유는, fcm 토큰을 받는 시기가 대략 온보딩 화면에 있을 때이기 때문입니다.
* 알림을 보내는 코드를 `:common:util` 모듈로 옮겼습니다.