### PR TITLE
kuring-230 공지 댓글 UI 추가

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -1,0 +1,183 @@
+package com.ku_stacks.ku_ring.designsystem.components.comment
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.R
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.domain.NoticeComment
+import com.ku_stacks.ku_ring.domain.PlainNoticeComment
+
+@Composable
+fun Comment(
+    comment: NoticeComment,
+    onReplyIconClick: () -> Unit,
+    onDeleteComment: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.background(KuringTheme.colors.background),
+    ) {
+        Comment(
+            comment = comment.comment,
+            onReplyIconClick = onReplyIconClick,
+            onDeleteComment = onDeleteComment,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        comment.replies.forEach { reply ->
+            Row(modifier = Modifier.padding(top = 6.dp, end = 7.dp, bottom = 6.dp)) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_reply_v2),
+                    contentDescription = null,
+                    tint = KuringTheme.colors.gray300,
+                    modifier = Modifier
+                        .padding(start = 7.dp, top = 16.dp, end = 3.dp)
+                        .size(24.dp),
+                )
+                Comment(
+                    comment = reply,
+                    onReplyIconClick = onReplyIconClick,
+                    onDeleteComment = onDeleteComment,
+                    modifier = Modifier.background(
+                        color = KuringTheme.colors.gray100,
+                        shape = RoundedCornerShape(20.dp),
+                    ),
+                    contentPadding = PaddingValues(horizontal = 17.dp, vertical = 9.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun Comment(
+    comment: PlainNoticeComment,
+    onReplyIconClick: () -> Unit,
+    onDeleteComment: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 20.dp, vertical = 15.dp),
+) {
+    Column(
+        modifier = modifier
+            .padding(contentPadding)
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        CommentHeader(
+            commentId = comment.id,
+            username = comment.authorName,
+            onReplyIconClick = onReplyIconClick,
+            onDeleteComment = onDeleteComment,
+        )
+        Text(
+            text = comment.content,
+            style = TextStyle(
+                fontSize = 12.sp,
+                lineHeight = 18.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.gray400,
+            )
+        )
+        Text(
+            text = comment.postedDatetime,
+            style = TextStyle(
+                fontSize = 10.sp,
+                lineHeight = 16.3.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.textCaption1,
+            )
+        )
+    }
+}
+
+@Composable
+private fun CommentHeader(
+    commentId: Int,
+    username: String,
+    onReplyIconClick: () -> Unit,
+    onDeleteComment: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_user_v2),
+            contentDescription = null,
+            tint = KuringTheme.colors.gray300,
+        )
+        Text(
+            text = username,
+            style = TextStyle(
+                fontSize = 15.sp,
+                lineHeight = 24.45.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.textBody,
+            )
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_message_circle_v2),
+            contentDescription = stringResource(R.string.comment_reply_icon),
+            modifier = Modifier.clickable { onReplyIconClick() },
+            tint = KuringTheme.colors.textBody,
+        )
+        // TODO: 자기 댓글에만 보여주기?
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
+            contentDescription = stringResource(R.string.comment_delete),
+            modifier = Modifier.clickable { onDeleteComment(commentId) },
+            tint = KuringTheme.colors.textBody,
+        )
+    }
+}
+
+private val previewComment = PlainNoticeComment(
+    id = 0,
+    parentNoticeId = 0,
+    authorId = 0,
+    authorName = "쿠링",
+    noticeId = 0,
+    content = "쿠링 댓글 내용".repeat(10),
+    postedDatetime = "2025.03.23 20:27",
+    updatedDatetime = "2025.03.23 20:27",
+)
+
+@LightAndDarkPreview
+@Composable
+private fun CommentPreview() {
+    KuringTheme {
+        Comment(
+            comment = NoticeComment(
+                comment = previewComment,
+                replies = List(3) { previewComment },
+                hasNext = false,
+            ),
+            onReplyIconClick = {},
+            onDeleteComment = {},
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxWidth(),
+        )
+    }
+}

