### PR TITLE
kuring-169 공지 구독 화면을 compose로 migrate

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
@@ -22,15 +22,8 @@ import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import javax.inject.Inject
 
 class KuringNavigatorImpl @Inject constructor() : KuringNavigator {
-
-    override fun createEditSubscriptionIntent(context: Context, isFirstRun: Boolean): Intent {
-        return Intent(context, EditSubscriptionActivity::class.java).apply {
-            putExtra(EditSubscriptionActivity.FIRST_RUN_FLAG, isFirstRun)
-        }
-    }
-
-    override fun navigateToEditSubscription(activity: Activity, isFirstRun: Boolean) {
-        EditSubscriptionActivity.start(activity, isFirstRun)
+    override fun navigateToEditSubscription(activity: Activity) {
+        EditSubscriptionActivity.start(activity)
     }
 
     override fun navigateToEditSubscribedDepartment(activity: Activity) {

--- a/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
+++ b/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
@@ -7,8 +7,7 @@ import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.domain.WebViewNotice
 
 interface KuringNavigator {
-    fun createEditSubscriptionIntent(context: Context, isFirstRun: Boolean = false): Intent
-    fun navigateToEditSubscription(activity: Activity, isFirstRun: Boolean = false)
+    fun navigateToEditSubscription(activity: Activity)
     fun navigateToEditSubscribedDepartment(activity: Activity)
     fun navigateToFeedback(activity: Activity)
     fun createMainIntent(context: Context): Intent

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
@@ -3,14 +3,12 @@ package com.ku_stacks.ku_ring.edit_subscription
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.viewModels
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
-import androidx.databinding.DataBindingUtil
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.edit_subscription.compose.EditSubscriptionScreen
-import com.ku_stacks.ku_ring.edit_subscription.databinding.ActivityEditSubscriptionBinding
 import com.ku_stacks.ku_ring.thirdparty.compose.KuringCompositionLocalProvider
 import com.ku_stacks.ku_ring.thirdparty.di.LocalNavigator
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,44 +16,26 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class EditSubscriptionActivity : AppCompatActivity() {
 
-    private lateinit var binding: ActivityEditSubscriptionBinding
-    private val viewModel by viewModels<EditSubscriptionViewModel>()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setupBinding()
-        setupView()
-    }
-
-    private fun setupBinding() {
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_edit_subscription)
-        binding.lifecycleOwner = this
-    }
-
-    private fun setupView() {
-        viewModel.firstRunFlag = intent.getBooleanExtra(FIRST_RUN_FLAG, false)
-        binding.composeView.setContent {
+        setContent {
             KuringCompositionLocalProvider {
                 val navigator = LocalNavigator.current
                 KuringTheme {
                     EditSubscriptionScreen(
-                        viewModel = viewModel,
                         onNavigateToBack = ::finish,
-                        onAddDepartmentButtonClick = { navigator.navigateToEditSubscribedDepartment(this) },
-                        onSubscriptionComplete = ::onSubscriptionComplete,
+                        onAddDepartmentButtonClick = {
+                            navigator.navigateToEditSubscribedDepartment(this)
+                        },
+                        onFinish = {
+                            setResult(RESULT_OK)
+                            finish()
+                        },
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
             }
-        }
-    }
-
-    private fun onSubscriptionComplete() {
-        if (viewModel.isInitialLoadDone) {
-            viewModel.saveSubscribe()
-            setResult(RESULT_OK)
-            finish()
         }
     }
 

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionActivity.kt
@@ -45,11 +45,8 @@ class EditSubscriptionActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val FIRST_RUN_FLAG = "firstRunFlag"
-        fun start(activity: Activity, isFirstRun: Boolean) {
-            val intent = Intent(activity, EditSubscriptionActivity::class.java).apply {
-                putExtra(FIRST_RUN_FLAG, isFirstRun)
-            }
+        fun start(activity: Activity) {
+            val intent = Intent(activity, EditSubscriptionActivity::class.java)
             activity.startActivity(intent)
         }
     }

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionViewModel.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionViewModel.kt
@@ -16,7 +16,12 @@ import com.ku_stacks.ku_ring.util.modifyMap
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -56,9 +61,6 @@ class EditSubscriptionViewModel @Inject constructor(
     private var isInitialDepartmentLoaded = false
     val isInitialLoadDone: Boolean
         get() = isInitialCategoryLoaded && isInitialDepartmentLoaded
-
-    /** 첫 앱 구동자에게 보여지는 온보딩 후의 푸시 세팅을 위한 분기처리 용도 */
-    var firstRunFlag = false
 
     init {
         firebaseMessaging.token.addOnCompleteListener { task ->

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.LightPreview
@@ -60,13 +61,14 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun EditSubscriptionScreen(
-    viewModel: EditSubscriptionViewModel,
     onNavigateToBack: () -> Unit,
     onAddDepartmentButtonClick: () -> Unit,
-    onSubscriptionComplete: () -> Unit,
+    onFinish: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: EditSubscriptionViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+
     EditSubscriptionScreen(
         categories = uiState.categories,
         departments = uiState.departments,
@@ -74,7 +76,12 @@ fun EditSubscriptionScreen(
         onCategoryClick = viewModel::onNormalSubscriptionItemClick,
         onDepartmentClick = viewModel::onDepartmentSubscriptionItemClick,
         onAddDepartmentButtonClick = onAddDepartmentButtonClick,
-        onSubscriptionComplete = onSubscriptionComplete,
+        onSubscriptionComplete = {
+            if (viewModel.isInitialLoadDone) {
+                viewModel.saveSubscribe()
+                onFinish()
+            }
+        },
         modifier = modifier,
     )
 }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-169

## 요약

`:feature:edit_notification` 모듈을 compose로 migrate했습니다. 사실 UI 자체는 전부 compose로 작성되어 있었고, Activity에 남아있던 로직을 compose로 옮기는 등 리팩토링 작업을 주로 수행했습니다.

## 커밋 설명

UI 변경사항이 없는 관계로 스크린샷은 첨부하지 않았습니다.

* 5bb0775a94999a11bf8821bfffdcc58a398208d5: 구독 수정 화면에서 view 코드를 제거하고, Activity에 남아있던 로직을 모두 compose로 옮겼습니다.
* 69cf804f260e6a8b7ba821301b3a12bf203ec498: `EditSubscriptionViewModel`에서 사용되지 않는 변수를 제거했습니다. 구독 수정 화면이 온보딩 과정에서 사용자에게 보이지 않게 되어, `isFirstRun` 변수를 사용할 필요가 없어졌습니다.
* ef2913c20c329320e3a5b832aa99fd64a55e14c1: `KuringNavigator`에서 `isFirstRun` 변수 제거