### PR TITLE
kuring-219 다크 모드에서 커서의 시인성 향상

### DIFF
--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotTextField.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotTextField.kt
@@ -11,13 +11,10 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -83,6 +80,7 @@ internal fun KuringBotTextField(
         singleLine = false,
         interactionSource = interactionSource,
         maxLines = 5,
+        cursorBrush = SolidColor(textColor),
     )
 }
 


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-219?atlOrigin=eyJpIjoiMWI2MzAxZTNjYjE4NDdmYjhlYTQxYjdjNTc4YmQyNTMiLCJwIjoiaiJ9

## 요약

쿠링봇 `TextField`의 커서 색깔이 검은색으로 고정되어 있어, 다크 모드에서 커서가 잘 보이지 않는 문제가 있었습니다.

따라서 커서 색을 텍스트 색과 동일하게 수정했습니다.

![noname-side](https://github.com/user-attachments/assets/9afa6f08-ca89-4f0c-b065-fdcf3c01084d)

_솔직히 이건 머티리얼 잘못인듯_