--- a/core/designsystem/src/main/res/drawable/ic_message_circle_v2.xml
+++ b/core/designsystem/src/main/res/drawable/ic_message_circle_v2.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M19.5,11.583C19.503,12.683 19.246,13.768 18.75,14.75C18.162,15.927 17.258,16.916 16.139,17.608C15.021,18.299 13.732,18.666 12.417,18.667C11.317,18.67 10.232,18.413 9.25,17.917L4.5,19.5L6.083,14.75C5.587,13.768 5.33,12.683 5.333,11.583C5.334,10.268 5.701,8.979 6.392,7.86C7.084,6.742 8.074,5.838 9.25,5.25C10.232,4.754 11.317,4.497 12.417,4.5H12.833C14.57,4.596 16.211,5.329 17.441,6.559C18.671,7.789 19.404,9.43 19.5,11.167V11.583Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_reply_v2.xml
+++ b/core/designsystem/src/main/res/drawable/ic_reply_v2.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="19dp"
+    android:viewportWidth="13"
+    android:viewportHeight="19">
+    <path
+        android:pathData="M1.02,1.585L1.02,12.596"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M12.031,12.597L1.02,12.597"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M12.316,12.882L7.311,7.877"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M12.316,12.882L7.311,17.887"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_user_v2.xml
+++ b/core/designsystem/src/main/res/drawable/ic_user_v2.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M18.667,19.5V17.833C18.667,16.949 18.316,16.101 17.691,15.476C17.065,14.851 16.218,14.5 15.333,14.5H8.667C7.783,14.5 6.935,14.851 6.31,15.476C5.685,16.101 5.333,16.949 5.333,17.833V19.5"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M12,11.167C13.841,11.167 15.333,9.674 15.333,7.833C15.333,5.992 13.841,4.5 12,4.5C10.159,4.5 8.667,5.992 8.667,7.833C8.667,9.674 10.159,11.167 12,11.167Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#999999"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="notice_refresh_error_message">공지 로드 중 에러가 발생했어요.\n잠시 후 다시 시도해 주세요.</string>
     <string name="webview_url_null">페이지 로드 중 에러가 발생했어요.\n잠시 후 다시 시도해 주세요.</string>
 
