### PR TITLE
kuring-167 공지 웹뷰 페이지를 compose로 migrate

### DIFF
--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.designsystem.components
 import android.content.Context
 import android.view.ViewGroup
 import android.webkit.WebChromeClient
+import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -19,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -38,7 +40,8 @@ fun KuringWebView(
     modifier: Modifier = Modifier,
     customSettings: WebSettings.() -> Unit = {},
 ) {
-    if (url != null) {
+    // Preview에서 android view를 지원하지 않으므로, 프리뷰가 아닐 때에만 웹뷰를 보여주도록 설정
+    if (url != null && !LocalInspectionMode.current) {
         KuringWebView(
             url = url,
             customSettings = customSettings,
@@ -133,7 +136,6 @@ private fun KuringWebViewErrorScreen(modifier: Modifier = Modifier) {
     }
 }
 
-// 프리뷰에서 실제 웹 페이지를 보여줄 수 없으므로, URL이 없는 프리뷰만 작성함
 @LightAndDarkPreview
 @Composable
 private fun KuringWebViewPreview_urlNull() {

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
@@ -36,10 +36,12 @@ import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 fun KuringWebView(
     url: String?,
     modifier: Modifier = Modifier,
+    customSettings: WebSettings.() -> Unit = {},
 ) {
     if (url != null) {
         KuringWebView(
             url = url,
+            customSettings = customSettings,
             modifier = modifier,
         )
     } else {
@@ -51,6 +53,7 @@ fun KuringWebView(
 @Composable
 private fun KuringWebView(
     url: String,
+    customSettings: WebSettings.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var progress by remember { mutableIntStateOf(0) }
@@ -65,7 +68,11 @@ private fun KuringWebView(
         }
         AndroidView(
             factory = { context ->
-                createWebView(context) { progress = it }
+                createWebView(
+                    context = context,
+                    onSetProgress = { progress = it },
+                    customSettings = customSettings,
+                )
             },
             update = {
                 it.loadUrl(url)
@@ -74,7 +81,11 @@ private fun KuringWebView(
     }
 }
 
-private fun createWebView(context: Context, onSetProgress: (Int) -> Unit) = WebView(context).apply {
+private fun createWebView(
+    context: Context,
+    onSetProgress: (Int) -> Unit,
+    customSettings: WebSettings.() -> Unit = {},
+) = WebView(context).apply {
     layoutParams = ViewGroup.LayoutParams(
         ViewGroup.LayoutParams.MATCH_PARENT,
         ViewGroup.LayoutParams.MATCH_PARENT
@@ -92,6 +103,7 @@ private fun createWebView(context: Context, onSetProgress: (Int) -> Unit) = WebV
         loadWithOverviewMode = true
         blockNetworkLoads = false
         setSupportZoom(false)
+        customSettings()
     }
 }
 

--- a/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/CenterTitleTopBar.kt
+++ b/common/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/CenterTitleTopBar.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
@@ -111,7 +110,6 @@ fun CenterTitleTopBar(
     Box(
         modifier = modifier
             .background(backgroundColor)
-            .padding(horizontal = 7.dp)
             .fillMaxWidth(),
     ) {
         Navigation(

--- a/feature/notice_detail/build.gradle.kts
+++ b/feature/notice_detail/build.gradle.kts
@@ -2,7 +2,7 @@ import com.ku_stacks.ku_ring.buildlogic.dsl.setNameSpace
 
 plugins {
     kuring("view")
-    kuringPrimitive("retrofit")
+    kuring("compose")
 }
 
 android {
@@ -12,6 +12,9 @@ android {
 dependencies {
     implementation(projects.common.util)
     implementation(projects.common.uiUtil)
+    implementation(projects.common.designsystem)
     implementation(projects.data.domain)
     implementation(projects.data.notice)
+
+    implementation(libs.bundles.compose.interop)
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
@@ -1,29 +1,20 @@
 package com.ku_stacks.ku_ring.notice_detail
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.WebViewNotice
-import com.ku_stacks.ku_ring.notice_detail.databinding.ActivityNoticeWebBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class NoticeWebActivity : AppCompatActivity() {
 
-    private val viewModel by viewModels<NoticeWebViewModel>()
-    private lateinit var binding: ActivityNoticeWebBinding
-
-    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -32,14 +23,10 @@ class NoticeWebActivity : AppCompatActivity() {
             ?: throw IllegalStateException("WebViewNotice should not be null.")
 
         setContent {
-            val isSaved by viewModel.isSaved.collectAsStateWithLifecycle()
             KuringTheme {
                 NoticeWebScreen(
                     webViewNotice = webViewNotice,
-                    isSaved = isSaved,
                     onNavigateBack = ::finish,
-                    onSaveButtonClick = viewModel::onSaveButtonClick,
-                    afterPageLoaded = viewModel::updateNoticeTobeRead,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
@@ -5,21 +5,17 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ShareCompat
-import androidx.lifecycle.lifecycleScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.WebViewNotice
 import com.ku_stacks.ku_ring.notice_detail.databinding.ActivityNoticeWebBinding
-import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
-import timber.log.Timber
 
 @AndroidEntryPoint
 class NoticeWebActivity : AppCompatActivity() {
@@ -30,84 +26,24 @@ class NoticeWebActivity : AppCompatActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityNoticeWebBinding.inflate(layoutInflater)
-        setContentView(binding.root)
 
         // Deprecated되지 않은 다른 함수가 API 33 이상에서만 사용할 수 있어서 부득이하게 deprecated 함수를 사용
         val webViewNotice = intent.getSerializableExtra(WebViewNotice.EXTRA_KEY) as? WebViewNotice
             ?: throw IllegalStateException("WebViewNotice should not be null.")
 
-        binding.noticeBackBt.setOnClickListener { finish() }
-
-        binding.noticeShareBt.setOnClickListener {
-            shareLinkExternally(webViewNotice.url)
-        }
-
-        binding.noticeSaveButton.setOnClickListener { viewModel.onSaveButtonClick() }
-
-        binding.subjectTitle.text = WordConverter.convertEnglishToKorean(webViewNotice.category)
-
-        collectSavedStatus()
-
-        binding.noticeWebView.webViewClient = object : WebViewClient() {
-            override fun shouldOverrideUrlLoading(
-                view: WebView,
-                request: WebResourceRequest
-            ): Boolean {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = request.url
-                startActivity(intent)
-                return true
+        setContent {
+            val isSaved by viewModel.isSaved.collectAsStateWithLifecycle()
+            KuringTheme {
+                NoticeWebScreen(
+                    webViewNotice = webViewNotice,
+                    isSaved = isSaved,
+                    onNavigateBack = ::finish,
+                    onSaveButtonClick = viewModel::onSaveButtonClick,
+                    afterPageLoaded = viewModel::updateNoticeTobeRead,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
         }
-
-        binding.noticeWebView.settings.apply {
-            builtInZoomControls = true
-            domStorageEnabled = true
-            javaScriptEnabled = true
-            loadWithOverviewMode = true
-            setSupportZoom(true)
-            displayZoomControls = false
-        }
-
-        // WebChromeClient
-        binding.noticeWebView.webChromeClient = object : WebChromeClient() {
-            override fun onProgressChanged(view: WebView, newProgress: Int) {
-                binding.noticeProgressbar.progress = newProgress
-                if (newProgress == 100) {
-                    updateNoticeTobeRead(webViewNotice.articleId, webViewNotice.category)
-                    binding.noticeProgressbar.visibility = View.GONE
-                    binding.noticeWebView.webChromeClient = null
-                } else {
-                    binding.noticeProgressbar.visibility = View.VISIBLE
-                }
-                super.onProgressChanged(view, newProgress)
-            }
-        }
-
-        binding.noticeWebView.loadUrl(webViewNotice.url)
-    }
-
-    private fun collectSavedStatus() {
-        lifecycleScope.launchWhenResumed {
-            viewModel.isSaved.collectLatest { isSaved ->
-                binding.isNoticeSaved = isSaved
-            }
-        }
-    }
-
-    private fun updateNoticeTobeRead(articleId: String?, category: String?) {
-        if (!articleId.isNullOrEmpty() && !category.isNullOrEmpty()) {
-            viewModel.updateNoticeTobeRead(articleId, category)
-        }
-    }
-
-    private fun shareLinkExternally(url: String) {
-        ShareCompat.IntentBuilder(this)
-            .setChooserTitle(R.string.share_externally)
-            .setText(url)
-            .setType("text/plain")
-            .startChooser()
     }
 
     override fun finish() {

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -1,0 +1,146 @@
+package com.ku_stacks.ku_ring.notice_detail
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ShareCompat
+import com.ku_stacks.ku_ring.designsystem.components.KuringWebView
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.domain.WebViewNotice
+import com.ku_stacks.ku_ring.util.WordConverter
+
+@Composable
+fun NoticeWebScreen(
+    webViewNotice: WebViewNotice,
+    isSaved: Boolean,
+    onNavigateBack: () -> Unit,
+    onSaveButtonClick: () -> Unit,
+    afterPageLoaded: (WebViewNotice) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DisposableEffect(webViewNotice) {
+        onDispose {
+            afterPageLoaded(webViewNotice)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterTitleTopBar(
+                title = WordConverter.convertEnglishToKorean(webViewNotice.category),
+                modifier = Modifier.fillMaxWidth(),
+                navigation = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_back_v2),
+                        contentDescription = stringResource(id = R.string.navigation_button_description),
+                    )
+                },
+                onNavigationClick = onNavigateBack,
+                action = {
+                    NoticeWebScreenActions(
+                        isSaved = isSaved,
+                        onSaveButtonClick = onSaveButtonClick,
+                        webViewNotice = webViewNotice,
+                    )
+                }
+            )
+        },
+        modifier = modifier,
+    ) {
+        KuringWebView(
+            url = webViewNotice.url,
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize(),
+            customSettings = {
+                builtInZoomControls = true
+            },
+        )
+    }
+}
+
+@Composable
+private fun NoticeWebScreenActions(
+    isSaved: Boolean,
+    onSaveButtonClick: () -> Unit,
+    webViewNotice: WebViewNotice,
+    modifier: Modifier = Modifier,
+) {
+    val bookmarkIconId =
+        if (isSaved) R.drawable.ic_bookmark_fill_v2 else R.drawable.ic_bookmark_v2
+    val context = LocalContext.current
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            painter = painterResource(id = bookmarkIconId),
+            contentDescription = stringResource(id = R.string.save_button_description),
+            tint = KuringTheme.colors.gray600,
+            modifier = Modifier
+                .clickable(role = Role.Switch, onClick = onSaveButtonClick),
+        )
+        Icon(
+            painter = painterResource(id = R.drawable.ic_share_v2),
+            contentDescription = stringResource(id = R.string.share_externally_description),
+            tint = KuringTheme.colors.gray600,
+            modifier = Modifier.clickable(
+                role = Role.Button,
+                onClick = { onShareButtonClick(context, webViewNotice.url) }
+            ),
+        )
+    }
+}
+
+private fun onShareButtonClick(context: Context, url: String) {
+    ShareCompat.IntentBuilder(context)
+        .setChooserTitle(R.string.share_externally_description)
+        .setText(url)
+        .setType("text/plain")
+        .startChooser()
+}
+
+@LightAndDarkPreview
+@Composable
+private fun NoticeWebScreenPreview() {
+    var isSaved by remember { mutableStateOf(false) }
+    KuringTheme {
+        NoticeWebScreen(
+            webViewNotice = WebViewNotice(
+                url = "https://www.google.com",
+                articleId = "123",
+                category = "학사",
+                subject = "쿠링 발전의 건에 대하여",
+            ),
+            isSaved = isSaved,
+            onNavigateBack = {},
+            onSaveButtonClick = { isSaved = !isSaved },
+            afterPageLoaded = {},
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
+        )
+    }
+}

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ku_stacks.ku_ring.designsystem.components.KuringWebView
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
@@ -32,6 +34,25 @@ import com.ku_stacks.ku_ring.util.WordConverter
 
 @Composable
 fun NoticeWebScreen(
+    webViewNotice: WebViewNotice,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: NoticeWebViewModel = hiltViewModel(),
+) {
+    val isSaved by viewModel.isSaved.collectAsStateWithLifecycle()
+
+    NoticeWebScreen(
+        webViewNotice = webViewNotice,
+        isSaved = isSaved,
+        onNavigateBack = onNavigateBack,
+        onSaveButtonClick = viewModel::onSaveButtonClick,
+        afterPageLoaded = viewModel::updateNoticeTobeRead,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun NoticeWebScreen(
     webViewNotice: WebViewNotice,
     isSaved: Boolean,
     onNavigateBack: () -> Unit,

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -46,7 +46,7 @@ fun NoticeWebScreen(
         isSaved = isSaved,
         onNavigateBack = onNavigateBack,
         onSaveButtonClick = viewModel::onSaveButtonClick,
-        afterPageLoaded = viewModel::updateNoticeTobeRead,
+        doAfterPageLoaded = viewModel::updateNoticeTobeRead,
         modifier = modifier,
     )
 }
@@ -57,12 +57,12 @@ private fun NoticeWebScreen(
     isSaved: Boolean,
     onNavigateBack: () -> Unit,
     onSaveButtonClick: () -> Unit,
-    afterPageLoaded: (WebViewNotice) -> Unit,
+    doAfterPageLoaded: (WebViewNotice) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     DisposableEffect(webViewNotice) {
         onDispose {
-            afterPageLoaded(webViewNotice)
+            doAfterPageLoaded(webViewNotice)
         }
     }
 
@@ -158,7 +158,7 @@ private fun NoticeWebScreenPreview() {
             isSaved = isSaved,
             onNavigateBack = {},
             onSaveButtonClick = { isSaved = !isSaved },
-            afterPageLoaded = {},
+            doAfterPageLoaded = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -17,9 +17,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ShareCompat
@@ -108,23 +110,20 @@ private fun NoticeWebScreenActions(
     webViewNotice: WebViewNotice,
     modifier: Modifier = Modifier,
 ) {
-    val bookmarkIconId =
-        if (isSaved) R.drawable.ic_bookmark_fill_v2 else R.drawable.ic_bookmark_v2
     val context = LocalContext.current
-
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Icon(
-            painter = painterResource(id = bookmarkIconId),
+            imageVector = ImageVector.vectorResource(id = if (isSaved) R.drawable.ic_bookmark_fill_v2 else R.drawable.ic_bookmark_v2),
             contentDescription = stringResource(id = R.string.save_button_description),
             tint = KuringTheme.colors.gray600,
             modifier = Modifier
                 .clickable(role = Role.Switch, onClick = onSaveButtonClick),
         )
         Icon(
-            painter = painterResource(id = R.drawable.ic_share_v2),
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_share_v2),
             contentDescription = stringResource(id = R.string.share_externally_description),
             tint = KuringTheme.colors.gray600,
             modifier = Modifier.clickable(

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -11,7 +11,6 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,9 +35,9 @@ class NoticeWebViewModel @Inject constructor(
         }
     }
 
-    fun updateNoticeTobeRead(articleId: String, category: String) {
+    fun updateNoticeTobeRead(webViewNotice: WebViewNotice) {
         disposable.add(
-            noticeRepository.updateNoticeToBeRead(articleId, category)
+            noticeRepository.updateNoticeToBeRead(webViewNotice.articleId, webViewNotice.category)
                 .subscribeOn(Schedulers.io())
                 .subscribe({ }, { })
         )

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="navigation_button_description">뒤로 가기</string>
     <string name="save_button_description">공지 보관하기</string>
     <string name="invalid_external_storage_permission_msg">외부저장소의 읽기 권한이 거부되었어요. 파일 다운로드가 제한되며, 안드로이드 앱 설정 화면에서 권한을 수정할 수 있어요.</string>
     <string name="valid_external_storage_permission_msg">권한이 허용되었습니다. 파일을 다시 선택해주세요</string>
     <string name="download_success">다운로드가 완료되었어요</string>
     <string name="download_fail">다운로드에 실패했어요</string>
-    <string name="share_externally">공유하기</string>
+    <string name="share_externally_description">공유하기</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-167?atlOrigin=eyJpIjoiMmMwYWQwNGQ1ZTdiNDhkZGEwOWYwZTljZDg2MDQzZDEiLCJwIjoiaiJ9

## 작업 요약

공지 웹뷰 페이지를 compose로 migrate했습니다. `Activity::finish` 등 최소한의 코드를 제외하고 모두 compose로 옮겼습니다.

| Before | After |
| --- | --- |
| ![old](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/ef2bbff3-ab03-4b2e-b10e-b3ed1be655c8) | ![new](https://github.com/ku-ring/KU-Ring-Android/assets/45386920/282e3f6c-1d05-4e5c-a16a-a419be40da7c) |

## 주요 커밋

* 65eca094235a7bd0a106fdd0b330929b4f2fbbfc: Compose 프리뷰에서는 android view를 지원하지 않아, `KuringWebView`를 포함하는 composable 전체를 프리뷰에서 볼 수 없는 문제가 있었습니다. 이에 프리뷰에서는 웹뷰 대신 항상 `KuringWebViewErrorPage`를 보여주도록 수정했습니다.
* 055996cad9c516e9a4a02df39855f7c902ea30f3: 공지 웹뷰 레이아웃을 compose로 migrate한 `NoticeWebScreen`을 구현했습니다.
* 0b84edbd93e4d5e6b54294fff192189bbeccd779: ViewModel을 매개변수로 받는 `NoticeWebScreen`의 오버로딩을 추가했습니다. 향후 single activity 적용을 대비하여, `Activity.finish`를 제외한 모든 UI 로직 코드를 compose로 옮겼습니다.