### PR TITLE
Apply databinding enabled in app module

### DIFF
--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ApplicationPlugin.kt
@@ -17,7 +17,7 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 
-class ApplicationPlugin: Plugin<Project> {
+class ApplicationPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("com.android.application")
@@ -35,8 +35,14 @@ class ApplicationPlugin: Plugin<Project> {
             buildTypes {
                 release {
                     isMinifyEnabled = false
-                    proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+                    proguardFiles(
+                        getDefaultProguardFile("proguard-android-optimize.txt"),
+                        "proguard-rules.pro"
+                    )
                 }
+            }
+            buildFeatures {
+                dataBinding = true
             }
         }
         dependencies {


### PR DESCRIPTION
## Issue

- Databinding 생성된 클래스가 안 잡히는 이슈 포착
- [Reference](https://work2type.tistory.com/entry/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-Didnt-find-class-androidxdatabindingDataBinderMapperImpl-on-path-%EC%98%A4%EB%A5%98)