### PR TITLE
kuring-208 지원하지 않는 학과 추가

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/LazyNoticeItemColumn.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/LazyNoticeItemColumn.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.designsystem.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,6 +40,7 @@ fun LazyPagingNoticeItemColumn(
 ) {
     LazyColumn(
         modifier = modifier
+            .background(KuringTheme.colors.background)
             .fillMaxSize(),
         contentPadding = contentPadding,
     ) {

--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/UnsupportedDepartmentUtil.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/UnsupportedDepartmentUtil.kt
@@ -1,0 +1,24 @@
+package com.ku_stacks.ku_ring.department
+
+import com.ku_stacks.ku_ring.domain.Department
+
+object UnsupportedDepartmentUtil {
+    fun getUnsupportedDepartments(): List<Department> {
+        return unsupportedDepartments
+    }
+
+    fun isUnsupportedDepartment(name: String?): Boolean {
+        return unsupportedDepartments.any { it.name == name }
+    }
+
+    private val unsupportedDepartments = listOf(
+        Department(
+            name = "communication_design",
+            shortName = "comdes",
+            koreanName = "커뮤니케이션디자인학과",
+            isSubscribed = false,
+            isSelected = false,
+            isNotificationEnabled = false,
+        )
+    )
+}

--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.department.repository
 
+import com.ku_stacks.ku_ring.department.UnsupportedDepartmentUtil
 import com.ku_stacks.ku_ring.department.mapper.toDepartment
 import com.ku_stacks.ku_ring.department.mapper.toDepartmentList
 import com.ku_stacks.ku_ring.department.mapper.toEntity
@@ -14,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import javax.inject.Inject
 
 class DepartmentRepositoryImpl @Inject constructor(
@@ -36,6 +36,7 @@ class DepartmentRepositoryImpl @Inject constructor(
                 updateDepartmentsName(it)
             }
         }
+        addUnsupportedDepartments()
     }
 
     private suspend fun fetchDepartmentsFromRemote(): List<Department>? {
@@ -60,6 +61,14 @@ class DepartmentRepositoryImpl @Inject constructor(
             }
         }
         this.departments = null
+    }
+
+    private suspend fun addUnsupportedDepartments() {
+        UnsupportedDepartmentUtil.getUnsupportedDepartments().forEach { department ->
+            if (departmentDao.getDepartmentsByName(department.name).isEmpty()) {
+                departmentDao.insertDepartment(department.toEntity())
+            }
+        }
     }
 
     private suspend fun insertDepartment(department: Department) {

--- a/data/department/src/test/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryTest.kt
+++ b/data/department/src/test/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.ku_stacks.ku_ring.department.repository
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import com.ku_stacks.ku_ring.department.UnsupportedDepartmentUtil
 import com.ku_stacks.ku_ring.department.mapper.toDepartment
 import com.ku_stacks.ku_ring.department.test.DepartmentTestUtil
 import com.ku_stacks.ku_ring.local.room.DepartmentDao
@@ -100,6 +101,7 @@ class DepartmentRepositoryTest {
         val expectedDepartments =
             updatedDepartmentsResponse.map { it.toDepartment() }.sortedBy { it.name }
         val actual = departmentRepository.getAllDepartments().sortedBy { it.name }
+            .filterNot { UnsupportedDepartmentUtil.isUnsupportedDepartment(it.name) }
         assertEquals(expectedDepartments, actual)
     }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -2,14 +2,34 @@ package com.ku_stacks.ku_ring.main.notice.compose.inner_screen
 
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Text
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.runtime.*
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -22,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.ku_stacks.ku_ring.department.UnsupportedDepartmentUtil
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LazyPagingNoticeItemColumn
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
@@ -216,18 +237,41 @@ private fun DepartmentNoticeScreenContent(
                 selectedDepartmentName = selectedDepartment?.koreanName ?: "",
                 onClick = { scope.launch { sheetState.show() } },
             )
-            LazyPagingNoticeItemColumn(
-                notices = notices,
-                onNoticeClick = onNoticeClick,
-                modifier = Modifier.pullRefresh(refreshState),
-                noticeFilter = { !it.isImportant },
-            )
+
+            if (UnsupportedDepartmentUtil.isUnsupportedDepartment(selectedDepartment?.name)) {
+                UnsupportedDepartmentIndicator(modifier = Modifier.fillMaxSize())
+            } else {
+                LazyPagingNoticeItemColumn(
+                    notices = notices,
+                    onNoticeClick = onNoticeClick,
+                    modifier = Modifier.pullRefresh(refreshState),
+                    noticeFilter = { !it.isImportant },
+                )
+            }
         }
 
         PullRefreshIndicator(
             refreshing = isRefreshing,
             state = refreshState,
             modifier = Modifier.align(Alignment.TopCenter),
+        )
+    }
+}
+
+@Composable
+private fun UnsupportedDepartmentIndicator(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.background(KuringTheme.colors.background)) {
+        Text(
+            text = stringResource(id = R.string.unsupported_department),
+            style = TextStyle(
+                fontSize = 16.sp,
+                lineHeight = 24.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.textCaption2,
+                textAlign = TextAlign.Center,
+            ),
+            modifier = Modifier.align(Alignment.Center),
         )
     }
 }

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="department_screen_add_department_caption">아직 추가된 학과가 없어요.\n관심 학과를 추가하고 공지를 확인해 보세요!</string>
     <string name="department_screen_add_department_button">학과 추가하기</string>
 
