### PR TITLE
gradle: 제거되지 않은 build config 제거

### DIFF
--- a/core/util/build.gradle.kts
+++ b/core/util/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.ku_stacks.ku_ring.buildlogic.dsl.setNameSpace
-import java.util.Properties
 
 plugins {
     kuring("feature")
@@ -8,18 +7,8 @@ plugins {
     kuringPrimitive("retrofit")
 }
 
-val properties = Properties().apply {
-    load(rootProject.file("local.properties").inputStream())
-}
-
 android {
     setNameSpace("util")
-
-    defaultConfig {
-        buildConfigField("String", "APPS_FLYER_DEV_KEY", properties["APPS_FLYER_DEV_KEY"] as? String ?: "")
-        buildConfigField("String", "SENDBIRD_APP_ID", properties["SENDBIRD_APP_ID"] as? String ?: "")
-        buildConfigField("String", "SENDBIRD_API_TOKEN", properties["SENDBIRD_API_TOKEN"] as? String ?: "")
-    }
 }
 
 dependencies {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-220?atlOrigin=eyJpIjoiNjk1OThkODFiNDc3NGVlMmEzYjVmMjg2MjI3NDcxNGIiLCJwIjoiaiJ9

## 요약

#349 에서 미처 제거하지 못한 build config 필드를 제거합니다. 석준님 환경에서 정상 빌드되는 것 확인했습니다.