### PR TITLE
kuring-174 kapt를 ksp로 migrate

### DIFF
--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ApplicationPlugin.kt
@@ -21,6 +21,7 @@ class ApplicationPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("com.android.application")
+            apply("kotlin-kapt") // remove when view binding is no longer used
         }
 
         apply<KotlinPlugin>()

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ViewBasedFeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/ViewBasedFeaturePlugin.kt
@@ -11,8 +11,12 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 
-class ViewBasedFeaturePlugin: Plugin<Project> {
+class ViewBasedFeaturePlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
+        with(pluginManager) {
+            apply("kotlin-kapt") // remove when view binding is no longer used
+        }
+
         apply<FeaturePlugin>()
 
         extensions.getByType<BaseExtension>().apply {

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/dsl/GradleDsl.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/dsl/GradleDsl.kt
@@ -45,6 +45,24 @@ fun DependencyHandlerScope.kaptAndroidTest(
     add("kaptAndroidTest", artifact)
 }
 
+fun DependencyHandlerScope.ksp(
+    artifact: MinimalExternalModuleDependency,
+) {
+    add("ksp", artifact)
+}
+
+fun DependencyHandlerScope.kspTest(
+    artifact: MinimalExternalModuleDependency,
+) {
+    add("kspTest", artifact)
+}
+
+fun DependencyHandlerScope.kspAndroidTest(
+    artifact: MinimalExternalModuleDependency,
+) {
+    add("kspAndroidTest", artifact)
+}
+
 fun DependencyHandlerScope.debugImplementation(
     artifact: MinimalExternalModuleDependency,
 ) {

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/dsl/GradleDsl.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/dsl/GradleDsl.kt
@@ -27,24 +27,6 @@ fun DependencyHandlerScope.implementation(
     add("implementation", artifact)
 }
 
-fun DependencyHandlerScope.kapt(
-    artifact: MinimalExternalModuleDependency,
-) {
-    add("kapt", artifact)
-}
-
-fun DependencyHandlerScope.kaptTest(
-    artifact: MinimalExternalModuleDependency,
-) {
-    add("kaptTest", artifact)
-}
-
-fun DependencyHandlerScope.kaptAndroidTest(
-    artifact: MinimalExternalModuleDependency,
-) {
-    add("kaptAndroidTest", artifact)
-}
-
 fun DependencyHandlerScope.ksp(
     artifact: MinimalExternalModuleDependency,
 ) {

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/HiltPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/HiltPlugin.kt
@@ -2,9 +2,9 @@ package com.ku_stacks.ku_ring.buildlogic.primitive
 
 import com.ku_stacks.ku_ring.buildlogic.dsl.androidTestImplementation
 import com.ku_stacks.ku_ring.buildlogic.dsl.implementation
-import com.ku_stacks.ku_ring.buildlogic.dsl.kapt
-import com.ku_stacks.ku_ring.buildlogic.dsl.kaptAndroidTest
-import com.ku_stacks.ku_ring.buildlogic.dsl.kaptTest
+import com.ku_stacks.ku_ring.buildlogic.dsl.ksp
+import com.ku_stacks.ku_ring.buildlogic.dsl.kspAndroidTest
+import com.ku_stacks.ku_ring.buildlogic.dsl.kspTest
 import com.ku_stacks.ku_ring.buildlogic.dsl.library
 import com.ku_stacks.ku_ring.buildlogic.dsl.libs
 import com.ku_stacks.ku_ring.buildlogic.dsl.testImplementation
@@ -12,22 +12,23 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 
-class HiltPlugin: Plugin<Project> {
+class HiltPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("kotlin-kapt")
+            apply("com.google.devtools.ksp")
             apply("dagger.hilt.android.plugin")
         }
 
         dependencies {
             implementation(libs.library("hilt-navigation-compose"))
             implementation(libs.library("hilt-android"))
-            kapt(libs.library("androidx-hilt-compiler"))
-            kapt(libs.library("hilt-compiler"))
+            ksp(libs.library("androidx-hilt-compiler"))
+            ksp(libs.library("hilt-compiler"))
             testImplementation(libs.library("hilt-android-testing"))
             androidTestImplementation(libs.library("hilt-android-testing"))
-            kaptTest(libs.library("hilt-compiler"))
-            kaptAndroidTest(libs.library("hilt-compiler"))
+            kspTest(libs.library("hilt-compiler"))
+            kspAndroidTest(libs.library("hilt-compiler"))
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/HiltPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/HiltPlugin.kt
@@ -15,7 +15,6 @@ import org.gradle.kotlin.dsl.dependencies
 class HiltPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
-            apply("kotlin-kapt")
             apply("com.google.devtools.ksp")
             apply("dagger.hilt.android.plugin")
         }

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RoomPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RoomPlugin.kt
@@ -12,7 +12,6 @@ import org.gradle.kotlin.dsl.dependencies
 class RoomPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
-            apply("kotlin-kapt")
             apply("com.google.devtools.ksp")
         }
 

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RoomPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RoomPlugin.kt
@@ -1,7 +1,7 @@
 package com.ku_stacks.ku_ring.buildlogic.primitive
 
 import com.ku_stacks.ku_ring.buildlogic.dsl.implementation
-import com.ku_stacks.ku_ring.buildlogic.dsl.kapt
+import com.ku_stacks.ku_ring.buildlogic.dsl.ksp
 import com.ku_stacks.ku_ring.buildlogic.dsl.library
 import com.ku_stacks.ku_ring.buildlogic.dsl.libs
 import com.ku_stacks.ku_ring.buildlogic.dsl.testImplementation
@@ -13,13 +13,14 @@ class RoomPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         with(pluginManager) {
             apply("kotlin-kapt")
+            apply("com.google.devtools.ksp")
         }
 
         dependencies {
             implementation(libs.library("androidx-room-ktx"))
             implementation(libs.library("androidx-room-runtime"))
             implementation(libs.library("androidx-room-rxjava3"))
-            kapt(libs.library("androidx-room-compiler"))
+            ksp(libs.library("androidx-room-compiler"))
             testImplementation(libs.library("androidx-room-testing"))
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.kotlin.ksp) apply false
     alias(libs.plugins.dagger.hilt) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.crashlytics) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # project-level dependency
 android-gradle = "8.5.0"
 kotlin = '2.0.0'
+ksp = '2.0.0-1.0.22'
 hilt = '2.51.1'
 google-services = '4.4.2'
 firebase-gradle = '3.0.2'
@@ -274,6 +275,7 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-174?atlOrigin=eyJpIjoiNjEyYjEzNDY5OTgwNGJiZTg2ODQyZDZlMmFlMDhkY2MiLCJwIjoiaiJ9

## 작업 내용

Kotlin 2.0 이후에는 kapt는 더 이상 업데이트되지 않고, 대신 ksp를 사용하는 것이 좋습니다. 따라서 쿠링 앱에서도 kapt를 ksp로 migrate했습니다. 

Room, Hilt 등 대부분의 라이브러리는 이미 ksp를 지원하지만, view binding은 여전히 kapt를 사용하고 있으며 ksp를 지원할 계획도 없다고 합니다. 

이 때문에 kapt를 완전히 제거하지는 못했고, 따라서 빌드 시간 향상도 예상보다 크지 않았습니다(49초 → 42초). View를 완전히 제거한 후에는 빌드 시간이 크게 향상될 것으로 예상합니다. 실제로 빌드 돌려보면 `kapt...` 작업에서 잠깐 버벅이는 느낌이 있습니다.

## 커밋 설명

* 8194b44775286c9630b0e6487958eb6b7b158a72: 의존성을 선언할 때 사용하는 `kapt()`, `kaptTest()` 등은 모두 ksp로 교체했습니다.
* c4a504956913e90ae6a363b69ac4140207db2621: 다만 상술했듯이 view 코드에서 kapt를 요구하는 경우가 있어, `ApplicationPlugin`과 `ViewBasedFeaturePlugin`에 kapt를 선언했습니다.