### PR TITLE
kuring-205 쿠링봇 fab 오류 수정

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -59,9 +59,6 @@ fun MainScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
             },
-            floatingActionButton = {
-                KuringBotFab(onClick = { navigator.navigateToKuringBot(activity) })
-            },
             modifier = modifier,
         ) {
             NavHost(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeCompositionLocalProvider.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeCompositionLocalProvider.kt
@@ -1,0 +1,35 @@
+package com.ku_stacks.ku_ring.main.notice.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
+import com.ku_stacks.ku_ring.main.notice.compose.components.KuringBotFabState
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+
+@Composable
+fun NoticeCompositionLocalProvider(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val kuringBotFabState = remember {
+        EntryPointAccessors
+            .fromApplication<NoticeScreenEntryPoint>(context)
+            .kuringBotFabState()
+    }
+    CompositionLocalProvider(LocalKuringBotFabState provides kuringBotFabState) {
+        content()
+    }
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface NoticeScreenEntryPoint {
+    fun kuringBotFabState(): KuringBotFabState
+}
+
+val LocalKuringBotFabState = staticCompositionLocalOf<KuringBotFabState> {
+    error("No bottom sheet state")
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
@@ -36,30 +36,45 @@ internal fun NoticeScreen(
         onDoubleTap = onBackDoubleTap,
     )
 
-    val navigator = LocalNavigator.current
-    val context = LocalContext.current
-    Scaffold(
-        topBar = {
-            NoticeScreenHeader(
-                onSearchIconClick = onSearchIconClick,
-                onNotificationIconClick = onNotificationIconClick,
-                modifier = Modifier.fillMaxWidth(),
+    NoticeCompositionLocalProvider {
+        val navigator = LocalNavigator.current
+        val context = LocalContext.current
+        val kuringBotFabState = LocalKuringBotFabState.current
+        Scaffold(
+            topBar = {
+                NoticeScreenHeader(
+                    onSearchIconClick = onSearchIconClick,
+                    onNotificationIconClick = onNotificationIconClick,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            floatingActionButton = {
+                if (kuringBotFabState.isVisible) {
+                    KuringBotFab(onClick = { navigator.navigateToKuringBot(context) })
+                }
+            },
+            modifier = modifier,
+        ) { contentPadding ->
+            NoticeTabScreens(
+                onNoticeClick = onNoticeClick,
+                onNavigateToEditDepartment = onNavigateToEditDepartment,
+                modifier = Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize(),
             )
-        },
-        floatingActionButton = {
-            KuringBotFab(onClick = { navigator.navigateToKuringBot(context) })
-        },
-        modifier = modifier,
-    ) { contentPadding ->
-        NoticeTabScreens(
-            onNoticeClick = onNoticeClick,
-            onNavigateToEditDepartment = onNavigateToEditDepartment,
-            modifier = Modifier
-                .padding(contentPadding)
-                .fillMaxSize(),
-        )
+        }
     }
 }
+
+/*
+NoticeScreen
+- KuringBotFab
+- NoticeTabScreens
+  - DepartmentNoticeScreen
+    - DepartmentNoticeScreen
+      - DepartmentSelectorBottomSheet
+  - CategoryNoticeScreen
+ */
 
 
 @LightAndDarkPreview

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
@@ -1,6 +1,9 @@
 package com.ku_stacks.ku_ring.main.notice.compose
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,7 +21,6 @@ import com.ku_stacks.ku_ring.main.notice.compose.components.NoticeScreenHeader
 import com.ku_stacks.ku_ring.main.notice.compose.inner_screen.NoticeTabScreens
 import com.ku_stacks.ku_ring.thirdparty.di.LocalNavigator
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun NoticeScreen(
     onSearchIconClick: () -> Unit,
@@ -49,7 +51,11 @@ internal fun NoticeScreen(
                 )
             },
             floatingActionButton = {
-                if (kuringBotFabState.isVisible) {
+                AnimatedVisibility(
+                    visible = kuringBotFabState.isVisible,
+                    enter = fadeIn(tween(40)),
+                    exit = fadeOut(targetAlpha = 1f),
+                ) {
                     KuringBotFab(onClick = { navigator.navigateToKuringBot(context) })
                 }
             },
@@ -65,17 +71,6 @@ internal fun NoticeScreen(
         }
     }
 }
-
-/*
-NoticeScreen
-- KuringBotFab
-- NoticeTabScreens
-  - DepartmentNoticeScreen
-    - DepartmentNoticeScreen
-      - DepartmentSelectorBottomSheet
-  - CategoryNoticeScreen
- */
-
 
 @LightAndDarkPreview
 @Composable

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
@@ -2,17 +2,21 @@ package com.ku_stacks.ku_ring.main.notice.compose
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.ku_stacks.ku_ring.designsystem.components.DoubleTapBackHandler
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.Notice
+import com.ku_stacks.ku_ring.main.notice.compose.components.KuringBotFab
 import com.ku_stacks.ku_ring.main.notice.compose.components.NoticeScreenHeader
 import com.ku_stacks.ku_ring.main.notice.compose.inner_screen.NoticeTabScreens
+import com.ku_stacks.ku_ring.thirdparty.di.LocalNavigator
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -32,18 +36,27 @@ internal fun NoticeScreen(
         onDoubleTap = onBackDoubleTap,
     )
 
-    Column(modifier = modifier) {
-        NoticeScreenHeader(
-            onSearchIconClick = onSearchIconClick,
-            onNotificationIconClick = onNotificationIconClick,
-            modifier = Modifier.fillMaxWidth(),
-        )
+    val navigator = LocalNavigator.current
+    val context = LocalContext.current
+    Scaffold(
+        topBar = {
+            NoticeScreenHeader(
+                onSearchIconClick = onSearchIconClick,
+                onNotificationIconClick = onNotificationIconClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        floatingActionButton = {
+            KuringBotFab(onClick = { navigator.navigateToKuringBot(context) })
+        },
+        modifier = modifier,
+    ) { contentPadding ->
         NoticeTabScreens(
             onNoticeClick = onNoticeClick,
             onNavigateToEditDepartment = onNavigateToEditDepartment,
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
+                .padding(contentPadding)
+                .fillMaxSize(),
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/components/KuringBotFab.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/components/KuringBotFab.kt
@@ -1,4 +1,4 @@
-package com.ku_stacks.ku_ring.main
+package com.ku_stacks.ku_ring.main.notice.compose.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.main.R
 
 @Composable
 internal fun KuringBotFab(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/components/KuringBotFabState.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/components/KuringBotFabState.kt
@@ -1,0 +1,21 @@
+package com.ku_stacks.ku_ring.main.notice.compose.components
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import javax.inject.Inject
+
+@Stable
+class KuringBotFabState @Inject constructor() {
+    var isVisible: Boolean by mutableStateOf(true)
+        private set
+
+    fun show() {
+        isVisible = true
+    }
+
+    fun hide() {
+        isVisible = false
+    }
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,6 +51,7 @@ import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.main.R
 import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeScreenState
 import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeViewModel
+import com.ku_stacks.ku_ring.main.notice.compose.LocalKuringBotFabState
 import com.ku_stacks.ku_ring.main.notice.compose.components.DepartmentHeader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -169,6 +172,18 @@ private fun DepartmentNoticeScreen(
         initialValue = ModalBottomSheetValue.Hidden,
         animationSpec = tween(durationMillis = 250)
     )
+
+    val kuringBotFabState = LocalKuringBotFabState.current
+
+    val isOpening by remember { derivedStateOf { sheetState.targetValue != ModalBottomSheetValue.Hidden } }
+    val shouldFabVisible = !sheetState.isVisible && !isOpening
+    LaunchedEffect(shouldFabVisible) {
+        if (shouldFabVisible) {
+            kuringBotFabState.show()
+        } else {
+            kuringBotFabState.hide()
+        }
+    }
 
     ModalBottomSheetLayout(
         sheetContent = {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-205?atlOrigin=eyJpIjoiYmEyZDJhMjBkYWNhNDAxMTlhYzkyNTc1NTIyM2RhYjgiLCJwIjoiaiJ9

## 문제 상황

1. 쿠링봇 버튼이 모든 탭에서 보이는 문제가 있습니다. 공지 탭에서만 보이도록 수정해야 합니다.
2. 쿠링봇이 학과 선택 바텀시트를 가리는 문제가 있습니다.
![image](https://github.com/user-attachments/assets/f85e5164-5699-453f-a988-e453a498a24d)

## 해결

쿠링봇 버튼이 공지 탭에서만 보이도록 수정했습니다.

학과 선택 bottom sheet가 열려 있을 때에는 쿠링봇 버튼이 보이지 않습니다. 

쿠링봇 버튼의 상태를 관리하는 `KuringBotFabState`를 정의하고, Composition local을 통해 state 객체를 내려보냅니다. 학과 선택 bottom sheet에서 시트를 열고 닫을 때 `KuringBotFabState`의 `hide()` 또는 `show()` 함수를 실행합니다.


https://github.com/user-attachments/assets/7ecc388e-3951-47da-a5a6-1992973627fb



## 향후

향후에는 화면 구조를 수정하여 쿠링봇 버튼과 학과 선택 시트가 같은 hierarchy에 오도록 수정하여, 버튼과 바텀시트가 서로를 직접 참조할 수 있도록 수정할 예정입니다.