### PR TITLE
kuring-210 학과 클릭 영역을 넓힘

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DepartmentItems.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DepartmentItems.kt
@@ -3,24 +3,12 @@ package com.ku_stacks.ku_ring.designsystem.components
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.minimumInteractiveComponentSize
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -65,9 +53,10 @@ fun DepartmentWithAddIcon(
     BaseDepartment(
         department = department,
         modifier = modifier,
+        onClick = { onAddDepartment(department) }
     ) {
         Spacer(modifier = Modifier.weight(1f))
-        AddIconButton(onClick = { onAddDepartment(department) })
+        AddIcon()
     }
 }
 
@@ -80,6 +69,7 @@ fun DepartmentWithCheckOrUncheckIcon(
     BaseDepartment(
         department = department,
         modifier = modifier,
+        onClick = { onClickDepartment(department) }
     ) {
         Spacer(modifier = Modifier.weight(1f))
         Crossfade(
@@ -87,9 +77,9 @@ fun DepartmentWithCheckOrUncheckIcon(
             label = "department check/uncheck",
         ) {
             if (it) {
-                CheckIconButton(onClick = { onClickDepartment(department) })
+                CheckIcon()
             } else {
-                UncheckIconButton(onClick = { onClickDepartment(department) })
+                UncheckIcon()
             }
         }
     }
@@ -104,12 +94,14 @@ fun DepartmentWithCheckIcon(
     BaseDepartment(
         department = department,
         modifier = modifier,
+        onClick = { onClickDepartment(department) },
+        role = Role.Checkbox,
     ) {
         if (department.isSelected) {
             SelectedDepartmentMark()
         }
         Spacer(modifier = Modifier.weight(1f))
-        CheckIconButton(onClick = { onClickDepartment(department) })
+        CheckIcon()
     }
 }
 
@@ -159,57 +151,42 @@ private fun DeleteButton(
 }
 
 @Composable
-private fun AddIconButton(
-    onClick: () -> Unit,
+private fun AddIcon(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
 ) {
-    IconButton(
-        onClick = onClick,
-        modifier = modifier,
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_plus_v2),
-            contentDescription = contentDescription,
-            tint = KuringTheme.colors.gray300,
-        )
-    }
+    Icon(
+        painter = painterResource(id = R.drawable.ic_plus_v2),
+        contentDescription = contentDescription,
+        tint = KuringTheme.colors.gray300,
+        modifier = modifier.minimumInteractiveComponentSize(),
+    )
 }
 
 @Composable
-private fun CheckIconButton(
-    onClick: () -> Unit,
+private fun CheckIcon(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
 ) {
-    IconButton(
-        onClick = onClick,
-        modifier = modifier,
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_check_circle_fill_v2),
-            contentDescription = contentDescription,
-            tint = KuringTheme.colors.mainPrimary,
-        )
-    }
+    Icon(
+        painter = painterResource(id = R.drawable.ic_check_circle_fill_v2),
+        contentDescription = contentDescription,
+        tint = KuringTheme.colors.mainPrimary,
+        modifier = modifier.minimumInteractiveComponentSize(),
+    )
 }
 
 @Composable
-private fun UncheckIconButton(
-    onClick: () -> Unit,
+private fun UncheckIcon(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
 ) {
-    IconButton(
-        onClick = onClick,
-        modifier = modifier,
-    ) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_check_circle_fill_2_v2),
-            contentDescription = contentDescription,
-            tint = KuringTheme.colors.gray300,
-        )
-    }
+    Icon(
+        painter = painterResource(id = R.drawable.ic_check_circle_fill_2_v2),
+        contentDescription = contentDescription,
+        tint = KuringTheme.colors.gray300,
+        modifier = modifier.minimumInteractiveComponentSize(),
+    )
 }
 
 @Composable

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DepartmentItems.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/DepartmentItems.kt
@@ -216,10 +216,13 @@ private fun UncheckIconButton(
 private fun BaseDepartment(
     department: Department,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    role: Role? = if (onClick == null) null else Role.Button,
     contents: @Composable RowScope.() -> Unit = {},
 ) {
     Row(
         modifier = modifier
+            .clickable(enabled = onClick != null, onClick = { onClick?.invoke() }, role = role)
             .background(KuringTheme.colors.background)
             .padding(horizontal = 24.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-210?atlOrigin=eyJpIjoiZDI3YmQyZWI2MjZjNDkyZTk5NDhlOGU2YzVjNGExMTQiLCJwIjoiaiJ9

자잘하게 많네요 ㅋㅋ

## 요약

학과 선택 화면에서는 학과 아이템의 오른쪽 아이콘 부분만 clickable한데, 사용자 소통 결과 학과 이름을 클릭했을 때에도 콜백이 작동하게 해달라는 의견이 있었습니다. ([8/21 회의록](https://www.notion.so/kuring/bd050427d7884c56a3e2bfda615f2945?pvs=4#37e1cfd034924f1f94dd795dd89b4764) 참고)

![image](https://github.com/user-attachments/assets/4e2e8ec6-51aa-486f-84fe-251dc9297e24)

![image](https://github.com/user-attachments/assets/ec998bd4-88c4-45db-8f54-4abbeab81965)

## 구현 결과

따라서 학과 아이템 전체를 클릭 가능하도록 수정했습니다. 단, 학과를 삭제할 때에는 아이템 전체가 아닌 `삭제` 버튼을 클릭해야만 삭제되도록 했습니다.

![녹화_2024_08_24_20_03_11_688](https://github.com/user-attachments/assets/79babc32-1a21-49fb-9278-e92b92a6eab1)

