### PR TITLE
[수정] assembleRelease 오류 해결

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # project-level dependency
-android-gradle = "8.0.0"
+android-gradle = "8.1.4"
 kotlin = '1.8.22'
 hilt = '2.45'
 google-services = '4.3.14'
@@ -15,7 +15,7 @@ compose-compiler = '1.4.8'
 compose-bom = '2024.01.00'
 coil = '2.6.0'
 fragment = '1.5.0'
-kotlinx-coroutines = '1.6.4'
+kotlinx-coroutines = '1.7.3'
 okhttp = '4.9.0'
 paging = '3.2.0-alpha05'
 retrofit = '2.9.0'


### PR DESCRIPTION
> Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.

Gradle dependencies 확인 결과 DataBinding과 `kotlinx-coroutines`의 이슈라고 추정했고, AGP(DataBinding)를 8.0.0에서 8.1.4로, `kotlinx-coroutines`를 1.6.4에서 1.7.3으로 업데이트했습니다. 

저 버전을 선택한 이유는, 두 버전 모두 Kotlin 1.8.x에 의존하는 가장 최신 버전이었기 때문입니다. AGP 8.2.0와 `kotlinx-coroutines` 1.8.0 이후 버전에서는 Kotlin 1.9.x에 의존합니다.