### PR TITLE
ui: 회원가입 UI 구현

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.ku_stacks.ku_ring.R
+import com.ku_stacks.ku_ring.auth.AuthActivity
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.domain.WebViewNotice
 import com.ku_stacks.ku_ring.domain.mapper.toWebViewNotice
@@ -99,5 +100,9 @@ class KuringNavigatorImpl @Inject constructor() : KuringNavigator {
 
     override fun navigateToLibrarySeat(activity: Activity) {
         LibrarySeatActivity.start(activity)
+    }
+
+    override fun navigateToAuth(activity: Activity) {
+        AuthActivity.start(activity)
     }
 }

--- a/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
+++ b/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
@@ -29,4 +29,5 @@ interface KuringNavigator {
     fun navigateToOssLicensesMenu(activity: Activity)
     fun navigateToKuringBot(context: Context)
     fun navigateToLibrarySeat(activity: Activity)
+    fun navigateToAuth(activity: Activity)
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
@@ -6,9 +6,14 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.ui.Modifier
 import com.ku_stacks.ku_ring.auth.compose.AuthScreen
 import com.ku_stacks.ku_ring.feature.auth.R
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AuthActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -16,7 +21,10 @@ class AuthActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContent {
             AuthScreen(
-                onNavigateUp = this::finish
+                onNavigateUp = this::finish,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .navigationBarsPadding()
             )
         }
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthDestination.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthDestination.kt
@@ -1,0 +1,39 @@
+package com.ku_stacks.ku_ring.auth.compose
+
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hasRoute
+import kotlinx.serialization.Serializable
+
+
+internal sealed interface AuthDestination {
+    @Serializable
+    data object SignIn : AuthDestination
+
+    @Serializable
+    data object SignUp : AuthDestination
+
+    @Serializable
+    data object SignUpTermsAndConditions : AuthDestination
+
+    @Serializable
+    data object SignUpEmailVerification : AuthDestination
+
+    @Serializable
+    data object SignUpPasswordSet : AuthDestination
+
+    @Serializable
+    data object SignUpComplete : AuthDestination
+
+    companion object {
+        fun getOrder(route: NavDestination): Int =
+            when {
+                route.hasRoute(SignIn::class) -> 0
+                route.hasRoute(SignUp::class) -> 1
+                route.hasRoute(SignUpTermsAndConditions::class) -> 2
+                route.hasRoute(SignUpEmailVerification::class) -> 3
+                route.hasRoute(SignUpPasswordSet::class) -> 4
+                route.hasRoute(SignUpComplete::class) -> 5
+                else -> 6
+            }
+    }
+}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
@@ -12,8 +12,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.ku_stacks.ku_ring.auth.compose.signin.signInNavGraph
 import com.ku_stacks.ku_ring.auth.compose.signup.signUpNavGraph
-import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
-import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 
 @Composable
 internal fun AuthScreen(
@@ -58,11 +56,3 @@ internal fun animationDirection(initialState: NavBackStackEntry, targetState: Na
 
 internal val NavBackStackEntry.screenOrder: Int
     get() = AuthDestination.getOrder(destination)
-
-@LightAndDarkPreview
-@Composable
-private fun AuthScreenPreview() {
-    KuringTheme {
-        AuthScreen(onNavigateUp = {})
-    }
-}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
@@ -1,13 +1,19 @@
 package com.ku_stacks.ku_ring.auth.compose
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
-import com.ku_stacks.ku_ring.auth.compose.signin.SignInDestination
 import com.ku_stacks.ku_ring.auth.compose.signin.signInNavGraph
+import com.ku_stacks.ku_ring.auth.compose.signup.signUpNavGraph
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 
 @Composable
 internal fun AuthScreen(
@@ -15,16 +21,55 @@ internal fun AuthScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
 ) {
+    val navigationSpec = tween<IntOffset>(durationMillis = 200)
+
     NavHost(
         navController = navController,
-        startDestination = SignInDestination.SignIn,
+        startDestination = AuthDestination.SignIn,
+        enterTransition = {
+            slideIntoContainer(
+                towards = animationDirection(initialState, targetState),
+                animationSpec = navigationSpec,
+            )
+        },
+        exitTransition = {
+            slideOutOfContainer(
+                towards = animationDirection(initialState, targetState),
+                animationSpec = navigationSpec,
+            )
+        },
         modifier = modifier.fillMaxSize()
     ) {
         signInNavGraph(
             onNavigateUp = onNavigateUp,
-            onNavigateToMain = { }, //TODO: 로그인으로 진입하기 전 화면으로 이동
-            onNavigateToSignUp = { }, // TODO: 회원가입 화면으로 이동
-            onNavigateToFindPassword = {},  //TODO: 비밀번호 찾기 화면으로 이동
+            onNavigateToMain = navController::navigateUp,
+            onNavigateToSignUp = { navController.navigate(AuthDestination.SignUp) },
+            onNavigateToFindPassword = { },  //TODO: 비밀번호 찾기 화면으로 이동
         )
+
+        signUpNavGraph(
+            navController = navController,
+            onSignUpComplete = {
+                navController.popBackStack(AuthDestination.SignIn, inclusive = false)
+            },
+        )
+    }
+}
+
+internal fun animationDirection(initialState: NavBackStackEntry, targetState: NavBackStackEntry) =
+    if (initialState.screenOrder < targetState.screenOrder) {
+        AnimatedContentTransitionScope.SlideDirection.Left
+    } else {
+        AnimatedContentTransitionScope.SlideDirection.Right
+    }
+
+internal val NavBackStackEntry.screenOrder: Int
+    get() = AuthDestination.getOrder(destination)
+
+@LightAndDarkPreview
+@Composable
+private fun AuthScreenPreview() {
+    KuringTheme {
+        AuthScreen(onNavigateUp = {})
     }
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
@@ -41,18 +41,11 @@ internal fun AuthScreen(
         modifier = modifier.fillMaxSize()
     ) {
         signInNavGraph(
+            navController = navController,
             onNavigateUp = onNavigateUp,
-            onNavigateToMain = navController::navigateUp,
-            onNavigateToSignUp = { navController.navigate(AuthDestination.SignUp) },
-            onNavigateToFindPassword = { },  //TODO: 비밀번호 찾기 화면으로 이동
         )
 
-        signUpNavGraph(
-            navController = navController,
-            onSignUpComplete = {
-                navController.popBackStack(AuthDestination.SignIn, inclusive = false)
-            },
-        )
+        signUpNavGraph(navController = navController)
     }
 }
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/EmailInputGroup.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/EmailInputGroup.kt
@@ -27,7 +27,7 @@ private const val TEXT_FIELD_WEIGHT = 210 / 375f
 private const val BUTTON_WEIGHT = 114 / 375f
 
 @Composable
-internal fun EmailInputField(
+internal fun EmailInputGroup(
     text: String,
     onTextChange: (String) -> Unit,
     onSendButtonClick: () -> Unit,
@@ -73,7 +73,7 @@ private fun EmailInputFieldPreview() {
     var isCodeSent by remember { mutableStateOf(false) }
 
     KuringTheme {
-        EmailInputField(
+        EmailInputGroup(
             text = email,
             onTextChange = { email = it },
             onSendButtonClick = { isCodeSent = !isCodeSent },

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInDestination.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInDestination.kt
@@ -1,8 +1,0 @@
-package com.ku_stacks.ku_ring.auth.compose.signin
-
-import kotlinx.serialization.Serializable
-
-sealed interface SignInDestination {
-    @Serializable
-    data object SignIn: SignInDestination
-}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
@@ -2,7 +2,7 @@ package com.ku_stacks.ku_ring.auth.compose.signin
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.dialog
+import com.ku_stacks.ku_ring.auth.compose.AuthDestination
 import com.ku_stacks.ku_ring.auth.compose.signin.inner_screen.SignInScreen
 
 internal fun NavGraphBuilder.signInNavGraph(
@@ -11,7 +11,7 @@ internal fun NavGraphBuilder.signInNavGraph(
     onNavigateToSignUp: () -> Unit,
     onNavigateToFindPassword: () -> Unit,
 ) {
-    composable<SignInDestination.SignIn> {
+    composable<AuthDestination.SignIn> {
         SignInScreen(
             onNavigateUp = onNavigateUp,
             onNavigateToMain = onNavigateToMain,

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
@@ -1,22 +1,21 @@
 package com.ku_stacks.ku_ring.auth.compose.signin
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.ku_stacks.ku_ring.auth.compose.AuthDestination
 import com.ku_stacks.ku_ring.auth.compose.signin.inner_screen.SignInScreen
 
 internal fun NavGraphBuilder.signInNavGraph(
+    navController: NavHostController,
     onNavigateUp: () -> Unit,
-    onNavigateToMain: () -> Unit,
-    onNavigateToSignUp: () -> Unit,
-    onNavigateToFindPassword: () -> Unit,
 ) {
     composable<AuthDestination.SignIn> {
         SignInScreen(
             onNavigateUp = onNavigateUp,
-            onNavigateToMain = onNavigateToMain,
-            onNavigateToSignUp = onNavigateToSignUp,
-            onNavigateToFindPassword = onNavigateToFindPassword,
+            onNavigateToMain = navController::navigateUp,
+            onNavigateToSignUp = { navController.navigate(AuthDestination.SignUp) },
+            onNavigateToFindPassword = { },  //TODO: 비밀번호 찾기 화면으로 이동
         )
     }
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpNavigation.kt
@@ -11,7 +11,6 @@ import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.SignUpCompleteScre
 import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.TermsAndConditionsScreen
 
 internal fun NavGraphBuilder.signUpNavGraph(
-    onSignUpComplete: () -> Unit,
     navController: NavHostController,
 ) {
     navigation<AuthDestination.SignUp>(
@@ -43,7 +42,9 @@ internal fun NavGraphBuilder.signUpNavGraph(
         }
         composable<AuthDestination.SignUpComplete> {
             SignUpCompleteScreen(
-                onNavigateToSignIn = onSignUpComplete,
+                onNavigateToSignIn = {
+                    navController.popBackStack(AuthDestination.SignIn, inclusive = false)
+                },
             )
         }
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpNavigation.kt
@@ -1,0 +1,52 @@
+package com.ku_stacks.ku_ring.auth.compose.signup
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import com.ku_stacks.ku_ring.auth.compose.AuthDestination
+import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.EmailVerificationScreen
+import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.PasswordSetScreen
+import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.SignUpCompleteScreen
+import com.ku_stacks.ku_ring.auth.compose.signup.inner_screen.TermsAndConditionsScreen
+
+internal fun NavGraphBuilder.signUpNavGraph(
+    onSignUpComplete: () -> Unit,
+    navController: NavHostController,
+) {
+    navigation<AuthDestination.SignUp>(
+        startDestination = AuthDestination.SignUpTermsAndConditions,
+    ) {
+        composable<AuthDestination.SignUpTermsAndConditions> {
+            TermsAndConditionsScreen(
+                onNavigateUp = navController::navigateUp,
+                onNavigateToEmailVerification = {
+                    navController.navigate(AuthDestination.SignUpEmailVerification)
+                },
+            )
+        }
+        composable<AuthDestination.SignUpEmailVerification> {
+            EmailVerificationScreen(
+                onNavigateUp = navController::navigateUp,
+                onNavigateToPassword = {
+                    navController.navigate(AuthDestination.SignUpPasswordSet)
+                },
+            )
+        }
+        composable<AuthDestination.SignUpPasswordSet> {
+            PasswordSetScreen(
+                onNavigateUp = navController::navigateUp,
+                onNavigateToSignUpComplete = {
+                    navController.navigate(AuthDestination.SignUpComplete)
+                },
+            )
+        }
+        composable<AuthDestination.SignUpComplete> {
+            SignUpCompleteScreen(
+                onNavigateToSignIn = onSignUpComplete,
+            )
+        }
+    }
+}
+
+

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
@@ -1,0 +1,170 @@
+package com.ku_stacks.ku_ring.auth.compose.signup.inner_screen
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.auth.compose.component.CodeInputField
+import com.ku_stacks.ku_ring.auth.compose.component.EmailInputGroup
+import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
+import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_button_proceed
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_navigate_to_ku_mail
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_top_bar_heading
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_top_bar_sub_heading
+
+
+@Composable
+internal fun EmailVerificationScreen(
+    onNavigateUp: () -> Unit,
+    onNavigateToPassword: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var email by remember { mutableStateOf("") }
+    var code by remember { mutableStateOf("") }
+    var isCodeSent by remember { mutableStateOf(false) }
+    var isVerified by remember { mutableStateOf(false) }
+
+    EmailVerificationScreen(
+        email = email,
+        code = code,
+        isCodeSent = isCodeSent,
+        isVerified = isVerified,
+        onEmailChange = { email = it },
+        onCodeChange = { code = it },
+        onSendCodeClick = { isCodeSent = !isCodeSent },
+        onVerifyCodeClick = { isVerified = !isVerified },
+        onBackButtonClick = onNavigateUp,
+        onKuMailClick = {},
+        onProceedButtonClick = onNavigateToPassword,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun EmailVerificationScreen(
+    email: String,
+    code: String,
+    isCodeSent: Boolean,
+    isVerified: Boolean,
+    onEmailChange: (String) -> Unit,
+    onCodeChange: (String) -> Unit,
+    onSendCodeClick: () -> Unit,
+    onVerifyCodeClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    onKuMailClick: () -> Unit,
+    onProceedButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KuringTheme.colors.background)
+    ) {
+        AuthTopBar(
+            headingText = stringResource(sign_up_top_bar_heading),
+            subHeadingText = stringResource(sign_up_top_bar_sub_heading),
+            onBackButtonClick = onBackButtonClick,
+        )
+
+        EmailInputGroup(
+            text = email,
+            onTextChange = onEmailChange,
+            onSendButtonClick = onSendCodeClick,
+            isCodeSent = isCodeSent,
+            modifier = Modifier
+                .padding(top = 45.dp)
+        )
+
+        AnimatedVisibility(
+            visible = isCodeSent,
+            enter = fadeIn(),
+            exit = fadeOut()
+        ) {
+            CodeInputField(
+                text = code,
+                onTextChange = onCodeChange,
+                onVerifyButtonClick = onVerifyCodeClick,
+                modifier = Modifier
+                    .padding(top = 8.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Text(
+            text = stringResource(sign_up_navigate_to_ku_mail),
+            style = TextStyle(
+                fontSize = 16.sp,
+                lineHeight = 24.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight.Medium,
+                color = KuringTheme.colors.textCaption1
+            ),
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onKuMailClick,
+                ),
+        )
+
+        KuringCallToAction(
+            text = stringResource(sign_up_button_proceed),
+            onClick = onProceedButtonClick,
+            enabled = isVerified,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun EmailVerificationScreenPreview() {
+    KuringTheme {
+        var email by remember { mutableStateOf("") }
+        var code by remember { mutableStateOf("") }
+        var isCodeSent by remember { mutableStateOf(false) }
+        var isVerified by remember { mutableStateOf(false) }
+
+        EmailVerificationScreen(
+            email = email,
+            code = code,
+            isCodeSent = isCodeSent,
+            isVerified = isVerified,
+            onEmailChange = { email = it },
+            onCodeChange = { code = it },
+            onSendCodeClick = { isCodeSent = !isCodeSent },
+            onVerifyCodeClick = { isVerified = !isVerified },
+            onBackButtonClick = { },
+            onKuMailClick = {},
+            onProceedButtonClick = { },
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
@@ -1,0 +1,141 @@
+package com.ku_stacks.ku_ring.auth.compose.signup.inner_screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedSupportingTextField
+import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
+import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
+import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_button_proceed
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_placeholder_password
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_placeholder_password_check
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_supporting_text_not_equal
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_supporting_text_wrong
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_top_bar_heading
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_top_bar_sub_heading
+
+@Composable
+internal fun PasswordScreen(
+    onNavigateUp: () -> Unit,
+    onNavigateToSignUpComplete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PasswordScreen(
+        password = "",
+        passwordCheck = "",
+        passwordTextFieldState = OutlinedTextFieldState.Empty,
+        passwordCheckTextFieldState = OutlinedTextFieldState.Empty,
+        isPasswordChecked = false,
+        onBackButtonClick = onNavigateUp,
+        onPasswordChange = {},
+        onPasswordCheckChange = {},
+        onProceedButtonClick = onNavigateToSignUpComplete,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun PasswordScreen(
+    password: String,
+    passwordCheck: String,
+    passwordTextFieldState: OutlinedTextFieldState,
+    passwordCheckTextFieldState: OutlinedTextFieldState,
+    isPasswordChecked: Boolean,
+    onBackButtonClick: () -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onPasswordCheckChange: (String) -> Unit,
+    onProceedButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KuringTheme.colors.background)
+    ) {
+        AuthTopBar(
+            headingText = stringResource(sign_up_password_top_bar_heading),
+            subHeadingText = stringResource(sign_up_password_top_bar_sub_heading),
+            onBackButtonClick = onBackButtonClick
+        )
+
+        OutlinedSupportingTextField(
+            query = password,
+            onQueryUpdate = onPasswordChange,
+            textFieldState = passwordTextFieldState,
+            placeholderText = stringResource(sign_up_password_placeholder_password),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 20.dp, top = 45.dp),
+        )
+
+        OutlinedSupportingTextField(
+            query = passwordCheck,
+            onQueryUpdate = onPasswordCheckChange,
+            textFieldState = passwordCheckTextFieldState,
+            placeholderText = stringResource(sign_up_password_placeholder_password_check),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 20.dp, top = 8.dp),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        KuringCallToAction(
+            text = stringResource(sign_up_password_button_proceed),
+            onClick = onProceedButtonClick,
+            enabled = isPasswordChecked,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun PasswordScreenPreview() {
+    var password by remember { mutableStateOf("") }
+    var passwordCheck by remember { mutableStateOf("") }
+    val passwordTextFieldState = if (password.isNotBlank() && password.length < 6) {
+        OutlinedTextFieldState.Error(stringResource(sign_up_password_supporting_text_wrong))
+    } else if (password.isNotBlank() && password == passwordCheck) {
+        OutlinedTextFieldState.Correct("")
+    } else {
+        OutlinedTextFieldState.Empty
+    }
+    val passwordCheckTextFieldState = if (passwordCheck.isNotBlank() && password != passwordCheck) {
+        OutlinedTextFieldState.Error(stringResource(sign_up_password_supporting_text_not_equal))
+    } else if (passwordCheck.isNotBlank() && password == passwordCheck) {
+        OutlinedTextFieldState.Correct("")
+    } else {
+        OutlinedTextFieldState.Empty
+    }
+
+    KuringTheme {
+        PasswordScreen(
+            password = password,
+            passwordCheck = passwordCheck,
+            passwordTextFieldState = passwordTextFieldState,
+            passwordCheckTextFieldState = passwordCheckTextFieldState,
+            isPasswordChecked = (password == passwordCheck) && password.isNotEmpty(),
+            onBackButtonClick = {},
+            onPasswordChange = { password = it },
+            onPasswordCheckChange = { passwordCheck = it },
+            onProceedButtonClick = {},
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedSupportingTextField
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
@@ -80,6 +81,7 @@ private fun PasswordSetScreen(
             onQueryUpdate = onPasswordChange,
             textFieldState = passwordTextFieldState,
             placeholderText = stringResource(sign_up_password_placeholder_password),
+            visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 20.dp, end = 20.dp, top = 45.dp),
@@ -90,6 +92,7 @@ private fun PasswordSetScreen(
             onQueryUpdate = onPasswordCheckChange,
             textFieldState = passwordCheckTextFieldState,
             placeholderText = stringResource(sign_up_password_placeholder_password_check),
+            visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 20.dp, end = 20.dp, top = 8.dp),

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/PasswordSetScreen.kt
@@ -29,27 +29,30 @@ import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_top_bar_head
 import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_password_top_bar_sub_heading
 
 @Composable
-internal fun PasswordScreen(
+internal fun PasswordSetScreen(
     onNavigateUp: () -> Unit,
     onNavigateToSignUpComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    PasswordScreen(
-        password = "",
-        passwordCheck = "",
+    var password by remember { mutableStateOf("") }
+    var passwordCheck by remember { mutableStateOf("") }
+
+    PasswordSetScreen(
+        password = password,
+        passwordCheck = passwordCheck,
         passwordTextFieldState = OutlinedTextFieldState.Empty,
         passwordCheckTextFieldState = OutlinedTextFieldState.Empty,
-        isPasswordChecked = false,
+        isPasswordChecked = password == passwordCheck,
         onBackButtonClick = onNavigateUp,
-        onPasswordChange = {},
-        onPasswordCheckChange = {},
+        onPasswordChange = { password = it },
+        onPasswordCheckChange = { passwordCheck = it },
         onProceedButtonClick = onNavigateToSignUpComplete,
         modifier = modifier,
     )
 }
 
 @Composable
-private fun PasswordScreen(
+private fun PasswordSetScreen(
     password: String,
     passwordCheck: String,
     passwordTextFieldState: OutlinedTextFieldState,
@@ -126,7 +129,7 @@ private fun PasswordScreenPreview() {
     }
 
     KuringTheme {
-        PasswordScreen(
+        PasswordSetScreen(
             password = password,
             passwordCheck = passwordCheck,
             passwordTextFieldState = passwordTextFieldState,

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SignUpCompleteScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SignUpCompleteScreen.kt
@@ -1,0 +1,87 @@
+package com.ku_stacks.ku_ring.auth.compose.signup.inner_screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_complete_button_proceed
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_complete_heading
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_complete_sub_heading
+
+@Composable
+internal fun SignUpCompleteScreen(
+    onNavigateToSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(KuringTheme.colors.background),
+    ) {
+        Text(
+            text = stringResource(sign_up_complete_heading),
+            modifier = Modifier.padding(top = 124.dp),
+            style = TextStyle(
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                lineHeight = 34.sp,
+                color = KuringTheme.colors.textTitle,
+            )
+        )
+
+        Text(
+            text = stringResource(sign_up_complete_sub_heading),
+            modifier = Modifier.padding(top = 12.dp),
+            style = TextStyle(
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+                lineHeight = 24.sp,
+                color = KuringTheme.colors.textCaption1,
+            )
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        KuringCallToAction(
+            onClick = onNavigateToSignIn,
+            text = stringResource(sign_up_complete_button_proceed),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 10.dp),
+        )
+    }
+}
+
+//TODO: 구현 예정
+@Composable
+private fun SignUpCompleteAnimation(
+    modifier: Modifier = Modifier,
+) {
+
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SignUpCompleteScreenPreview() {
+    KuringTheme {
+        SignUpCompleteScreen(
+            onNavigateToSignIn = {},
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
@@ -1,0 +1,244 @@
+package com.ku_stacks.ku_ring.auth.compose.signup.inner_screen
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
+import com.ku_stacks.ku_ring.designsystem.R.drawable.ic_check_circle_fill_2_v2
+import com.ku_stacks.ku_ring.designsystem.R.drawable.ic_check_circle_fill_v2
+import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_conditions_body
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_conditions_button_proceed
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_conditions_request
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_conditions_request_approved
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_conditions_request_declined
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_top_bar_heading
+import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_top_bar_sub_heading
+
+
+@Composable
+internal fun TermsScreen(
+    onNavigateUp: () -> Unit,
+    onNavigateToEmailVerification: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isApproved by remember { mutableStateOf(false) }
+
+    TermsScreen(
+        isApproved = isApproved,
+        onRadioButtonClick = { isApproved = it },
+        onProceedButtonClick = onNavigateToEmailVerification,
+        onBackButtonClick = onNavigateUp,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TermsScreen(
+    isApproved: Boolean,
+    onRadioButtonClick: (Boolean) -> Unit,
+    onProceedButtonClick: () -> Unit,
+    onBackButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(KuringTheme.colors.background),
+    ) {
+        AuthTopBar(
+            headingText = stringResource(sign_up_terms_top_bar_heading),
+            subHeadingText = stringResource(sign_up_terms_top_bar_sub_heading),
+            onBackButtonClick = onBackButtonClick,
+        )
+
+        CompositionLocalProvider(
+            LocalOverscrollConfiguration provides null
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(start = 20.dp, end = 20.dp, top = 45.dp)
+                    .fillMaxWidth()
+                    .aspectRatio(1.15f)
+                    .border(width = 1.dp, color = KuringTheme.colors.gray200)
+                    .verticalScroll(scrollState),
+            ) {
+                Spacer(modifier = Modifier.padding(top = 18.dp))
+                Text(
+                    text = stringResource(sign_up_terms_conditions_body),
+                    style = TextStyle(
+                        fontSize = 15.sp,
+                        lineHeight = 24.sp,
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight(500),
+                        color = KuringTheme.colors.textCaption1,
+                    ),
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                )
+            }
+        }
+
+        UserGrantRadioButtonGroup(
+            isApproved = isApproved,
+            onClick = onRadioButtonClick,
+            modifier = Modifier.padding(top = 13.dp, start = 20.dp, end = 20.dp),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        KuringCallToAction(
+            text = stringResource(sign_up_terms_conditions_button_proceed),
+            onClick = onProceedButtonClick,
+            enabled = isApproved,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+internal fun UserGrantRadioButtonGroup(
+    isApproved: Boolean,
+    onClick: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Text(
+            text = stringResource(sign_up_terms_conditions_request),
+            style = TextStyle(
+                fontSize = 15.sp,
+                lineHeight = 24.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.textBody,
+            ),
+        )
+
+        UserGrantRadioButton(
+            selected = isApproved,
+            text = stringResource(sign_up_terms_conditions_request_approved),
+            onClick = { onClick(true) },
+        )
+
+        UserGrantRadioButton(
+            selected = !isApproved,
+            text = stringResource(sign_up_terms_conditions_request_declined),
+            onClick = { onClick(false) },
+        )
+    }
+}
+
+@Composable
+private fun UserGrantRadioButton(
+    selected: Boolean,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Crossfade(
+            targetState = selected,
+            modifier = Modifier.clickable { onClick() },
+            label = "department check/uncheck",
+        ) {
+            if (it) CheckIcon() else UncheckIcon()
+        }
+
+        Text(
+            text = text,
+            modifier = Modifier.padding(start = 8.dp),
+            style = TextStyle(
+                fontSize = 15.sp,
+                lineHeight = 24.sp,
+                fontFamily = Pretendard,
+                fontWeight = FontWeight(500),
+                color = KuringTheme.colors.textBody,
+            )
+        )
+    }
+}
+
+@Composable
+private fun CheckIcon(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    Icon(
+        painter = painterResource(ic_check_circle_fill_v2),
+        contentDescription = contentDescription,
+        tint = KuringTheme.colors.mainPrimary,
+        modifier = modifier
+            .size(24.dp)
+            .padding(2.dp),
+    )
+}
+
+@Composable
+private fun UncheckIcon(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    Icon(
+        painter = painterResource(ic_check_circle_fill_2_v2),
+        contentDescription = contentDescription,
+        tint = KuringTheme.colors.gray300,
+        modifier = modifier
+            .size(24.dp)
+            .padding(2.dp),
+    )
+}
+
+@LightAndDarkPreview
+@Composable
+private fun TermsScreenPreview() {
+    KuringTheme {
+        var selected by remember { mutableStateOf(false) }
+        TermsScreen(
+            isApproved = selected,
+            onRadioButtonClick = { selected = it },
+            onProceedButtonClick = {},
+            onBackButtonClick = {},
+        )
+    }
+}

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
@@ -50,7 +50,7 @@ import com.ku_stacks.ku_ring.feature.auth.R.string.sign_up_terms_top_bar_sub_hea
 
 
 @Composable
-internal fun TermsScreen(
+internal fun TermsAndConditionsScreen(
     onNavigateUp: () -> Unit,
     onNavigateToEmailVerification: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -23,4 +23,62 @@
     <string name="sign_in_button_sign_in">로그인</string>
     <string name="sign_in_extra_option_find_password">비밀번호 찾기</string>
     <string name="sign_in_extra_option_sign_up">회원가입 하기</string>
+
+    <!--SignUp Terms and Conditions Screen-->
+    <string name="sign_up_terms_top_bar_heading">개인정보 수집/이용 동의</string>
+    <string name="sign_up_terms_top_bar_sub_heading">회원가입 전 하단 유의사항을 확인하고,\n개인정보 수집 및 이용에 동의해주세요.</string>
+    <string name="sign_up_terms_conditions_request">[필수] 개인정보 수집/이용에 동의하십니까?</string>
+    <string name="sign_up_terms_conditions_request_approved">예</string>
+    <string name="sign_up_terms_conditions_request_declined">아니오</string>
+    <string name="sign_up_terms_conditions_button_proceed">다음</string>
+    <string name="sign_up_terms_conditions_body">[ 개인정보 수집/이용 및 제공에 대한 안내 ]
+        \n\'쿠링\'은 개인정보보호법에 의거 대학 구성원에게 대학의 공지사항을 제공하기 위해 필요한 개인정보를 수집하고 활용합니다. 그 외 목적으로 활용될 경우 정보주체에게 사전 고지되며, 활용에 동의한 범위와 기간에 한해 안전하게 제공, 처리 및 삭제됩니다.
+        \n\n1. 수집하는 개인정보의 항목
+        \n가. 쿠링은 계정생성, 각종 서비스의 제공을 위해 최초 계정생성 당시 아래와 같은 최소한의 개인정보를 필수항목으로 수집하고 있습니다.
+        \n- 학교 메일 아이디, 비밀번호
+        \n나. 서비스 이용과정에서 아래와 같은 정보들이 자동으로 생성되어 수집 및 이용될 수 있습니다.
+        \n- IP주소, 쿠키정보, 접속 일시, 이용 내역, 불량 이용 기록, 계정인증정보, 계정 사용자 정보 등
+        \n다. \‘쿠링\' 통합계정을 이용하는 서비스 이용과정에서 해당 서비스 이용자에 한해서만 개인정보 추가 수집이 발생할 수 있으며, 이러한 경우 별도의 동의를 받습니다.
+        \n2. 개인정보의 수집 및 이용 목적
+        \n가. 계정 생성
+        \n- 통합계정 서비스 제공, 컨텐츠 제공, 본인인증
+        \n나. 계정 관리
+        \n- 개인식별, 부정 이용방지와 비인가 사용방지
+        \n3. 개인정보의 보유 및 이용기간
+        \n이용자의 개인정보는 원칙적으로 개인정보의 수집 및 이용목적이 달성되면 지체 없이 파기합니다. 단, 다음의 정보에 대해서는 아래의 이유로 명시한 기간 동안 보존합니다.
+        \n가. 통합계정 서비스 이용
+        \n- 보존이유: 통합계정을 통한 서비스 제공
+        \n- 보존기간: 통합계정 서비스 지침에 따라 보존되며, 보존기간 만료 시 지체 없이 파기
+        \n4. 거부 권리 및 서비스 이용 제한
+        \n개인정보의 수집 및 이용 동의를 거부할 권리가 있으며, 동의 거부 시 서비스 이용이 제한됨.\n</string>
+
+    <!--SignUp Verification Screen-->
+    <string name="sign_up_top_bar_heading">재학생 인증 및 아이디 생성</string>
+    <string name="sign_up_top_bar_sub_heading">학교 이메일 계정으로 본교 학생임을 인증해주세요.\n이메일 주소는 아이디로 사용될 예정이에요.</string>
+    <string name="sign_up_placeholder_email">힉교 이메일 주소</string>
+    <string name="sign_up_placeholder_code">인증번호</string>
+    <string name="sign_up_supporting_text_email_duplicate">이미 등록된 이메일입니다.</string>
+    <string name="sign_up_supporting_text_email_unregistered">건국대학교 도메인을 사용해주세요.</string>
+    <string name="sign_up_supporting_text_code_error">올바르지 않은 인증번호에요.</string>
+    <string name="sign_up_supporting_text_code_correct">확인되었어요.</string>
+    <string name="sign_up_button_email">인증번호</string>
+    <string name="sign_up_button_email_resend">재전송</string>
+    <string name="sign_up_button_code">확인</string>
+    <string name="sign_up_navigate_to_ku_mail">학교 메일 바로가기 ></string>
+    <string name="sign_up_button_proceed">확인</string>
+
+    <!--SignUp Password Screen-->
+    <string name="sign_up_password_top_bar_heading">비밀번호 설정하기</string>
+    <string name="sign_up_password_top_bar_sub_heading">6~20자 영문 소문자, 숫자를 조합하여\n비밀번호를 생성해주세요:)</string>
+    <string name="sign_up_password_placeholder_password">비밀번호</string>
+    <string name="sign_up_password_placeholder_password_check">비밀번호 재확인</string>
+    <string name="sign_up_password_supporting_text_wrong">6~20자 영문 소문자, 숫자를 조합하여 입력해주세요.</string>
+    <string name="sign_up_password_supporting_text_not_equal">비밀번호가 일치하지 않습니다.</string>
+    <string name="sign_up_password_button_proceed">확인</string>
+
+    <!--SignUp Complete Screen-->
+    <string name="sign_up_complete_heading">회원가입이 완료되었어요!</string>
+    <string name="sign_up_complete_sub_heading">이어서 쿠링을 더 다채롭게 이용해보세요!</string>
+    <string name="sign_up_complete_button_proceed">로그인 후 쿠링 계속하기</string>
+
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-231?atlOrigin=eyJpIjoiZmUxMjU5MDg4NjI1NDEyOWFkODdlNjA1N2IzOTk1MTkiLCJwIjoiaiJ9

## 요약
- 회원가입 관련 UI 구현
   - 개인정보 수집 및 동의 0e2ffaca9f2ff2827935c09a75ed04b7bb62a38f
   - 재학생 인증 34c667629ade7d07ef97845671b99957645a30bb
   - 비밀번호 설정 8bd0d91aa2f48eb5c80237742a5a43a7c0515553
   - 회원가입 완료 3132a48ef75efe3ceec42d62fdcae001dde65e5a
- 화면 간 전환 구현
   - KuringNavigator에 AuthActivity 추가 5500ff499c69c8c11a5443ca0d050a57a0924bc8
   - `:feature:auth` 내 Navigation 구현 35dc2bf0a6d01c4b534b74724d6e3a6326a59cbf
   
## 영상
https://github.com/user-attachments/assets/6bc90aab-c0f4-4155-8fe8-b776d9c96e95

## 참고
- 서버 통신이나 값의 유효성을 확인하고, 그것에 따른 상태를 바꾸는 등의 로직을 제외한 UI 및 단순 로직 구현입니다.
- 추가적으로 화면 전환도 구현해뒀습니다.
- 근데 Jira 티켓 하나에 PR 여러 개 연결해도 되나요? 로그인에 이어서 회원가입을 동일한 티켓에 등록한 상태입니다,,

