### PR TITLE
kuring-175 [수정] UI를 호출한 후에 공지 웹뷰를 띄우도록 수정

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
@@ -40,10 +40,6 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        (intent?.getSerializableExtra(WebViewNotice.EXTRA_KEY) as? WebViewNotice)?.let { webViewNotice ->
-            navToNoticeActivity(webViewNotice)
-        }
-
         setContent {
             KuringTheme {
                 var currentRoute: MainScreenRoute by remember { mutableStateOf(MainScreenRoute.Notice) }
@@ -60,6 +56,10 @@ class MainActivity : AppCompatActivity() {
                     modifier = Modifier.fillMaxSize().background(KuringTheme.colors.background),
                 )
             }
+        }
+
+        (intent?.getSerializableExtra(WebViewNotice.EXTRA_KEY) as? WebViewNotice)?.let { webViewNotice ->
+            navToNoticeActivity(webViewNotice)
         }
     }
 


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-175?atlOrigin=eyJpIjoiZjlkOGE2ZWE5ZmI1NDUxY2JlZjZjNWE3ZTFiN2ZiMjkiLCJwIjoiaiJ9

## 문제 상황

https://console.firebase.google.com/u/0/project/ku-stack/crashlytics/app/android:com.ku_stacks.ku_ring/issues/907ccac6fc6cc66ddae5a2737b8d52fb?time=last-ninety-days&types=crash&versions=2.0.3%20(20003)&sessionEventKey=66852B03026A0001378FF154FE291321_1965803660808720120

Type-safe 내비게이션 머지 이후 뭔가 이슈가 많이 발생하고 있습니다.

데체웨...?

## 수정 내용

아직 명확한 솔루션을 찾지 못한 상황입니다. Fake 공지로 재현되지도 않아서 어려움을 겪고 있습니다..;;

`MainActivity.kt`를 보면, `setContent`를 호출하기 전에 웹뷰 화면으로 이동하고 있습니다. `setContent`가 내비게이션 그래프를 세팅하기 전에 웹뷰 화면으로 이동하고 있는 것 같아 `setContent` 호출 이후에 웹뷰로 이동하도록 수정했습니다.

근데 이걸로 해결되지는 않을 것 같습니다. 그냥 제 희망사항 ㅠ

## 해결방법?

내비게이션 문제를 원천적으로 해결해야 할 것 같습니다.

공지 웹뷰 화면을 별도의 `Activity`에서 보여주는 대신 메인 화면의 navigation에 통합해볼 생각입니다. 다음 버전에서 출시하는 것을 목표로 작업하겠습니다. 

일단 내일 출시할 2.0.4에서 계속 지켜보는 걸로.