### PR TITLE
[2.0/delete-redundant-braches] 60일동안 커밋 없는 브랜치 자동삭제 스크립트 제작

### DIFF
--- a/.github/workflows/auto-delete-merged-branches.yml
+++ b/.github/workflows/auto-delete-merged-branches.yml
@@ -14,6 +14,9 @@ on:
         description: 'Dry run mode'
         required: false
         default: 'no'
+        options:
+          - 'yes'
+          - 'no'
 
 jobs:
   delete-branch:

--- a/.github/workflows/auto-delete-merged-branches.yml
+++ b/.github/workflows/auto-delete-merged-branches.yml
@@ -10,6 +10,10 @@ on:
         default: 'warning'
       tags:
         description: 'Test scenario tags'
+      dry_run:
+        description: 'Dry run mode'
+        required: false
+        default: 'no'
 
 jobs:
   delete-branch:
@@ -21,8 +25,8 @@ jobs:
         with:
           github_token: ${{ github.token }}
           last_commit_age_days: 60
-          ignore_branches: master, develop
-          dry_run: no
+          ignore_branches: main, develop
+          dry_run: ${{ github.event.inputs.dry_run }}
 
       - name: Get output
         run: "echo 'Deleted branches: ${{ steps.delete_step.outputs.deleted_branches }}'"

--- a/.github/workflows/auto-delete-merged-branches.yml
+++ b/.github/workflows/auto-delete-merged-branches.yml
@@ -1,0 +1,28 @@
+name: Branch Auto Deletion
+on:
+  schedule:
+    - cron: "45 19 * * MON"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Delete branches
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        id: delete_step
+        with:
+          github_token: ${{ github.token }}
+          last_commit_age_days: 60
+          ignore_branches: master, develop
+          dry_run: no
+
+      - name: Get output
+        run: "echo 'Deleted branches: ${{ steps.delete_step.outputs.deleted_branches }}'"


### PR DESCRIPTION
## Description

- [phpdocker-io/github-actions-delete-abandoned-branches@v1](https://github.com/phpdocker-io/github-actions-delete-abandoned-branches)을 활용하여 60일동안 커밋 기록 없는 브랜치는 자동 삭제합니다.
- 매주 월요일 7시 45분에 해당 액션 돌아감
- workflow_dispatch 활용해서 수동으로 돌릴 때 dry_run: yes 설정하면 삭제할 수 있는 브랜치만 볼 수 있음