### PR TITLE
github: main 브랜치에서 release 액션이 돌지 않도록 수정

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - release/*
-      - main
   pull_request:
     branches:
       - release/*
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
과거 2.0 출시 때 추가했던 main 릴리스 액션을 제거합니다.