### PR TITLE
kuring-182 공지 탭 순서 변경

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/NoticeScreenTabItem.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/NoticeScreenTabItem.kt
@@ -3,10 +3,10 @@ package com.ku_stacks.ku_ring.main.notice
 enum class NoticeScreenTabItem(val shortCategoryName: String, val koreanName: String) {
     DEPARTMENT("dep", "학과"),
     BACHELOR("bch", "학사"),
-    EMPLOYMENT("emp", "취창업"),
-    INTERNATIONAL("nat", "국제"),
     SCHOLARSHIP("sch", "장학"),
     LIBRARY("lib", "도서관"),
+    EMPLOYMENT("emp", "취창업"),
+    INTERNATIONAL("nat", "국제"),
     STUDENT("stu", "학생"),
     INDUSTRY_UNIVERSITY("ind", "산학"),
     NORMAL("nor", "일반");


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-182?atlOrigin=eyJpIjoiMTM2YzkxODhhYTYxNGNlZDk0NjdiYzY3Zjc0ZWYxMDciLCJwIjoiaiJ9

## 요약

디자인팀의 요청에 따라 공지 탭 순서를 변경하였습니다.

![image](https://github.com/user-attachments/assets/883a9ec9-072d-4c1f-a1ba-abc82aeb5b6e)

## 스크린샷

![image](https://github.com/user-attachments/assets/e8037c3e-5bd0-4130-bbea-d16a457bbabf)
![image](https://github.com/user-attachments/assets/c86012db-9d88-4e25-b5a7-cd65d66544b1)