+    <string name="unsupported_department">홈페이지 사정 상,\n공지를 불러올 수 없는 학과예요.</string>
+
     <string name="department_selector_bottom_sheet_cta">학과 편집하기</string>
 
     <!--  search  -->

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingViewModel.kt
@@ -30,12 +30,6 @@ class OnboardingViewModel @Inject constructor(
     val selectedDepartment: StateFlow<Department?>
         get() = _selectedDepartment
 
-    init {
-        viewModelScope.launch {
-            departmentRepository.updateDepartmentsFromRemote()
-        }
-    }
-
     fun onQueryUpdate(newQuery: String) {
         _query.value = newQuery
     }

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(projects.core.preferences)
     implementation(projects.core.work)
     implementation(projects.data.space)
+    implementation(projects.data.department)
 
     implementation(libs.androidx.constraintlayout)
     implementation(libs.semver)

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
@@ -70,6 +70,7 @@ class SplashActivity : AppCompatActivity() {
         }
 
         enqueueReengagementNotificationWork()
+        updateDepartmentsFromRemote()
         loadMinimumAppVersion()
         collectScreenState()
     }
@@ -88,6 +89,12 @@ class SplashActivity : AppCompatActivity() {
             ExistingWorkPolicy.REPLACE,
             notificationWorkRequest,
         )
+    }
+
+    private fun updateDepartmentsFromRemote() {
+        lifecycleScope.launch {
+            viewModel.updateDepartmentsFromRemote()
+        }
     }
 
     private fun loadMinimumAppVersion() {

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashViewModel.kt
@@ -2,6 +2,7 @@ package com.ku_stacks.ku_ring.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.space.repository.KuringSpaceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,11 +14,16 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val kuringSpaceRepository: KuringSpaceRepository
+    private val kuringSpaceRepository: KuringSpaceRepository,
+    private val departmentRepository: DepartmentRepository,
 ) : ViewModel() {
 
     private val _splashScreenState = MutableStateFlow(SplashScreenState.INITIAL)
     val splashScreenState: StateFlow<SplashScreenState> = _splashScreenState.asStateFlow()
+
+    suspend fun updateDepartmentsFromRemote() {
+        departmentRepository.updateDepartmentsFromRemote()
+    }
 
     fun checkUpdateRequired(currentVersion: String) = viewModelScope.launch {
         _splashScreenState.value = SplashScreenState.LOADING

--- a/feature/splash/src/test/java/com/ku_stacks/ku_ring/splash/SplashViewModelTest.kt
+++ b/feature/splash/src/test/java/com/ku_stacks/ku_ring/splash/SplashViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.splash
 
+import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
 import com.ku_stacks.ku_ring.space.repository.KuringSpaceRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,14 +17,17 @@ import org.mockito.Mockito
 class SplashViewModelTest {
 
     private val dispatcher = StandardTestDispatcher()
-    private val repository: KuringSpaceRepository = Mockito.mock(KuringSpaceRepository::class.java)
+    private val kuringSpaceRepository: KuringSpaceRepository =
+        Mockito.mock(KuringSpaceRepository::class.java)
+    private val departmentRepository: DepartmentRepository =
+        Mockito.mock(DepartmentRepository::class.java)
     private lateinit var viewModel: SplashViewModel
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun init() {
         Dispatchers.setMain(dispatcher)
-        viewModel = SplashViewModel(repository)
+        viewModel = SplashViewModel(kuringSpaceRepository, departmentRepository)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -62,7 +66,7 @@ class SplashViewModelTest {
         currentVersion: String,
         expected: SplashScreenState,
     ) {
-        Mockito.`when`(repository.getMinimumAppVersion()).thenReturn(minimumVersion)
+        Mockito.`when`(kuringSpaceRepository.getMinimumAppVersion()).thenReturn(minimumVersion)
         viewModel.checkUpdateRequired(currentVersion).join()
 
         assertEquals(expected, viewModel.splashScreenState.value)
@@ -72,7 +76,7 @@ class SplashViewModelTest {
         currentVersion: String,
         exceptionClass: Class<out Exception>,
     ) {
-        Mockito.`when`(repository.getMinimumAppVersion()).thenThrow(exceptionClass)
+        Mockito.`when`(kuringSpaceRepository.getMinimumAppVersion()).thenThrow(exceptionClass)
         viewModel.checkUpdateRequired(currentVersion).join()
 
         assertEquals(SplashScreenState.UPDATE_NOT_REQUIRED, viewModel.splashScreenState.value)


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-202?atlOrigin=eyJpIjoiYTc4NTI3MTVhNDhjNDNmY2FhYTUwY2EwYWJmNjBkZWQiLCJwIjoiaiJ9

## 요약

공지를 볼 수 없는 커뮤니케이션디자인학과를 앱에 추가해야 하는데, `지원하지 않는 학과`로 추상화하여 작업했습니다.

* 서버로부터 학과를 갱신할 때, 지원하지 않는 학과도 업데이트
* 지원하지 않는 학과의 공지 리스트 UI 추가
* 그 외 자잘한 기능 수정

![image](https://github.com/user-attachments/assets/66e39124-4873-42d1-979c-f36c08caf927)

