### PR TITLE
kuring-151 쿠링 인스타그램 탐색 링크 추가

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingFragment.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingFragment.kt
@@ -1,5 +1,8 @@
 package com.ku_stacks.ku_ring.main.setting
 
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -71,7 +74,7 @@ class SettingFragment : Fragment() {
                             R.anim.anim_stay_exit
                         )
                     },
-                    onNavigateToKuringInstagram = {},
+                    onNavigateToKuringInstagram = ::navigateToKuringInstagram,
                     onNavigateToFeedback = { navigator.navigateToFeedback(activity) },
                     modifier = Modifier
                         .background(Background)
@@ -89,6 +92,23 @@ class SettingFragment : Fragment() {
             R.anim.anim_slide_right_enter,
             R.anim.anim_stay_exit
         )
+    }
+
+    private fun navigateToKuringInstagram() {
+        val intent = getInstagramIntent()
+        startActivity(intent)
+    }
+
+    private fun getInstagramIntent(): Intent {
+        val packageName = getString(R.string.instagram_package)
+        val appScheme = getString(R.string.instagram_app_scheme)
+        val webScheme = getString(R.string.instagram_web_scheme)
+        return try {
+            requireActivity().packageManager.getPackageInfo(packageName, 0)
+            Intent(Intent.ACTION_VIEW, Uri.parse(appScheme))
+        } catch (e: PackageManager.NameNotFoundException) {
+            Intent(Intent.ACTION_VIEW, Uri.parse(webScheme))
+        }
     }
 
     override fun onDestroyView() {

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="search_staff_copy_email_complete">이메일이 클립보드에 복사되었어요</string>
     <string name="search_staff_copy_phone_number_complete">전화번호가 클립보드에 복사되었어요</string>
 
+    <!--  setting  -->
     <string name="setting_subscribe_title">공지 구독</string>
     <string name="setting_subscribe_notifications">공지 구독하기</string>
     <string name="setting_subscribe_others">기타 알림 받기</string>
@@ -72,7 +73,9 @@
     <string name="notion_privacy_policy_url">https://kuring.notion.site/65ba27f2367044e0be7061e885e7415c</string>
     <string name="notion_terms_of_service_url">https://kuring.notion.site/e88095d4d67d4c4c92983fd85cb693b9</string>
     <string name="notion_kuring_team_url">https://kuring.notion.site/a69fdf7ff06848c2aedef1fdcf13ca57</string>
-    <string name="instagram_url">https://bit.ly/3I30uiG</string>
+    <string name="instagram_package">com.instagram.android</string>
+    <string name="instagram_app_scheme">http://instagram.com/_u/kuring.konkuk</string>
+    <string name="instagram_web_scheme">https://www.instagram.com/kuring.konkuk</string>
 
     <!--  campus map  -->
     <string name="kuring_campus">쿠링 캠퍼스</string>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-151?atlOrigin=eyJpIjoiYjc2ZmMxNjkxYWE2NDdmYThiOTQwYjYxYzRjYjljN2UiLCJwIjoiaiJ9

## 요약

설정 화면의 `인스타그램` 항목을 터치하면 쿠링 인스타그램 계정으로 이동하는 코드를 추가했습니다. 앱이 있으면 앱으로 열고, 앱이 없으면 웹 페이지로 엽니다.

에뮬레이터로 실행한 결과입니다. 인스타그램 앱이 없어서 웹으로 연 모습입니다.

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/86376dcd-3b19-46e9-a3d1-efce48e41f19)

## 이후 작업

아이콘 점검만 하면 끝. 이건 내일 할게요