### PR TITLE
[2.0/fix-gradle-properties] 빌드 속도 향상을 위한 gradle.properties 개선

### DIFF
--- a/common/util/build.gradle
+++ b/common/util/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     kaptTest libs.hilt.compiler
 
     // Lifecycle
-    testFixturesImplementation libs.android.lifecycle.extensions
+    testFixturesImplementation libs.androidx.lifecycle.livedata
 
     // retrofit
     implementation libs.bundles.retrofit

--- a/common/util/src/testFixtures/java/com/ku_stacks/ku_ring/util/TestingLiveDataExt.java
+++ b/common/util/src/testFixtures/java/com/ku_stacks/ku_ring/util/TestingLiveDataExt.java
@@ -17,7 +17,7 @@ public class TestingLiveDataExt {
         final Object[] data = new Object[1];
         final CountDownLatch latch = new CountDownLatch(1);
 
-        Observer<T> observer = new Observer<T>() {
+        Observer<T> observer = new Observer<>() {
             @Override
             public void onChanged(T value) {
                 data[0] = value;
@@ -36,22 +36,6 @@ public class TestingLiveDataExt {
 
             //noinspection unchecked
             return (T) data[0];
-        } finally {
-            liveData.removeObserver(observer);
-        }
-    }
-
-    public static <T> void observeForTesting(LiveData<T> liveData, Runnable block) {
-        Observer<T> observer = new Observer<T>() {
-            @Override
-            public void onChanged(T t) {
-                // Do nothing, just needed for observing
-            }
-        };
-
-        try {
-            liveData.observeForever(observer);
-            block.run();
         } finally {
             liveData.removeObserver(observer);
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,9 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.daemon=true
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ androidx-swiperefreshlayout = 'androidx.swiperefreshlayout:swiperefreshlayout:1.
 androidx-viewpager2 = 'androidx.viewpager2:viewpager2:1.0.0'
 
 # AndroidX ViewModel
-android-lifecycle-extensions = 'android.arch.lifecycle:extensions:1.1.1'
 androidx-lifecycle-viewmodel-ktx = 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+androidx-lifecycle-livedata = 'androidx.lifecycle:lifecycle-livedata:2.7.0'
 androidx-activity-ktx = 'androidx.activity:activity-ktx:1.2.3'
 
 # Firebase
@@ -137,7 +137,7 @@ androidx-work-testing = { module = 'androidx.work:work-testing', version.ref = '
 androidx-work-hilt = 'androidx.hilt:hilt-work:1.0.0'
 
 # Unit Test
-androidx-core-testing = 'androidx.arch.core:core-testing:2.1.0'
+androidx-core-testing = 'androidx.arch.core:core-testing:2.2.0'
 androidx-test-core = 'androidx.test:core:1.4.0'
 mockito-core = 'org.mockito:mockito-core:3.5.9'
 mockito-inline = 'org.mockito:mockito-inline:2.21.0'
@@ -211,7 +211,6 @@ rxjava = [
     'rxjava',
 ]
 viewmodel-ktx = [
-    'android-lifecycle-extensions',
     'androidx-lifecycle-viewmodel-ktx',
     'androidx-activity-ktx',
 ]

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
         maven { url 'https://jitpack.io' }
         maven { url "https://repo.sendbird.com/public/maven" }
     }


### PR DESCRIPTION
- 우선 이미 셧다운된 jcenter는 레포지터리 프로바이더 목록에서 제외했습니다.
- 다음과 같이 gradle 패러미터 변경했습니다.
  - JVM Heap 사이즈 4기가로 올렸습니다.
  - 병렬 빌드 옵션 켰습니다.
  - 데몬 프로세스 켰습니다. 데몬 프로세스의 메모리 상에 빌드 결과물 보관할 수 있어서 다음 빌드에서 시간을 줄일 수 있습니다.
  - Jetifier 껐습니다. 해당 옵션 꺼야 [빌드 5~8% 한번에 빨라진다고](https://pluu.github.io/blog/android/io22/2022/05/20/io22-whats-new-in-android-development-tools/) 합니다.