### PR TITLE
kuring-168 KuringRoute의 companion object 인터페이스 정의

### DIFF
--- a/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringRouteCompanionObject.kt
+++ b/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringRouteCompanionObject.kt
@@ -1,0 +1,20 @@
+package com.ku_stacks.ku_ring.ui_util
+
+import androidx.navigation.NavBackStackEntry
+
+interface KuringRouteCompanionObject<T : KuringRoute> {
+    val entries: List<T>
+
+    fun contains(entry: NavBackStackEntry): Boolean = entries.any { routeEntry ->
+        routeEntry.route == entry.route
+    }
+
+    fun fromNavBackStackEntry(entry: NavBackStackEntry): T =
+        entry.route.let { route ->
+            entries.firstOrNull { it.route == route }
+                ?: throw IllegalArgumentException("Unknown route: $route")
+        }
+
+    private val NavBackStackEntry.route: String
+        get() = destination.route.orEmpty()
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -42,7 +44,7 @@ fun MainScreen(
     modifier: Modifier = Modifier,
 ) {
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentRoute = currentBackStackEntry?.let { MainScreenRoute.of(it) }
+    val currentRoute = currentBackStackEntry?.let { MainScreenRoute.fromNavBackStackEntry(it) }
         ?: MainScreenRoute.Notice
 
     Scaffold(
@@ -67,24 +69,22 @@ fun MainScreen(
                     .padding(it)
                     .fillMaxSize(),
                 enterTransition = {
-                    val initialRoute = MainScreenRoute.of(initialState)
-                    val targetRoute = MainScreenRoute.of(targetState)
-                    val enterDirection =
-                        slideDirection(
-                            initialRoute = initialRoute,
-                            targetRoute = targetRoute,
-                        )
-                    slideIntoContainer(enterDirection)
+                    if (MainScreenRoute.contains(initialState) &&
+                        MainScreenRoute.contains(targetState)
+                    ) {
+                        fadeIn(initialAlpha = 1f)
+                    } else {
+                        slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Start)
+                    }
                 },
                 exitTransition = {
-                    val initialRoute = MainScreenRoute.of(initialState)
-                    val targetRoute = MainScreenRoute.of(targetState)
-                    val enterDirection =
-                        slideDirection(
-                            initialRoute = initialRoute,
-                            targetRoute = targetRoute,
-                        )
-                    slideOutOfContainer(enterDirection)
+                    if (MainScreenRoute.contains(initialState) &&
+                        MainScreenRoute.contains(targetState)
+                    ) {
+                        fadeOut(targetAlpha = 1f)
+                    } else {
+                        slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.End)
+                    }
                 },
             ) {
                 mainScreenNavGraph(
@@ -94,23 +94,6 @@ fun MainScreen(
             }
         }
     }
-}
-
-private fun MainScreenRoute.screenOrder() =
-    when (this) {
-        is MainScreenRoute.Notice -> 0
-        is MainScreenRoute.Archive -> 1
-        is MainScreenRoute.CampusMap -> 2
-        is MainScreenRoute.Settings -> 3
-    }
-
-private fun slideDirection(
-    initialRoute: MainScreenRoute,
-    targetRoute: MainScreenRoute,
-) = if (initialRoute.screenOrder() > targetRoute.screenOrder()) {
-    AnimatedContentTransitionScope.SlideDirection.Right
-} else {
-    AnimatedContentTransitionScope.SlideDirection.Left
 }
 
 fun NavGraphBuilder.mainScreenNavGraph(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenRoute.kt
@@ -1,7 +1,7 @@
 package com.ku_stacks.ku_ring.main
 
-import androidx.navigation.NavBackStackEntry
 import com.ku_stacks.ku_ring.ui_util.KuringRoute
+import com.ku_stacks.ku_ring.ui_util.KuringRouteCompanionObject
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -19,13 +19,7 @@ sealed interface MainScreenRoute : KuringRoute {
     @Serializable
     data object Settings : MainScreenRoute
 
-    companion object {
-        val entries = listOf(Notice, Archive, CampusMap, Settings)
-
-        fun of(entry: NavBackStackEntry): MainScreenRoute =
-            entry.destination.route.orEmpty().let { route ->
-                return entries.firstOrNull { it.route == route }
-                    ?: throw IllegalArgumentException("Unknown route: $route")
-            }
+    companion object : KuringRouteCompanionObject<MainScreenRoute> {
+        override val entries = listOf(Notice, Archive, CampusMap, Settings)
     }
 }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-168?atlOrigin=eyJpIjoiZjY2YTczMzQ0MDcwNDljMzgyOGIyZDUwNDZiODM3ZDIiLCJwIjoiaiJ9

## PR 요약

``MainScreenRoute.Companion``에서 entry를 찾는 코드를 인터페이스로 정의하여 다른 route 클래스에서 재사용할 수 있도록 수정했습니다.

또, 메인 화면의 4개 탭을 이동할 때에는 애니메이션 효과를 삭제했고, 4개 탭 외의 화면으로 이동할 때에만 slide 애니메이션을 재생하도록 수정했습니다. 이전 activity 시절의 화면 전환 정책을 적용한 것입니다.

## Context: 내비게이션 그래프

현재 설정 화면은 ``MainScreen``의 그래프와 별도의 그래프를 갖고 있는데, 이것을 메인 화면의 그래프에 nested로 편입하는 작업을 수행하고 있습니다. 

설정 화면은 큰 문제 없이 작업하고 있지만, 향후 모든 화면을 단일 graph로 합칠 때 그래프 구성이나 애니메이션을 팀 전체에서 통일해야 할 필요가 있습니다. 

이에 그래프 구성 및 화면 전환 애니메이션을 디자인팀과 상의할 예정입니다.