### PR TITLE
kuring-158 공지 제목이 1줄일 때, 2줄 높이로 보여주지 않도록 수정

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
@@ -48,7 +47,6 @@ fun NoticeItem(
     contentVerticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
     content: @Composable (() -> Unit)? = null,
 ) {
-    // TODO: 중요 공지일 경우 배경색을 초록색으로 바꾸고, [중요] 태그 보여주기
     val background =
         if (notice.isImportant) KuringTheme.colors.mainPrimarySelected else KuringTheme.colors.background
     Row(
@@ -82,7 +80,7 @@ private fun NoticeItemContent(
     notice: Notice,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.heightIn(min = 64.dp)) {
+    Box(modifier = modifier) {
         Column(
             modifier = Modifier.align(Alignment.CenterStart),
             verticalArrangement = Arrangement.spacedBy(4.dp),


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-158?atlOrigin=eyJpIjoiMzgwYTRhNmMwYmRiNDRhMTkwNjFkYTZlOGNjYmY3NjkiLCJwIjoiaiJ9

## 요약

왜인지는 모르겠으나, 공지 제목이 1줄일 때에도 2줄 높이로 보여주고 있던 문제를 해결했습니다.

(before - after)

![image](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/f682b275-4a71-4b60-89dd-e8a1b8df340a)

## 찐막

이제 칼 들고 협박해도 더 안함

출시합시다