### PR TITLE
빌드시 테스트 태스크 제외시키고 CI에서만 돌리기

### DIFF
--- a/.github/workflows/android-develop.yml
+++ b/.github/workflows/android-develop.yml
@@ -37,12 +37,12 @@ jobs:
         mkdir ./app/src/debug
         echo '${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}' > ./app/src/debug/google-services.json
 
-    - name: Create local.properteis
+    - name: Create local.properties
       run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       
     # Build Debug App
     - name: Build with Gradle
-      run: ./gradlew :app:assembleDebug
+      run: ./gradlew :app:assembleDebug -PisCI=true
       
     # Run unit test
     - name: Run unit test

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -48,11 +48,11 @@ jobs:
 
     # Build APK Release
     - name: Build release Apk
-      run: ./gradlew :app:assembleRelease
+      run: ./gradlew :app:assembleRelease -PisCI=true
 
     # Build AAB Release
     - name: Build release Bundle
-      run: ./gradlew :app:bundleRelease
+      run: ./gradlew :app:bundleRelease -PisCI=true
       
     # Upload AAB
     - name: Upload a Build AAB Artifact

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/FeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/FeaturePlugin.kt
@@ -1,13 +1,14 @@
 package com.ku_stacks.ku_ring.buildlogic.convention
 
-import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.LibraryExtension
+import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import com.ku_stacks.ku_ring.buildlogic.dsl.configureAndroidLibrary
 import com.ku_stacks.ku_ring.buildlogic.primitive.CommonAndroidPlugin
 import com.ku_stacks.ku_ring.buildlogic.primitive.HiltPlugin
 import com.ku_stacks.ku_ring.buildlogic.primitive.KotlinPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
@@ -31,6 +32,12 @@ class FeaturePlugin: Plugin<Project> {
                     isMinifyEnabled = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
                 }
+            }
+            tasks.withType(Test::class.java).configureEach {
+                enabled = project.hasProperty("isCI") && project.property("isCI") == "true"
+            }
+            tasks.withType(AndroidUnitTest::class.java).configureEach {
+                enabled = project.hasProperty("isCI") && project.property("isCI") == "true"
             }
         }
     }


### PR DESCRIPTION
- 안드로이드 클린빌드시 unit test, android test 모두 돌아가는 것을 파악
  - CI 빌드가 아닌 로컬빌드에서 test 태스크는 건너뛰게 설정

결과

- 기존 클린빌드 시간 65초대에서 55초로 줄임

<img width="437" alt="스크린샷 2024-10-20 오후 3 57 22" src="https://github.com/user-attachments/assets/6bc8252c-fbca-442d-95c8-4db1ff1d9f40">
