### PR TITLE
kuring-145 [수정] 서버에서 내려주는 새 날짜 형식에 대응 (yyyy.MM.dd)

### DIFF
--- a/common/util/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
+++ b/common/util/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.util
 
 import timber.log.Timber
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -27,7 +28,7 @@ object DateUtil {
                 today == str
             }
 
-            19 -> {
+            10, 19 -> {
                 val dateString = str.substring(0, 4) + str.substring(5, 7) + str.substring(8, 10)
                 today == dateString
             }
@@ -41,13 +42,18 @@ object DateUtil {
 
     @JvmStatic
     fun convertDateToDay(str: String): String {
-        val oldSimpleDateFormat = SimpleDateFormat("yyyyMMdd", Locale.KOREA)
-        val date = oldSimpleDateFormat.parse(str)
-        val newSimpleDateFormat = SimpleDateFormat("yyyy.MM.dd (E)", Locale.KOREA)
-        return if (date == null) {
+        return try {
+            val oldSimpleDateFormat = SimpleDateFormat("yyyyMMdd", Locale.KOREA)
+            val date = oldSimpleDateFormat.parse(str)
+            val newSimpleDateFormat = SimpleDateFormat("yyyy.MM.dd (E)", Locale.KOREA)
+            if (date == null) {
+                str
+            } else {
+                newSimpleDateFormat.format(date)
+            }
+        } catch (e: ParseException) {
+            Timber.e("date $str is not parsable")
             str
-        } else {
-            newSimpleDateFormat.format(date)
         }
     }
 


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-145?atlOrigin=eyJpIjoiN2UzZGM4NGU5MWJkNDQ0NjhhZGRjOWQxNjZlOWZhMWYiLCJwIjoiaiJ9

## 요약

일부 공지의 날짜 형식을 파싱할 때 에러가 발생하고 있습니다. 새로 배포된 서버에서 보내주는 날짜 형식이 바뀌었기 때문입니다.

* 기존: `yyyyMMdd`
* 현재: `yyyy.MM.dd`

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/ec06880d-bd74-450a-96fb-d19413941d42)

2.0부터는 에러가 발생하는 해당 코드를 사용하지 않으므로, try catch를 통해 `ParseException`이 발생하면 원본 문자열을 돌려주도록 임시로 대처했습니다.

이 PR은 머지되는 즉시 출시될 예정입니다.