### PR TITLE
kuring-211 쿠링봇 질문/응답 텍스트를 선택할 수 있도록 수정

### DIFF
--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
@@ -6,15 +6,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -311,26 +308,28 @@ private fun KuringBotMessages(
 
 @Composable
 private fun KuringBotUIMessage(message: KuringBotUIMessage) {
-    when (message) {
-        KuringBotUIMessage.Loading -> {
-            LoadingMessage()
-        }
-
-        is KuringBotUIMessage.Question -> {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                QuestionMessage(
-                    message = message,
-                    modifier = Modifier.align(Alignment.CenterEnd),
-                )
+    SelectionContainer {
+        when (message) {
+            KuringBotUIMessage.Loading -> {
+                LoadingMessage()
             }
-        }
 
-        is KuringBotUIMessage.QuestionsRemaining -> {
-            QuestionsRemainingMessage(message = message)
-        }
+            is KuringBotUIMessage.Question -> {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    QuestionMessage(
+                        message = message,
+                        modifier = Modifier.align(Alignment.CenterEnd),
+                    )
+                }
+            }
 
-        is KuringBotUIMessage.Response -> {
-            ResponseMessage(message = message)
+            is KuringBotUIMessage.QuestionsRemaining -> {
+                QuestionsRemainingMessage(message = message)
+            }
+
+            is KuringBotUIMessage.Response -> {
+                ResponseMessage(message = message)
+            }
         }
     }
 }


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-211?atlOrigin=eyJpIjoiN2Q1NWRjMDJiYjVlNGQ2YzhlNDViZWEwMGJlNGE3ZDkiLCJwIjoiaiJ9

## 요약

Compose `Text`는 기본적으로 텍스트 선택을 허용하지 않습니다. 그런데 디자인팀에서 텍스트가 선택 가능하도록 수정할 것을 요청하셔서, `SelectionContainer`를 사용하여 메시지 단위로 텍스트를 선택할 수 있도록 수정했습니다.

![image](https://github.com/user-attachments/assets/b03dc456-847d-4221-8349-c6fbf0384423)

![image](https://github.com/user-attachments/assets/73e94ebf-2228-4ab5-aff1-f102cacd9e0e)

## TMI

처음에는 선택 scope를 전체 메시지로 넓히려고 했습니다. 즉 `KuringBotMessages`를 `SelectionContainer`로 감싸는 것입니다.

그런데 메시지 전체를 감싸면 알 수 없는 이유로 `Column` weight가 깨집니다(스샷 참고). 그래서 전체 메시지가 아닌 개별 메시지 단위로 선택할 수 있도록 구현했습니다.

![image](https://github.com/user-attachments/assets/7acb2a0f-1a44-42d9-94e6-557a4e25d233)
