### PR TITLE
릴리스 액션 실행 조건 변경

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,11 +3,11 @@ name: Android-release CI/CD
 on:
   push:
     branches:
-      - release
+      - release/*
       - main
   pull_request:
     branches:
-      - release
+      - release/*
       - main
 
 jobs:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - release/*
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
`release` 브랜치를 없애고, 대신 `release/{x.y.z}` 브랜치에서 릴리스 액션이 실행되도록 수정했습니다.