### PR TITLE
fix: Prevent multiple selection of the same tab

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenNavigationBar.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenNavigationBar.kt
@@ -53,7 +53,11 @@ internal fun MainScreenNavigationBar(
                             id = R.string.main_bottom_navigation_item,
                             label
                         ),
-                        onClick = { onNavigationItemClick(route) },
+                        onClick = {
+                            if (currentRoute != route) {
+                                onNavigationItemClick(route)
+                            }
+                        },
                     ).padding(vertical = 11.dp),
             )
         }


### PR DESCRIPTION
## 문제 상황

이미 선택된 탭이 여러번 다시 눌릴수 있어 의도치않게 동작합니다
![ezgif-2-14d4fd026e](https://github.com/user-attachments/assets/ed6dee96-177a-48ca-b040-0791d544ce1d)

## 해결

간단하게 현재 보는 탭이 아닐경우에만 바텀탭이 선택되도록 하였습니다

