### PR TITLE
[fix-runcatching] suspend 함수에서 runCatching 사용하는 anti-pattern 수정

### DIFF
--- a/core/util/src/main/java/com/ku_stacks/ku_ring/util/Result.kt
+++ b/core/util/src/main/java/com/ku_stacks/ku_ring/util/Result.kt
@@ -1,0 +1,13 @@
+package com.ku_stacks.ku_ring.util
+
+import kotlin.coroutines.cancellation.CancellationException
+
+suspend inline fun <R> suspendRunCatching(block: () -> R): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (c: CancellationException) {
+        throw c
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
+}

--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.ku_stacks.ku_ring.local.room.DepartmentDao
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.remote.department.DepartmentClient
 import com.ku_stacks.ku_ring.util.IODispatcher
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -40,7 +41,7 @@ class DepartmentRepositoryImpl @Inject constructor(
     }
 
     private suspend fun fetchDepartmentsFromRemote(): List<Department>? {
-        return runCatching {
+        return suspendRunCatching {
             departmentClient.fetchDepartmentList().data?.map { it.toDepartment() } ?: emptyList()
         }.getOrNull()
     }

--- a/data/library/src/main/java/com/ku_stacks/ku_ring/library/repository/LibraryRepositoryImpl.kt
+++ b/data/library/src/main/java/com/ku_stacks/ku_ring/library/repository/LibraryRepositoryImpl.kt
@@ -3,12 +3,13 @@ package com.ku_stacks.ku_ring.library.repository
 import com.ku_stacks.ku_ring.domain.LibraryRoom
 import com.ku_stacks.ku_ring.library.mapper.toLibraryAreaList
 import com.ku_stacks.ku_ring.remote.library.LibraryClient
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import javax.inject.Inject
 
 class LibraryRepositoryImpl @Inject constructor(
     private val libraryClient: LibraryClient
 ) : LibraryRepository {
-    override suspend fun getRemainingSeats(): Result<List<LibraryRoom>> = runCatching {
+    override suspend fun getRemainingSeats(): Result<List<LibraryRoom>> = suspendRunCatching {
         libraryClient.fetchRoomSeatStatus().toLibraryAreaList()
     }
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/repository/NoticeRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.ku_stacks.ku_ring.remote.notice.NoticeClient
 import com.ku_stacks.ku_ring.remote.notice.request.SubscribeRequest
 import com.ku_stacks.ku_ring.util.IODispatcher
 import com.ku_stacks.ku_ring.util.WordConverter
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -136,7 +137,7 @@ class NoticeRepositoryImpl @Inject constructor(
         subscribeCategories: List<String>
     ) {
         val subscribeRequest = SubscribeRequest(subscribeCategories)
-        runCatching {
+        suspendRunCatching {
             noticeClient.saveSubscribe(
                 token,
                 subscribeRequest

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/CategoryNoticeMediator.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/CategoryNoticeMediator.kt
@@ -11,6 +11,7 @@ import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.remote.notice.NoticeClient
 import com.ku_stacks.ku_ring.remote.notice.response.NoticeResponse
 import com.ku_stacks.ku_ring.util.DateUtil
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 
 @OptIn(ExperimentalPagingApi::class)
 class CategoryNoticeMediator(
@@ -36,7 +37,7 @@ class CategoryNoticeMediator(
             return MediatorResult.Success(endOfPaginationReached = page != null)
         }
 
-        return runCatching {
+        return suspendRunCatching {
             val noticeResponse = noticeClient.fetchNoticeList(categoryShortName, page, itemSize)
             insertNotices(noticeResponse.noticeResponse)
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.remote.user
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.remote.user.request.RegisterUserRequest
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import javax.inject.Inject
 
 class UserClient @Inject constructor(
@@ -22,7 +23,7 @@ class UserClient @Inject constructor(
         userService.registerUser(RegisterUserRequest(token))
 
     suspend fun getKuringBotQueryCount(token: String): Int {
-        return runCatching {
+        return suspendRunCatching {
             userService.getKuringBotQueryCount(token).data.leftAskCount
         }.getOrElse { 0 }
     }

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.remote.user.UserClient
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -33,7 +34,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun sendFeedback(feedback: String): Result<DefaultResponse> {
-        return runCatching {
+        return suspendRunCatching {
             userClient.sendFeedback(
                 token = pref.fcmToken,
                 feedbackRequest = FeedbackRequest(feedback)

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionViewModel.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/EditSubscriptionViewModel.kt
@@ -13,6 +13,7 @@ import com.ku_stacks.ku_ring.thirdparty.firebase.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.util.WordConverter
 import com.ku_stacks.ku_ring.util.modifyList
 import com.ku_stacks.ku_ring.util.modifyMap
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -83,7 +84,7 @@ class EditSubscriptionViewModel @Inject constructor(
     private fun syncWithServer() {
         fcmToken?.let {
             viewModelScope.launch {
-                runCatching {
+                suspendRunCatching {
                     val subscribingList = noticeRepository.fetchSubscriptionFromRemote(it)
                     initialSortSubscription(subscribingList)
                 }.onFailure {

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.domain.WebViewNotice
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
+import com.ku_stacks.ku_ring.util.suspendRunCatching
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -33,7 +34,7 @@ class NoticeWebViewModel @Inject constructor(
 
     fun updateNoticeTobeRead(webViewNotice: WebViewNotice) {
         viewModelScope.launch {
-            runCatching {
+            suspendRunCatching {
                 noticeRepository.updateNoticeToBeReadOnStorage(webViewNotice.articleId, webViewNotice.category)
                 noticeRepository.updateNoticeToBeRead(
                     webViewNotice.articleId,


### PR DESCRIPTION
## TL;DR

- https://github.com/Kotlin/kotlinx.coroutines/issues/1814

## 이슈 설명

- 코루틴의 구조화 동시성의 구조상 한 Job이 캔슬되면 다른 잡이 캔슬되도록 만들어야 함. 그 구조가 Exception(CancellationException)을 다른 코루틴 잡에서 핸들링해서 터뜨리는 구조인데
- 현재 구조를 보았을 때 이런 구조화 동시성이 제대로 동작하지 않도록 사용이 되고 있어, 원하지 않은 동작으로 돌아갈 수 있음 (runCatching은 모든 에러를 다 캐치하도록 되어있음)
- 따라서 위의 제안해준 구조를 바탕으로 suspend 함수에서 runCatching 사용을 제거하고자 함