### PR TITLE
kuring-100 더보기 화면의 각 그룹 및 로직 정의

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/CenterTitleTopBar.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/CenterTitleTopBar.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentColor
@@ -153,7 +153,8 @@ private fun Action(
     actionClickLabel: String? = null,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
-    LazyColumn(
+    // TODO: Lazy layout 없이 같은 효과를 낼 수 있는 방법 찾기 (Navigation도 동일)
+    LazyRow(
         modifier = modifier.clickable(
             onClick = { onActionClick?.invoke() },
             onClickLabel = actionClickLabel,
@@ -197,7 +198,7 @@ private fun Navigation(
 ) {
     if (navigationIcon != null) {
         CompositionLocalProvider(LocalContentColor provides navigationContentColor) {
-            LazyColumn(
+            LazyRow(
                 modifier = modifier.clickable(
                     onClick = { onNavigationClick?.invoke() },
                     onClickLabel = navigationClickLabel,

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/theme/Color.kt
@@ -38,6 +38,8 @@ val Background: Color
     get() = Color(0xFFFFFFFF)
 val BoxBackgroundColor2: Color
     @Composable get() = Color(0xFFF2F3F5)
+val Borderline: Color
+    get() = Color(0x14000000)
 
 val lightColorPalette: Colors
     @Composable get() = lightColors(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingFragment.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingFragment.kt
@@ -4,12 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.ku_stacks.ku_ring.designsystem.theme.Background
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
 import com.ku_stacks.ku_ring.main.R
 import com.ku_stacks.ku_ring.main.databinding.FragmentSettingBinding
+import com.ku_stacks.ku_ring.main.setting.compose.SettingScreen
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
-import com.ku_stacks.ku_ring.ui_util.getAppVersionName
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -38,54 +47,43 @@ class SettingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupView()
-        binding.subscribeLayout.subscribeExtSwitch.isChecked = viewModel.isExtNotificationAllowed()
     }
 
     private fun setupView() {
-        /** subscribe layout */
-        binding.subscribeLayout.subscribeNoticeLayout.setOnClickListener {
-            navigator.navigateToEditSubscription(requireActivity())
-            requireActivity().overridePendingTransition(
-                R.anim.anim_slide_right_enter,
-                R.anim.anim_stay_exit
-            )
-        }
-        binding.subscribeLayout.subscribeExtSwitch.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.setExtNotificationAllowed(isChecked)
-        }
+        val activity = requireActivity()
 
-        /** information layout */
-        binding.informationLayout.newContentsLayout.setOnClickListener {
-            startWebViewActivity(getString(R.string.notion_new_contents_url))
-        }
-        binding.informationLayout.teamLayout.setOnClickListener {
-            startWebViewActivity(getString(R.string.notion_kuring_team_url))
-        }
-        binding.informationLayout.privacyPolicyLayout.setOnClickListener {
-            startWebViewActivity(getString(R.string.notion_privacy_policy_url))
-        }
-        binding.informationLayout.termsOfServiceLayout.setOnClickListener {
-            startWebViewActivity(getString(R.string.notion_terms_of_service_url))
-        }
-        binding.informationLayout.openSourceLayout.setOnClickListener {
-            val activity = requireActivity()
-            navigator.navigateToOssLicensesMenu(activity)
-            activity.overridePendingTransition(
-                R.anim.anim_slide_right_enter,
-                R.anim.anim_stay_exit
-            )
-        }
+        binding.composeView.setContent {
+            val isExtNotificationAllowed by viewModel.isExtNotificationAllowed.collectAsState()
 
-        /** feedback layout */
-        binding.feedbackLayout.feedbackSendLayout.setOnClickListener {
-            navigator.navigateToFeedback(requireActivity())
+            KuringTheme {
+                SettingScreen(
+                    onNavigateToEditSubscription = { navigator.navigateToEditSubscription(activity) },
+                    isExtNotificationEnabled = isExtNotificationAllowed,
+                    onExtNotificationEnabledToggle = viewModel::setExtNotificationAllowed,
+                    onNavigateToUpdateLog = { startWebViewActivity(R.string.notion_new_contents_url) },
+                    onNavigateToKuringTeam = { startWebViewActivity(R.string.notion_kuring_team_url) },
+                    onNavigateToPrivacyPolicy = { startWebViewActivity(R.string.notion_privacy_policy_url) },
+                    onNavigateToServiceTerms = { startWebViewActivity(R.string.notion_terms_of_service_url) },
+                    onNavigateToOpenSources = {
+                        navigator.navigateToOssLicensesMenu(activity)
+                        activity.overridePendingTransition(
+                            R.anim.anim_slide_right_enter,
+                            R.anim.anim_stay_exit
+                        )
+                    },
+                    onNavigateToKuringInstagram = {},
+                    onNavigateToFeedback = { navigator.navigateToFeedback(activity) },
+                    modifier = Modifier
+                        .background(Background)
+                        .fillMaxWidth()
+                        .wrapContentHeight(),
+                )
+            }
         }
-
-        /** set app version name */
-        binding.informationLayout.versionName = requireContext().getAppVersionName()
     }
 
-    private fun startWebViewActivity(url: String) {
+    private fun startWebViewActivity(@StringRes urlId: Int) {
+        val url = getString(urlId)
         navigator.navigateToNotionView(requireActivity(), url)
         requireActivity().overridePendingTransition(
             R.anim.anim_slide_right_enter,

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -3,6 +3,8 @@ package com.ku_stacks.ku_ring.main.setting
 import androidx.lifecycle.ViewModel
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,9 +12,12 @@ class SettingViewModel @Inject constructor(
     private val pref: PreferenceUtil
 ) : ViewModel() {
 
-    fun isExtNotificationAllowed() = pref.extNotificationAllowed
+    private val _isExtNotificationAllowed = MutableStateFlow(pref.extNotificationAllowed)
+    val isExtNotificationAllowed: StateFlow<Boolean>
+        get() = _isExtNotificationAllowed
 
     fun setExtNotificationAllowed(value: Boolean) {
         pref.extNotificationAllowed = value
+        _isExtNotificationAllowed.value = value
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/SettingScreen.kt
@@ -1,0 +1,108 @@
+package com.ku_stacks.ku_ring.main.setting.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.designsystem.components.CenterTitleTopBar
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.Background
+import com.ku_stacks.ku_ring.designsystem.theme.Borderline
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.setting.compose.groups.FeedbackGroup
+import com.ku_stacks.ku_ring.main.setting.compose.groups.InformationGroup
+import com.ku_stacks.ku_ring.main.setting.compose.groups.SocialNetworkServiceGroup
+import com.ku_stacks.ku_ring.main.setting.compose.groups.SubscribeGroup
+import com.ku_stacks.ku_ring.ui_util.getAppVersionName
+
+@Composable
+internal fun SettingScreen(
+    onNavigateToEditSubscription: () -> Unit,
+    isExtNotificationEnabled: Boolean,
+    onExtNotificationEnabledToggle: (Boolean) -> Unit,
+    onNavigateToUpdateLog: () -> Unit,
+    onNavigateToKuringTeam: () -> Unit,
+    onNavigateToPrivacyPolicy: () -> Unit,
+    onNavigateToServiceTerms: () -> Unit,
+    onNavigateToOpenSources: () -> Unit,
+    onNavigateToKuringInstagram: () -> Unit,
+    onNavigateToFeedback: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    val appVersion = LocalContext.current.getAppVersionName()
+
+    Column(modifier = modifier) {
+        CenterTitleTopBar(
+            title = stringResource(id = R.string.setting_screen_top_app_bar_title),
+            action = {},
+            modifier = Modifier.padding(vertical = 16.dp),
+        )
+        Column(modifier = Modifier.verticalScroll(scrollState)) {
+            SubscribeGroup(
+                onNavigateToEditSubscription = onNavigateToEditSubscription,
+                isExtNotificationEnabled = isExtNotificationEnabled,
+                onExtNotificationEnabledToggle = onExtNotificationEnabledToggle,
+            )
+            SettingScreenDivider()
+            InformationGroup(
+                appVersion = appVersion,
+                onNavigateToUpdateLog = onNavigateToUpdateLog,
+                onNavigateToKuringTeam = onNavigateToKuringTeam,
+                onNavigateToPrivacyPolicy = onNavigateToPrivacyPolicy,
+                onNavigateToServiceTerms = onNavigateToServiceTerms,
+                onNavigateToOpenSources = onNavigateToOpenSources,
+            )
+            SettingScreenDivider()
+            SocialNetworkServiceGroup(onNavigateToKuringInstagram = onNavigateToKuringInstagram)
+            SettingScreenDivider()
+            FeedbackGroup(onNavigateToFeedback = onNavigateToFeedback)
+
+            Spacer(modifier = Modifier.height(100.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingScreenDivider(modifier: Modifier = Modifier) {
+    Spacer(
+        modifier = modifier
+            .padding(vertical = 12.dp)
+            .background(Borderline)
+            .height(1.dp)
+            .fillMaxWidth(),
+    )
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SettingScreenPreview() {
+    KuringTheme {
+        SettingScreen(
+            onNavigateToEditSubscription = {},
+            isExtNotificationEnabled = true,
+            onExtNotificationEnabledToggle = {},
+            onNavigateToUpdateLog = {},
+            onNavigateToKuringTeam = {},
+            onNavigateToPrivacyPolicy = {},
+            onNavigateToServiceTerms = {},
+            onNavigateToOpenSources = {},
+            onNavigateToKuringInstagram = {},
+            onNavigateToFeedback = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2500.dp)
+                .background(Background),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/ChevronIcon.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/ChevronIcon.kt
@@ -1,0 +1,20 @@
+package com.ku_stacks.ku_ring.main.setting.compose.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.designsystem.theme.Gray300
+import com.ku_stacks.ku_ring.main.R
+
+@Composable
+internal fun ChevronIcon(modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_chevron),
+        contentDescription = null,
+        modifier = modifier.size(20.dp),
+        tint = Gray300,
+    )
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/FeedbackGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/FeedbackGroup.kt
@@ -1,0 +1,41 @@
+package com.ku_stacks.ku_ring.main.setting.compose.groups
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.setting.compose.components.ChevronIcon
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingGroup
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingItem
+
+@Composable
+internal fun FeedbackGroup(
+    onNavigateToFeedback: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingGroup(
+        groupTitle = stringResource(id = R.string.setting_feedback_title),
+        modifier = modifier,
+    ) {
+        SettingItem(
+            iconId = R.drawable.ic_feedback_v2,
+            title = stringResource(id = R.string.setting_feedback_send_feedback),
+            onClick = onNavigateToFeedback,
+            content = { ChevronIcon() },
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun FeedbackGroupPreview() {
+    KuringTheme {
+        FeedbackGroup(
+            onNavigateToFeedback = {},
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/InformationGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/InformationGroup.kt
@@ -1,0 +1,105 @@
+package com.ku_stacks.ku_ring.main.setting.compose.groups
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
+import com.ku_stacks.ku_ring.designsystem.theme.TextTitle
+import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.setting.compose.components.ChevronIcon
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingGroup
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingItem
+
+@Composable
+internal fun InformationGroup(
+    appVersion: String,
+    onNavigateToUpdateLog: () -> Unit,
+    onNavigateToKuringTeam: () -> Unit,
+    onNavigateToPrivacyPolicy: () -> Unit,
+    onNavigateToServiceTerms: () -> Unit,
+    onNavigateToOpenSources: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingGroup(
+        groupTitle = stringResource(id = R.string.setting_information_title),
+        modifier = modifier,
+    ) {
+        SettingItem(
+            iconId = R.drawable.ic_rocket_v2,
+            title = stringResource(id = R.string.setting_information_app_version),
+            content = { AppVersionText(appVersion = appVersion) },
+        )
+        SettingItem(
+            iconId = R.drawable.ic_star_v2,
+            title = stringResource(id = R.string.setting_information_new),
+            onClick = onNavigateToUpdateLog,
+            content = { ChevronIcon() },
+        )
+        SettingItem(
+            iconId = R.drawable.ic_kuring_team_v2,
+            title = stringResource(id = R.string.setting_information_kuring_team),
+            onClick = onNavigateToKuringTeam,
+            content = { ChevronIcon() },
+        )
+        SettingItem(
+            iconId = R.drawable.ic_shield_v2,
+            title = stringResource(id = R.string.setting_information_privacy_policy),
+            onClick = onNavigateToPrivacyPolicy,
+            content = { ChevronIcon() },
+        )
+        SettingItem(
+            iconId = R.drawable.ic_check_circle_v2,
+            title = stringResource(id = R.string.setting_information_service_terms),
+            onClick = onNavigateToServiceTerms,
+            content = { ChevronIcon() },
+        )
+        SettingItem(
+            iconId = R.drawable.ic_cloud_web_v2,
+            title = stringResource(id = R.string.setting_information_open_sources),
+            onClick = onNavigateToOpenSources,
+            content = { ChevronIcon() },
+        )
+    }
+}
+
+@Composable
+private fun AppVersionText(
+    appVersion: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = appVersion,
+        style = TextStyle(
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            fontFamily = Pretendard,
+            fontWeight = FontWeight(500),
+            color = TextTitle,
+            letterSpacing = 0.15.sp,
+        ),
+        modifier = modifier,
+    )
+}
+
+@LightAndDarkPreview
+@Composable
+private fun InformationGroupPreview() {
+    KuringTheme {
+        InformationGroup(
+            appVersion = "2.0.0",
+            onNavigateToUpdateLog = {},
+            onNavigateToKuringTeam = {},
+            onNavigateToPrivacyPolicy = {},
+            onNavigateToServiceTerms = {},
+            onNavigateToOpenSources = {},
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SocialNetworkServiceGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SocialNetworkServiceGroup.kt
@@ -1,0 +1,41 @@
+package com.ku_stacks.ku_ring.main.setting.compose.groups
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.setting.compose.components.ChevronIcon
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingGroup
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingItem
+
+@Composable
+internal fun SocialNetworkServiceGroup(
+    onNavigateToKuringInstagram: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingGroup(
+        groupTitle = stringResource(id = R.string.setting_sns_title),
+        modifier = modifier,
+    ) {
+        SettingItem(
+            iconId = R.drawable.ic_instagram_v2,
+            title = stringResource(id = R.string.setting_sns_instagram),
+            onClick = onNavigateToKuringInstagram,
+            content = { ChevronIcon() },
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SocialNetworkServiceGroupPreview() {
+    KuringTheme {
+        SocialNetworkServiceGroup(
+            onNavigateToKuringInstagram = {},
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
@@ -1,0 +1,86 @@
+package com.ku_stacks.ku_ring.main.setting.compose.groups
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.KuringSwitch
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.theme.Gray300
+import com.ku_stacks.ku_ring.designsystem.theme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.theme.Pretendard
+import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.setting.compose.components.ChevronIcon
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingGroup
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingItem
+
+@Composable
+internal fun SubscribeGroup(
+    onNavigateToEditSubscription: () -> Unit,
+    isExtNotificationEnabled: Boolean,
+    onExtNotificationEnabledToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        SettingGroup(groupTitle = stringResource(id = R.string.setting_subscribe_title)) {
+            SettingItem(
+                iconId = R.drawable.ic_bell_v2,
+                title = stringResource(id = R.string.setting_subscribe_notifications),
+                onClick = onNavigateToEditSubscription,
+                content = { ChevronIcon() },
+            )
+            SettingItem(
+                iconId = R.drawable.ic_bell_v2,
+                title = stringResource(id = R.string.setting_subscribe_others),
+                onClick = null,
+                content = {
+                    KuringSwitch(
+                        checked = isExtNotificationEnabled,
+                        onCheckedChange = {
+                            onExtNotificationEnabledToggle(!isExtNotificationEnabled)
+                        },
+                    )
+                },
+            )
+        }
+
+        Text(
+            text = stringResource(id = R.string.setting_subscribe_others_caption),
+            style = TextStyle(
+                fontSize = 12.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(400),
+                color = Gray300,
+                letterSpacing = 0.15.sp,
+            ),
+            modifier = Modifier
+                .padding(start = 56.dp)
+                .offset { IntOffset(0, -(10.dp.roundToPx())) },
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SubscribeGroupPreview() {
+    var enabled by remember { mutableStateOf(false) }
+    KuringTheme {
+        SubscribeGroup(
+            onNavigateToEditSubscription = { },
+            isExtNotificationEnabled = enabled,
+            onExtNotificationEnabledToggle = { enabled = !enabled },
+        )
+    }
+}

--- a/feature/main/src/main/res/layout/fragment_setting.xml
+++ b/feature/main/src/main/res/layout/fragment_setting.xml
@@ -1,59 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/setting_header_layout"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="@color/kus_background"
-        android:elevation="8dp"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/notosanskr_medium"
-            android:text="@string/setting"
-            android:textColor="@color/kus_primary"
-            android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/setting_header_layout">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <include
-                android:id="@+id/subscribe_layout"
-                layout="@layout/setting_subscribe" />
-
-            <include
-                android:id="@+id/information_layout"
-                layout="@layout/setting_information" />
-
-            <include
-                android:id="@+id/feedback_layout"
-                layout="@layout/setting_feedback" />
-        </LinearLayout>
-    </ScrollView>
-
-    <WebView
-        android:id="@+id/webview"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-100?atlOrigin=eyJpIjoiMTFlNjU2Y2MzOTM1NGU5YWFmNGQzOTZjMTQzM2VhODEiLCJwIjoiaiJ9

## 요약

1. 더보기 화면에 있는 각 그룹을 구현했습니다. 아래 사진에서 빨간색 네모 친 부분을 하나의 그룹으로 보았습니다.
2. `ViewModel` 로직을 구현했습니다. 사실 로직이랄 게 딱히 없습니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/d128d46c-680d-4836-a97f-dbce346dd77d)

## 이후 작업

* Compose와 Fragment 연결
* 사용하지 않는 코드 제거