### PR TITLE
Debug 앱에서는 crashlytics를 끔

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,9 @@ dependencies {
     implementation(libs.bundles.androidx.work)
     debugImplementation(libs.leakcanary.android)
     implementation(libs.play.services.auth)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics.ktx)
 }
 
 kapt {

--- a/app/src/main/java/com/ku_stacks/ku_ring/KuRingApplication.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/KuRingApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -17,4 +18,9 @@ class KuRingApplication : Application(), Configuration.Provider {
         .setMinimumLoggingLevel(Log.INFO)
         .setWorkerFactory(workerFactory)
         .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
+    }
 }


### PR DESCRIPTION
## 작업 요약

디버그 앱에서 발생한 오류가 release에서 발생한 것처럼 crashlytics에 잡히는 문제가 있어, debug 앱에서는 아예 crashlytics 감지를 끄도록 설정했습니다.

`KuringApplication.onCreate()`에서 디버그 앱이라면 crashlytics를 끕니다.

ref: https://stackoverflow.com/questions/62402856/new-firebase-crashlytics-disable-in-debug-mode