### PR TITLE
클린 빌드 시에도 테스트 코드를 실행하도록 수정

### DIFF
--- a/.github/workflows/android-develop.yml
+++ b/.github/workflows/android-develop.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir ./app/src/debug
         echo '${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}' > ./app/src/debug/google-services.json
 
-    - name: Create local.properteis
+    - name: Create local.properties
       run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       
     # Build Debug App
@@ -46,4 +46,4 @@ jobs:
       
     # Run unit test
     - name: Run unit test
-      run: ./gradlew testdebugUnitTest
+      run: ./gradlew testDebugUnitTest

--- a/.github/workflows/android-develop.yml
+++ b/.github/workflows/android-develop.yml
@@ -37,12 +37,12 @@ jobs:
         mkdir ./app/src/debug
         echo '${{ secrets.GOOGLE_SERVICES_JSON_DEBUG }}' > ./app/src/debug/google-services.json
 
-    - name: Create local.properties
+    - name: Create local.properteis
       run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
       
     # Build Debug App
     - name: Build with Gradle
-      run: ./gradlew :app:assembleDebug -PisCI=true
+      run: ./gradlew :app:assembleDebug
       
     # Run unit test
     - name: Run unit test

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -37,12 +37,12 @@ jobs:
         echo '${{ secrets.KU_RING_KEY_STORE_JKS }}' | base64 -d > ./app/signing/ku_ring_keystore.jks
         echo '${{ secrets.KEY_STORE_PROPERTIES }}' > ./app/signing/keystore.properties
 
-    - name: Create local.properteis
+    - name: Create local.properties
       run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
 
     # Run unit test
     - name: Run unit test
-      run: ./gradlew testreleaseUnitTest
+      run: ./gradlew testReleaseUnitTest
 
     # Build APK Release
     - name: Build release Apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,11 +46,11 @@ jobs:
 
     # Build APK Release
     - name: Build release Apk
-      run: ./gradlew :app:assembleRelease -PisCI=true
+      run: ./gradlew :app:assembleRelease
 
     # Build AAB Release
     - name: Build release Bundle
-      run: ./gradlew :app:bundleRelease -PisCI=true
+      run: ./gradlew :app:bundleRelease
       
     # Upload AAB
     - name: Upload a Build AAB Artifact

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/FeaturePlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/convention/FeaturePlugin.kt
@@ -1,14 +1,13 @@
 package com.ku_stacks.ku_ring.buildlogic.convention
 
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.LibraryExtension
-import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import com.ku_stacks.ku_ring.buildlogic.dsl.configureAndroidLibrary
 import com.ku_stacks.ku_ring.buildlogic.primitive.CommonAndroidPlugin
 import com.ku_stacks.ku_ring.buildlogic.primitive.HiltPlugin
 import com.ku_stacks.ku_ring.buildlogic.primitive.KotlinPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 
@@ -32,12 +31,6 @@ class FeaturePlugin: Plugin<Project> {
                     isMinifyEnabled = false
                     proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
                 }
-            }
-            tasks.withType(Test::class.java).configureEach {
-                enabled = project.hasProperty("isCI") && project.property("isCI") == "true"
-            }
-            tasks.withType(AndroidUnitTest::class.java).configureEach {
-                enabled = project.hasProperty("isCI") && project.property("isCI") == "true"
             }
         }
     }


### PR DESCRIPTION
#362 의 원래 목적은 클린 빌드 시에만 테스트 코드를 실행하지 않는 것이었으나, PR 적용 후 github actions를 제외한 모든 곳에서 테스트가 돌지 않고 있습니다. (정확히는 `-PisCI=true` 파라미터를 추가해야만 돔)

따라서 일단 #362 를 revert하고, 향후 클린 빌드만 타겟할 수 있는 방법을 찾으면 다시 고민해 봅시다.