### PR TITLE
refactor: Type-safe navigation route용 KuringRoute를 인터페이스로 분리

### DIFF
--- a/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringRoute.kt
+++ b/common/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringRoute.kt
@@ -1,0 +1,6 @@
+package com.ku_stacks.ku_ring.ui_util
+
+interface KuringRoute {
+    val route: String
+        get() = this::class.java.canonicalName?.toString().toString()
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
@@ -1,46 +1,22 @@
 package com.ku_stacks.ku_ring.main
 
+import com.ku_stacks.ku_ring.ui_util.KuringRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed interface MainScreenRoute {
-    val route: String
+sealed interface MainScreenRoute : KuringRoute {
 
     @Serializable
-    data object Notice : MainScreenRoute {
-        override val route: String
-            get() =
-                this::class.java.canonicalName
-                    ?.toString()
-                    .toString()
-    }
+    data object Notice : MainScreenRoute
 
     @Serializable
-    data object Archive : MainScreenRoute {
-        override val route: String
-            get() =
-                this::class.java.canonicalName
-                    ?.toString()
-                    .toString()
-    }
+    data object Archive : MainScreenRoute
 
     @Serializable
-    data object CampusMap : MainScreenRoute {
-        override val route: String
-            get() =
-                this::class.java.canonicalName
-                    ?.toString()
-                    .toString()
-    }
+    data object CampusMap : MainScreenRoute
 
     @Serializable
-    data object Settings : MainScreenRoute {
-        override val route: String
-            get() =
-                this::class.java.canonicalName
-                    ?.toString()
-                    .toString()
-    }
+    data object Settings : MainScreenRoute
 
     companion object {
         val entries = listOf(Notice, Archive, CampusMap, Settings)


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-168?atlOrigin=eyJpIjoiYTkwNjg2MGEwN2RkNDkyYWIzMjA4YjEzNjhjNzg4MzciLCJwIjoiaiJ9

## 요약

메인 화면 navigation migration 작업을 재개하였습니다. 구체적으로 말씀드리면, 설정 탭을 compose + type-safe navigation으로 migrate하는 중입니다.

작업에 앞서 현우님이 #235 에서 정의하셨던 route 코드를 인터페이스로 분리했습니다. 나중에 다른 화면에서도 사용할 수 있을 것 같아 `:common:ui_util` 모듈에 정의했습니다.

## 커밋 설명

* c8b66746b27ec796454e2290bc9011190b4dab84: `KuringRoute` 인터페이스 분리