### PR TITLE
kuring-168 뒤로 가기 이벤트를 처리하는 composable 정의

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DoubleTapBackHandler.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DoubleTapBackHandler.kt
@@ -1,0 +1,28 @@
+package com.ku_stacks.ku_ring.designsystem.components
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+@Composable
+fun DoubleTapBackHandler(
+    enabled: Boolean,
+    tapInterval: Long,
+    onSingleTap: () -> Unit,
+    onDoubleTap: () -> Unit,
+) {
+    var lastPressedTime by remember { mutableLongStateOf(0L) }
+
+    BackHandler(enabled = enabled) {
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastPressedTime < tapInterval) {
+            onDoubleTap()
+        } else {
+            lastPressedTime = currentTime
+            onSingleTap()
+        }
+    }
+}

--- a/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/ContextExt.kt
+++ b/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/ContextExt.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.StringRes
 import com.google.android.material.snackbar.Snackbar
 import com.ku_stacks.ku_ring.ui_util.dialogs.KuringDialog
 
@@ -12,6 +13,8 @@ fun View.showSnackBar(msg: String) =
 
 fun Context.showToast(msg: String) =
     Toast.makeText(applicationContext, msg, Toast.LENGTH_SHORT).show()
+
+fun Context.showToast(@StringRes id: Int) = showToast(getString(id))
 
 fun Context.makeDialog(title: String? = null, description: String? = null): KuringDialog {
     return KuringDialog(this).apply {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
@@ -8,10 +8,6 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
@@ -43,17 +39,9 @@ class MainActivity : AppCompatActivity() {
 
         setContent {
             KuringTheme {
-                var currentRoute: MainScreenRoute by remember { mutableStateOf(MainScreenRoute.Notice) }
                 val navController = rememberNavController()
                 MainScreen(
                     navController = navController,
-                    currentRoute = currentRoute,
-                    onNavigateToRoute = {
-                        if (currentRoute != it) {
-                            currentRoute = it
-                            navController.navigate(it)
-                        }
-                    },
                     modifier = Modifier.fillMaxSize().background(KuringTheme.colors.background),
                 )
             }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.navigation.compose.rememberNavController
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.WebViewNotice
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
-import com.ku_stacks.ku_ring.ui_util.showToast
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -26,8 +25,6 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var navigator: KuringNavigator
-
-    private var backPressedTime = 0L
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -65,15 +62,6 @@ class MainActivity : AppCompatActivity() {
 
     private fun navToNoticeActivity(webViewNotice: WebViewNotice) {
         navigator.navigateToNoticeWeb(this, webViewNotice)
-    }
-
-    override fun onBackPressed() {
-        if (System.currentTimeMillis() - backPressedTime < 2000) {
-            finish()
-        } else {
-            showToast(getString(R.string.home_finish_if_back_again))
-            backPressedTime = System.currentTimeMillis()
-        }
     }
 
     companion object {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -32,6 +32,7 @@ import com.ku_stacks.ku_ring.main.setting.compose.inner_screen.SettingScreen
 import com.ku_stacks.ku_ring.thirdparty.compose.KuringCompositionLocalProvider
 import com.ku_stacks.ku_ring.thirdparty.di.LocalNavigator
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
+import com.ku_stacks.ku_ring.ui_util.showToast
 import com.ku_stacks.ku_ring.util.findActivity
 
 @Composable
@@ -126,6 +127,12 @@ fun NavGraphBuilder.mainScreenNavGraph(
             },
             onNavigateToEditDepartment = {
                 navigator.navigateToEditSubscribedDepartment(activity)
+            },
+            onBackSingleTap = {
+                activity.showToast(R.string.home_finish_if_back_again)
+            },
+            onBackDoubleTap = {
+                activity.finish()
             },
             modifier =
             Modifier

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -22,6 +24,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.main.archive.compose.ArchiveScreen
 import com.ku_stacks.ku_ring.main.campusmap.CampusMapScreen
@@ -38,15 +41,21 @@ import com.ku_stacks.ku_ring.util.findActivity
 @Composable
 fun MainScreen(
     navController: NavHostController,
-    currentRoute: MainScreenRoute,
-    onNavigateToRoute: (MainScreenRoute) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute by remember {
+        derivedStateOf {
+            currentBackStackEntry?.let { MainScreenRoute.of(it) }
+                ?: MainScreenRoute.Notice
+        }
+    }
+
     Scaffold(
         bottomBar = {
             MainScreenNavigationBar(
                 currentRoute = currentRoute,
-                onNavigationItemClick = { onNavigateToRoute(it) },
+                onNavigationItemClick = { navController.navigate(it) },
                 modifier = Modifier.fillMaxWidth(),
             )
         },

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -59,10 +59,12 @@ fun MainScreen(
             NavHost(
                 navController = navController,
                 startDestination = MainScreenRoute.Notice,
-                modifier = Modifier.padding(it).fillMaxSize(),
+                modifier = Modifier
+                    .padding(it)
+                    .fillMaxSize(),
                 enterTransition = {
-                    val initialRoute = MainScreenRoute.of(initialState.destination.route.orEmpty())
-                    val targetRoute = MainScreenRoute.of(targetState.destination.route.orEmpty())
+                    val initialRoute = MainScreenRoute.of(initialState)
+                    val targetRoute = MainScreenRoute.of(targetState)
                     val enterDirection =
                         slideDirection(
                             initialRoute = initialRoute,
@@ -71,8 +73,8 @@ fun MainScreen(
                     slideIntoContainer(enterDirection)
                 },
                 exitTransition = {
-                    val initialRoute = MainScreenRoute.of(initialState.destination.route.orEmpty())
-                    val targetRoute = MainScreenRoute.of(targetState.destination.route.orEmpty())
+                    val initialRoute = MainScreenRoute.of(initialState)
+                    val targetRoute = MainScreenRoute.of(targetState)
                     val enterDirection =
                         slideDirection(
                             initialRoute = initialRoute,
@@ -126,17 +128,17 @@ fun NavGraphBuilder.mainScreenNavGraph(
                 navigator.navigateToEditSubscribedDepartment(activity)
             },
             modifier =
-                Modifier
-                    .background(KuringTheme.colors.background)
-                    .fillMaxSize(),
+            Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
         )
     }
     composable<MainScreenRoute.Archive> {
         ArchiveScreen(
             modifier =
-                Modifier
-                    .background(KuringTheme.colors.background)
-                    .fillMaxSize(),
+            Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
         )
     }
     composable<MainScreenRoute.CampusMap> {
@@ -166,10 +168,10 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onNavigateToKuringInstagram = { activity.navigateToKuringInstagram() },
             onNavigateToFeedback = { navigator.navigateToFeedback(activity) },
             modifier =
-                Modifier
-                    .background(KuringTheme.colors.background)
-                    .fillMaxWidth()
-                    .wrapContentHeight(),
+            Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxWidth()
+                .wrapContentHeight(),
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.main
 
+import androidx.navigation.NavBackStackEntry
 import com.ku_stacks.ku_ring.ui_util.KuringRoute
 import kotlinx.serialization.Serializable
 
@@ -21,8 +22,10 @@ sealed interface MainScreenRoute : KuringRoute {
     companion object {
         val entries = listOf(Notice, Archive, CampusMap, Settings)
 
-        fun of(route: String): MainScreenRoute =
-            entries.firstOrNull { it.route == route }
-                ?: throw IllegalArgumentException("Unknown route: $route")
+        fun of(entry: NavBackStackEntry): MainScreenRoute =
+            entry.destination.route.orEmpty().let { route ->
+                return entries.firstOrNull { it.route == route }
+                    ?: throw IllegalArgumentException("Unknown route: $route")
+            }
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.ku_stacks.ku_ring.designsystem.components.DoubleTapBackHandler
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.Notice
@@ -20,8 +21,17 @@ internal fun NoticeScreen(
     onNotificationIconClick: () -> Unit,
     onNoticeClick: (Notice) -> Unit,
     onNavigateToEditDepartment: () -> Unit,
+    onBackSingleTap: () -> Unit,
+    onBackDoubleTap: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    DoubleTapBackHandler(
+        enabled = true,
+        tapInterval = 2000L,
+        onSingleTap = onBackSingleTap,
+        onDoubleTap = onBackDoubleTap,
+    )
+
     Column(modifier = modifier) {
         NoticeScreenHeader(
             onSearchIconClick = onSearchIconClick,
@@ -38,6 +48,7 @@ internal fun NoticeScreen(
     }
 }
 
+
 @LightAndDarkPreview
 @Composable
 private fun NoticeScreenPreview() {
@@ -47,6 +58,8 @@ private fun NoticeScreenPreview() {
             onNotificationIconClick = {},
             onNoticeClick = {},
             onNavigateToEditDepartment = {},
+            onBackSingleTap = {},
+            onBackDoubleTap = {},
             modifier = Modifier
                 .fillMaxSize()
                 .background(KuringTheme.colors.background),


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-168?atlOrigin=eyJpIjoiYzRiYmE4NTJkY2Q5NGU5NWJiMmNhNGE1MWZmNDM5YjciLCJwIjoiaiJ9

## 요약

지금까지 뒤로 가기 이벤트는 ``MainActivity``에서 처리되고 있었는데, 현재 탭과 상관업이 뒤로가기를 두 번 누르기만 하면 앱이 종료되는 문제가 있었습니다.

따라서 공지 탭에서만 뒤로 가기 핸들러가 동작하고, 나머지 탭에서는 navigation 스택을 pop하도록 수정했습니다.

## 수정 이후의 동작

* 뒤로 가기 핸들러가 공지 탭에서만 동작합니다. 공지 탭에서 뒤로 가기를 누르면 토스트 메시지가 노출되고, 2초 안에 뒤로 가기를 다시 누르면 ``MainActivity``가 종료됩니다.
* 나머지 탭에서 뒤로 가기를 누르면, ``MainScreen``의 nav stack이 pop됩니다.