+    <string name="comment_reply_icon">대댓글 달기</string>
+    <string name="comment_delete">댓글 삭제하기</string>
+
     <!-- re-engagement notification -->
     <string name="reengagement_title">공지를 일주일 이상 확인하지 않았어요!</string>
     <string name="reengagement_body">놓친 공지가 있는지 확인해보세요 🔔</string>

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/NoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/NoticeComment.kt
@@ -1,0 +1,7 @@
+package com.ku_stacks.ku_ring.domain
+
+data class NoticeComment(
+    val comment: PlainNoticeComment,
+    val replies: List<PlainNoticeComment>,
+    val hasNext: Boolean,
+)

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -9,5 +9,5 @@ data class PlainNoticeComment(
     val content: String,
     val postedDatetime: String,
     val updatedDatetime: String,
-    // Field "destroyedAt" is not used now. Add when needed.
+    // TODO: Field "destroyedAt" is not used now. Add when needed.
 )

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -1,0 +1,13 @@
+package com.ku_stacks.ku_ring.domain
+
+data class PlainNoticeComment(
+    val id: Int,
+    val parentNoticeId: Int,
+    val authorId: Int,
+    val authorName: String,
+    val noticeId: Int,
+    val content: String,
+    val postedDatetime: String,
+    val updatedDatetime: String,
+    // Field "destroyedAt" is not used now. Add when needed.
+)

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -1,0 +1,72 @@
+package com.ku_stacks.ku_ring.notice_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.domain.NoticeComment
+import com.ku_stacks.ku_ring.notice_detail.R
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Composable
+internal fun CommentsBottomSheet(
+    comments: LazyPagingItems<NoticeComment>?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.comment_bottom_sheet_title),
+            style = TextStyle(
+                fontSize = 18.sp,
+                lineHeight = 26.64.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(600),
+                color = KuringTheme.colors.textTitle,
+            ),
+            modifier = Modifier.padding(vertical = 10.dp),
+        )
+        LazyPagingCommentColumn(
+            comments = comments,
+            onReplyIconClick = { /* TODO: implement */ },
+            onDeleteIconClick = { /* TODO: implement */ },
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .weight(1f),
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun CommentsBottomSheetPreview() {
+    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments))
+    val fakePagingData = fakeDataFlow.collectAsLazyPagingItems()
+
+    KuringTheme {
+        CommentsBottomSheet(
+            comments = fakePagingData,
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
+        )
+    }
+}

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -58,7 +58,7 @@ internal fun CommentsBottomSheet(
 @LightAndDarkPreview
 @Composable
 private fun CommentsBottomSheetPreview() {
-    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments))
+    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments(10)))
     val fakePagingData = fakeDataFlow.collectAsLazyPagingItems()
 
     KuringTheme {

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -112,7 +112,7 @@ fun LazyPagingCommentColumn(
 @LightAndDarkPreview
 @Composable
 private fun LazyPagingCommentColumnPreview() {
-    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments))
+    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments(10)))
     val fakePagingData = fakeDataFlow.collectAsLazyPagingItems()
     KuringTheme {
         LazyPagingCommentColumn(

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -1,0 +1,119 @@
+package com.ku_stacks.ku_ring.notice_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.components.comment.Comment
+import com.ku_stacks.ku_ring.designsystem.components.indicator.PagingLoadingIndicator
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.domain.NoticeComment
+import com.ku_stacks.ku_ring.notice_detail.R
+import kotlinx.coroutines.flow.MutableStateFlow
+
+// TODO: LazyNoticeItemColumn과 일반화
+
+@Composable
+fun LazyPagingCommentColumn(
+    comments: LazyPagingItems<NoticeComment>?,
+    onReplyIconClick: () -> Unit,
+    onDeleteIconClick: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier
+            .background(KuringTheme.colors.background)
+            .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        when (comments?.loadState?.refresh) {
+            LoadState.Loading -> {
+                item {
+                    PagingLoadingIndicator(
+                        modifier = Modifier.size(50.dp),
+                    )
+                }
+            }
+
+            is LoadState.Error -> {
+                item {
+                    Text(
+                        text = stringResource(id = R.string.comment_bottom_sheet_error_loading),
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.Normal,
+                        fontSize = 14.sp,
+                        color = colorResource(id = R.color.kus_label),
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+
+            else -> {
+                comments?.let { comments ->
+                    items(
+                        count = comments.itemCount,
+                        key = comments.itemKey { it.comment.id },
+                        contentType = comments.itemContentType { it.javaClass },
+                    ) { index ->
+                        comments[index]?.let { comment ->
+                            val borderColor = KuringTheme.colors.gray600
+                            Comment(
+                                comment = comment,
+                                onReplyIconClick = onReplyIconClick,
+                                onDeleteComment = onDeleteIconClick,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .drawBehind {
+                                        drawLine(
+                                            color = borderColor,
+                                            start = Offset(0f, size.height),
+                                            end = Offset(size.width, size.height),
+                                            strokeWidth = 1.dp.toPx(),
+                                        )
+                                    },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun LazyPagingCommentColumnPreview() {
+    val fakeDataFlow = MutableStateFlow(PagingData.from(fakeComments))
+    val fakePagingData = fakeDataFlow.collectAsLazyPagingItems()
+    KuringTheme {
+        LazyPagingCommentColumn(
+            comments = fakePagingData,
+            onReplyIconClick = {},
+            onDeleteIconClick = {},
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
+        )
+    }
+}

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -95,6 +95,14 @@ fun LazyPagingCommentColumn(
                             )
                         }
                     }
+
+                    if (comments.loadState.append == LoadState.Loading) {
+                        item {
+                            PagingLoadingIndicator(
+                                modifier = Modifier.size(40.dp),
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
@@ -14,10 +14,12 @@ internal val fakePlainComment = PlainNoticeComment(
     updatedDatetime = "2025.03.23 20:27",
 )
 internal const val size = 10
-internal val fakeComments = List(size) { index ->
-    NoticeComment(
-        comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
-        replies = List(2) { fakePlainComment.copy(id = index * 10 + it) },
-        hasNext = (index == size - 1),
-    )
+internal val fakeComments: (Int) -> List<NoticeComment> = { size ->
+    List(size) { index ->
+        NoticeComment(
+            comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
+            replies = List(2) { fakePlainComment.copy(id = index * 10 + it) },
+            hasNext = (index == size - 1),
+        )
+    }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
@@ -1,0 +1,23 @@
+package com.ku_stacks.ku_ring.notice_detail.component
+
+import com.ku_stacks.ku_ring.domain.NoticeComment
+import com.ku_stacks.ku_ring.domain.PlainNoticeComment
+
+internal val fakePlainComment = PlainNoticeComment(
+    id = 0,
+    parentNoticeId = 0,
+    authorId = 0,
+    authorName = "쿠링",
+    noticeId = 0,
+    content = "쿠링 댓글 내용".repeat(10),
+    postedDatetime = "2025.03.23 20:27",
+    updatedDatetime = "2025.03.23 20:27",
+)
+internal const val size = 10
+internal val fakeComments = List(size) { index ->
+    NoticeComment(
+        comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
+        replies = List(2) { fakePlainComment.copy(id = index * 10 + it) },
+        hasNext = (index == size - 1),
+    )
+}

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -7,4 +7,9 @@
     <string name="download_success">다운로드가 완료되었어요</string>
     <string name="download_fail">다운로드에 실패했어요</string>
     <string name="share_externally_description">공유하기</string>
+
+    <!--  Comment resources  -->
+    <string name="see_comment">댓글 보기</string>
+    <string name="comment_bottom_sheet_title">댓글</string>
+    <string name="comment_bottom_sheet_error_loading">댓글 로드 중 에러가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-230?atlOrigin=eyJpIjoiM2VhMDVjMmQxNmQ3NDcxZGI1YWJhMTU4ZmRhOWI1N2IiLCJwIjoiaiJ9

## 요약

공지 댓글 UI 컴포넌트를 추가했습니다.

## 상세

공지 아이템, 대댓글 아이템, 바텀시트까지 작업했습니다. 데이터 로직 연결은 다음 PR에서 진행합니다.

![image](https://github.com/user-attachments/assets/620cc1e8-a211-4836-9159-79f67a832f7c)
