### PR TITLE
kuring-235: 비밀번호 재설정 로직 

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_preview_close_v2.xml
+++ b/core/designsystem/src/main/res/drawable/ic_preview_close_v2.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M4.929,9C3.119,10.5 2,12 2,12C2,12 6.477,18 12,18C12.685,18 13.354,17.908 14,17.746M10.016,6.25C10.657,6.091 11.321,6 12,6C17.523,6 22,12 22,12C22,12 20.881,13.5 19.071,15"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#333333"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M10.157,10.311C9.749,10.755 9.5,11.349 9.5,12C9.5,13.381 10.619,14.5 12,14.5C12.681,14.5 13.299,14.227 13.75,13.785"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#333333"
+        android:strokeLineCap="round" />
+    <path
+        android:pathData="M21,21L3,3"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#333333"
+        android:strokeLineCap="round" />
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_preview_open_v2.xml
+++ b/core/designsystem/src/main/res/drawable/ic_preview_open_v2.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M12,18C17.523,18 22,12 22,12C22,12 17.523,6 12,6C6.477,6 2,12 2,12C2,12 6.477,18 12,18Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#333333" />
+    <path
+        android:pathData="M12,14.5C13.381,14.5 14.5,13.381 14.5,12C14.5,10.619 13.381,9.5 12,9.5C10.619,9.5 9.5,10.619 9.5,12C9.5,13.381 10.619,14.5 12,14.5Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.25"
+        android:fillColor="#00000000"
+        android:strokeColor="#333333" />
+</vector>

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -54,9 +54,8 @@ class UserClient @Inject constructor(
             accessToken = accessToken
         )
 
-    suspend fun patchPassword(token: String, request: AuthorizeUserRequest): DefaultResponse =
+    suspend fun patchPassword(request: AuthorizeUserRequest): DefaultResponse =
         userService.patchPassword(
-            token = token,
             request = request,
         )
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -52,7 +52,6 @@ interface UserService {
 
     @PATCH("v2/users/password")
     suspend fun patchPassword(
-        @Header("User-Token") token: String,
         @Body request: AuthorizeUserRequest,
     ): DefaultResponse
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/HeaderInterceptor.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/HeaderInterceptor.kt
@@ -46,7 +46,7 @@ class HeaderInterceptor @Inject constructor(@ApplicationContext context: Context
 
     private fun Request.Builder.addAccessTokenHeader(): Request.Builder {
         val accessToken = preferences.accessToken
-        addHeader("Authorization", "Bearer $accessToken")
+        if (accessToken.isNotBlank()) addHeader("Authorization", "Bearer $accessToken")
         return this
     }
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/verification/VerificationClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/verification/VerificationClient.kt
@@ -8,9 +8,12 @@ import javax.inject.Inject
 class VerificationClient @Inject constructor(
     private val verificationService: VerificationService,
 ) {
-    suspend fun sendVerificationCode(email: String): DefaultResponse =
-        verificationService.sendVerificationCode(SendCodeRequest(email))
+    suspend fun sendVerificationCode(request: SendCodeRequest): DefaultResponse =
+        verificationService.sendVerificationCode(request)
 
-    suspend fun verifyVerificationCode(email: String, code: String): DefaultResponse =
-        verificationService.verifyVerificationCode(VerifyCodeRequest(email, code))
+    suspend fun sendVerificationCodeForPasswordReset(request: SendCodeRequest): DefaultResponse =
+        verificationService.sendVerificationCodeForPasswordReset(request)
+
+    suspend fun verifyVerificationCode(request: VerifyCodeRequest): DefaultResponse =
+        verificationService.verifyVerificationCode(request)
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/verification/VerificationService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/verification/VerificationService.kt
@@ -7,8 +7,13 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface VerificationService {
-    @POST("v2/verification-code")
+    @POST("v2/verification-code/signup")
     suspend fun sendVerificationCode(
+        @Body request: SendCodeRequest,
+    ): DefaultResponse
+
+    @POST("v2/verification-code/password-reset")
+    suspend fun sendVerificationCodeForPasswordReset(
         @Body request: SendCodeRequest,
     ): DefaultResponse
 

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -107,7 +107,6 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun patchPassword(email: String, password: String): Result<Unit> =
         runCatching {
             userClient.patchPassword(
-                token = pref.fcmToken,
                 request = AuthorizeUserRequest(email, password),
             )
         }

--- a/data/verification/src/main/java/com/ku_stacks/ku_ring/verification/repository/VerificationRepository.kt
+++ b/data/verification/src/main/java/com/ku_stacks/ku_ring/verification/repository/VerificationRepository.kt
@@ -2,5 +2,6 @@ package com.ku_stacks.ku_ring.verification.repository
 
 interface VerificationRepository {
     suspend fun sendVerificationCode(email: String): Result<Unit>
+    suspend fun sendVerificationCodeForPasswordReset(email: String): Result<Unit>
     suspend fun verifyCode(email: String, code: String): Result<Unit>
 }

--- a/data/verification/src/main/java/com/ku_stacks/ku_ring/verification/repository/VerificationRepositoryImpl.kt
+++ b/data/verification/src/main/java/com/ku_stacks/ku_ring/verification/repository/VerificationRepositoryImpl.kt
@@ -1,23 +1,31 @@
 package com.ku_stacks.ku_ring.verification.repository
 
-import com.ku_stacks.ku_ring.remote.verification.VerificationService
+import com.ku_stacks.ku_ring.remote.verification.VerificationClient
 import com.ku_stacks.ku_ring.remote.verification.request.SendCodeRequest
 import com.ku_stacks.ku_ring.remote.verification.request.VerifyCodeRequest
 import com.ku_stacks.ku_ring.util.suspendRunCatching
 import javax.inject.Inject
 
 class VerificationRepositoryImpl @Inject constructor(
-    private val verificationService: VerificationService
+    private val verificationClient: VerificationClient
 ) : VerificationRepository {
-    override suspend fun sendVerificationCode(email: String): Result<Unit> = suspendRunCatching {
-        verificationService.sendVerificationCode(
-            request = SendCodeRequest(email = email)
-        )
-    }
+    override suspend fun sendVerificationCode(email: String): Result<Unit> =
+        suspendRunCatching {
+            verificationClient.sendVerificationCode(
+                request = SendCodeRequest(email = email)
+            )
+        }
+
+    override suspend fun sendVerificationCodeForPasswordReset(email: String): Result<Unit> =
+        suspendRunCatching {
+            verificationClient.sendVerificationCodeForPasswordReset(
+                request = SendCodeRequest(email = email)
+            )
+        }
 
     override suspend fun verifyCode(email: String, code: String): Result<Unit> =
         suspendRunCatching {
-            verificationService.verifyVerificationCode(
+            verificationClient.verifyVerificationCode(
                 request = VerifyCodeRequest(
                     email = email,
                     code = code,

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/CodeInputGroup.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/CodeInputGroup.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedSupportingTextField
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
+import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.feature.auth.R.string.code_input_group_placeholder_code
@@ -21,10 +22,18 @@ import com.ku_stacks.ku_ring.feature.auth.R.string.code_input_group_placeholder_
 internal fun CodeInputField(
     text: String,
     onTextChange: (String) -> Unit,
+    verifiedState: VerifiedState,
     modifier: Modifier = Modifier,
     timeSuffix: @Composable (() -> Unit)? = null,
-    textFieldState: OutlinedTextFieldState = OutlinedTextFieldState.Empty,
 ) {
+    val textFieldState = remember(verifiedState) {
+        when (verifiedState) {
+            is VerifiedState.Initial -> OutlinedTextFieldState.Empty
+            is VerifiedState.Success -> OutlinedTextFieldState.Correct("")
+            is VerifiedState.Fail -> OutlinedTextFieldState.Error(verifiedState.message ?: "")
+        }
+    }
+
     OutlinedSupportingTextField(
         query = text,
         onQueryUpdate = onTextChange,
@@ -47,7 +56,7 @@ private fun CodeInputFieldPreview() {
         CodeInputField(
             text = code,
             onTextChange = { code = it },
-            textFieldState = OutlinedTextFieldState.Correct("확인되었습니다."),
+            verifiedState = VerifiedState.Initial,
         )
     }
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/EmailInputGroup.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/EmailInputGroup.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.auth.compose.component.button.VerificationButton
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedSupportingTextField
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
+import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.feature.auth.R.string.email_input_group_button_email
@@ -32,9 +33,16 @@ internal fun EmailInputGroup(
     onTextChange: (String) -> Unit,
     onSendButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
-    textFieldState: OutlinedTextFieldState = OutlinedTextFieldState.Empty,
-    isCodeSent: Boolean = false, // TODO: ResetPassword 로직 구현 시 삭제
+    verifiedState: VerifiedState,
 ) {
+    val textFieldState = remember(verifiedState) {
+        when (verifiedState) {
+            is VerifiedState.Initial -> OutlinedTextFieldState.Empty
+            is VerifiedState.Success -> OutlinedTextFieldState.Correct("")
+            is VerifiedState.Fail -> OutlinedTextFieldState.Error(verifiedState.message ?: "")
+        }
+    }
+
     val buttonTextRes = remember(textFieldState) {
         if (textFieldState is OutlinedTextFieldState.Correct) email_input_group_button_resend
         else email_input_group_button_email
@@ -77,7 +85,7 @@ private fun EmailInputFieldPreview() {
             text = email,
             onTextChange = { email = it },
             onSendButtonClick = { isCodeSent = !isCodeSent },
-            textFieldState = OutlinedTextFieldState.Correct(""),
+            verifiedState = VerifiedState.Initial,
             modifier = Modifier
         )
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/PasswordInputGroup.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/component/PasswordInputGroup.kt
@@ -6,9 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Visibility
-import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,7 +15,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -28,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedSupportingTextField
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.feature.auth.R
 import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_placeholder_password
 import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_placeholder_password_check
 
@@ -92,7 +92,6 @@ private fun PasswordInputTextField(
     )
 }
 
-// TODO: 아이콘 리소스 변경
 @Composable
 private fun VisibilityControlButton(
     isVisible: Boolean,
@@ -100,9 +99,11 @@ private fun VisibilityControlButton(
     modifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val iconRes = if (isVisible) R.drawable.ic_preview_close_v2
+    else R.drawable.ic_preview_open_v2
+
     Icon(
-        imageVector = if (isVisible) Icons.Rounded.VisibilityOff
-        else Icons.Rounded.Visibility,
+        imageVector = ImageVector.vectorResource(iconRes),
         contentDescription = null,
         modifier = modifier
             .clickable(

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordNavigation.kt
@@ -13,7 +13,7 @@ internal fun NavGraphBuilder.resetPasswordNavGraph(
     navController: NavHostController,
 ) {
     navigation<AuthDestination.ResetPassword>(
-        startDestination = AuthDestination.ResetPasswordSetPassword,
+        startDestination = AuthDestination.ResetPasswordEmailVerification,
     ) {
         composable<AuthDestination.ResetPasswordEmailVerification> { backStackEntry ->
             val viewModel = backStackEntry.sharedViewModel<ResetPasswordViewModel>(navController)

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordNavigation.kt
@@ -7,27 +7,32 @@ import androidx.navigation.compose.navigation
 import com.ku_stacks.ku_ring.auth.compose.AuthDestination
 import com.ku_stacks.ku_ring.auth.compose.reset_password.inner_screen.EmailVerificationScreen
 import com.ku_stacks.ku_ring.auth.compose.reset_password.inner_screen.ResetPasswordScreen
+import com.ku_stacks.ku_ring.auth.compose.sharedViewModel
 
 internal fun NavGraphBuilder.resetPasswordNavGraph(
     navController: NavHostController,
 ) {
     navigation<AuthDestination.ResetPassword>(
-        startDestination = AuthDestination.ResetPasswordEmailVerification,
+        startDestination = AuthDestination.ResetPasswordSetPassword,
     ) {
-        composable<AuthDestination.ResetPasswordEmailVerification> {
+        composable<AuthDestination.ResetPasswordEmailVerification> { backStackEntry ->
+            val viewModel = backStackEntry.sharedViewModel<ResetPasswordViewModel>(navController)
             EmailVerificationScreen(
                 onNavigateUp = navController::navigateUp,
                 onNavigateToPassword = {
                     navController.navigate(AuthDestination.ResetPasswordSetPassword)
                 },
+                viewModel = viewModel
             )
         }
-        composable<AuthDestination.ResetPasswordSetPassword> {
+        composable<AuthDestination.ResetPasswordSetPassword> { backStackEntry ->
+            val viewModel = backStackEntry.sharedViewModel<ResetPasswordViewModel>(navController)
             ResetPasswordScreen(
                 onNavigateUp = navController::navigateUp,
                 onNavigateToSignIn = {
                     navController.popBackStack(AuthDestination.SignIn, inclusive = false)
                 },
+                viewModel = viewModel
             )
         }
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -73,7 +73,6 @@ class ResetPasswordViewModel @Inject constructor(
     }
 
     fun resetPassword(password: String) = viewModelScope.launch {
-
         userRepository.patchPassword(email = email, password = password)
             .onSuccess {
                 _sideEffect.send(ResetPasswordSideEffect.NavigateToSignIn)

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
+import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import com.ku_stacks.ku_ring.util.getHttpExceptionMessage
 import com.ku_stacks.ku_ring.verification.repository.VerificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,6 +18,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ResetPasswordViewModel @Inject constructor(
+    private val userRepository: UserRepository,
     private val verificationRepository: VerificationRepository
 ) : ViewModel() {
     private val _sideEffect = Channel<ResetPasswordSideEffect>()
@@ -58,11 +60,11 @@ class ResetPasswordViewModel @Inject constructor(
     }
 
     fun resetPassword(password: String) = viewModelScope.launch {
-        runCatching {
-            // TODO: 비밀번호 재설정 API 호출
-            Timber.tag("ResetPasswordViewModel").d("current password: $password")
-        }.onSuccess {
-            _sideEffect.send(ResetPasswordSideEffect.NavigateToSignIn)
-        }.onFailure(Timber::e)
+
+        userRepository.patchPassword(email = email, password = password)
+            .onSuccess {
+                _sideEffect.send(ResetPasswordSideEffect.NavigateToSignIn)
+            }
+            .onFailure(Timber::e)
     }
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -47,6 +47,11 @@ class ResetPasswordViewModel @Inject constructor(
         }
     }
 
+    fun initVerifiedStates() {
+        emailVerifiedState = VerifiedState.Initial
+        codeVerifiedState = VerifiedState.Initial
+    }
+
     fun sendVerificationCode() = viewModelScope.launch {
         codeVerifiedState = VerifiedState.Initial
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -50,7 +50,7 @@ class ResetPasswordViewModel @Inject constructor(
     fun sendVerificationCode() = viewModelScope.launch {
         codeVerifiedState = VerifiedState.Initial
 
-        verificationRepository.sendVerificationCode(email)
+        verificationRepository.sendVerificationCodeForPasswordReset(email)
             .onSuccess {
                 emailVerifiedState = VerifiedState.Success
             }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -28,14 +28,6 @@ class ResetPasswordViewModel @Inject constructor(
     var codeVerifiedState by mutableStateOf<VerifiedState>(VerifiedState.Initial)
         private set
 
-    var codeInputFieldEnable by mutableStateOf(false)
-        private set
-
-    fun updateEmail(email: String) {
-        this.email = email
-        codeInputFieldEnable = false
-    }
-
     private fun initializeVerifiedState() {
         emailVerifiedState = VerifiedState.Initial
         codeVerifiedState = VerifiedState.Initial

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -74,7 +74,7 @@ internal fun EmailVerificationScreen(
         onSendCodeClick = viewModel::sendVerificationCode,
         onBackButtonClick = onNavigateUp,
         onKuMailClick = { context.navigateToExternalBrowser(KU_MAIL_URL) },
-        onProceedButtonClick = viewModel::verifyCode,
+        onProceedButtonClick = viewModel::verifyVerificationCode,
         modifier = modifier,
     )
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -60,9 +60,6 @@ internal fun EmailVerificationScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
 
-    val emailInputFieldState = rememberOutlinedTextFieldState(viewModel.emailVerifiedState)
-    val codeInputFieldState = rememberOutlinedTextFieldState(viewModel.codeVerifiedState)
-
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
@@ -74,8 +71,8 @@ internal fun EmailVerificationScreen(
 
     EmailVerificationScreen(
         email = viewModel.email,
-        emailInputFieldState = emailInputFieldState,
-        codeInputFieldState = codeInputFieldState,
+        emailVerifiedState = viewModel.emailVerifiedState,
+        codeVerifiedState = viewModel.codeVerifiedState,
         onEmailChange = viewModel::updateEmail,
         onSendCodeClick = viewModel::sendVerificationCode,
         onBackButtonClick = onNavigateUp,
@@ -88,8 +85,8 @@ internal fun EmailVerificationScreen(
 @Composable
 internal fun EmailVerificationScreen(
     email: String,
-    emailInputFieldState: OutlinedTextFieldState,
-    codeInputFieldState: OutlinedTextFieldState,
+    emailVerifiedState: VerifiedState,
+    codeVerifiedState: VerifiedState,
     onEmailChange: (String) -> Unit,
     onSendCodeClick: () -> Unit,
     onBackButtonClick: () -> Unit,
@@ -99,8 +96,8 @@ internal fun EmailVerificationScreen(
 ) {
     var code by rememberSaveable { mutableStateOf("") }
 
-    val codeInputFieldEnable = remember(emailInputFieldState) {
-        emailInputFieldState is OutlinedTextFieldState.Correct
+    val codeInputFieldEnable = remember(emailVerifiedState) {
+        emailVerifiedState is VerifiedState.Success
     }
 
     LaunchedEffect(codeInputFieldEnable) {
@@ -123,7 +120,7 @@ internal fun EmailVerificationScreen(
             text = email,
             onTextChange = onEmailChange,
             onSendButtonClick = onSendCodeClick,
-            textFieldState = emailInputFieldState,
+            verifiedState = VerifiedState.Initial,
             modifier = Modifier
                 .padding(top = 45.dp)
         )
@@ -136,7 +133,7 @@ internal fun EmailVerificationScreen(
             CodeInputField(
                 text = code,
                 onTextChange = { code = it },
-                textFieldState = codeInputFieldState,
+                verifiedState = codeVerifiedState,
                 modifier = Modifier
                     .padding(top = 8.dp)
             )
@@ -193,8 +190,8 @@ private fun EmailVerificationScreenPreview() {
 
         EmailVerificationScreen(
             email = email,
-            emailInputFieldState = OutlinedTextFieldState.Empty,
-            codeInputFieldState = OutlinedTextFieldState.Empty,
+            emailVerifiedState = VerifiedState.Initial,
+            codeVerifiedState = VerifiedState.Initial,
             onEmailChange = { email = it },
             onSendCodeClick = { isCodeSent = !isCodeSent },
             onBackButtonClick = { },

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -59,6 +59,8 @@ internal fun EmailVerificationScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
 
+    var code by rememberSaveable { mutableStateOf("") }
+
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect { sideEffect ->
@@ -70,9 +72,14 @@ internal fun EmailVerificationScreen(
 
     EmailVerificationScreen(
         email = viewModel.email,
+        code = code,
         emailVerifiedState = viewModel.emailVerifiedState,
         codeVerifiedState = viewModel.codeVerifiedState,
-        onEmailChange = { viewModel.email = it },
+        onEmailChange = {
+            viewModel.email = it
+            code = ""
+        },
+        onCodeChange = { code = it },
         onSendCodeClick = viewModel::sendVerificationCode,
         onBackButtonClick = onNavigateUp,
         onKuMailClick = { context.navigateToExternalBrowser(KU_MAIL_URL) },
@@ -84,23 +91,20 @@ internal fun EmailVerificationScreen(
 @Composable
 internal fun EmailVerificationScreen(
     email: String,
+    code: String,
     emailVerifiedState: VerifiedState,
     codeVerifiedState: VerifiedState,
     onEmailChange: (String) -> Unit,
+    onCodeChange: (String) -> Unit,
     onSendCodeClick: () -> Unit,
     onBackButtonClick: () -> Unit,
     onKuMailClick: () -> Unit,
     onProceedButtonClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var code by rememberSaveable { mutableStateOf("") }
 
     val codeInputFieldEnable = remember(emailVerifiedState) {
         emailVerifiedState is VerifiedState.Success
-    }
-
-    LaunchedEffect(codeInputFieldEnable) {
-        if (!codeInputFieldEnable) code = ""
     }
 
     Column(
@@ -131,7 +135,7 @@ internal fun EmailVerificationScreen(
         ) {
             CodeInputField(
                 text = code,
-                onTextChange = { code = it },
+                onTextChange = onCodeChange,
                 verifiedState = codeVerifiedState,
                 modifier = Modifier
                     .padding(top = 8.dp)
@@ -174,13 +178,16 @@ internal fun EmailVerificationScreen(
 private fun EmailVerificationScreenPreview() {
     KuringTheme {
         var email by remember { mutableStateOf("") }
+        var code by remember { mutableStateOf("") }
         var isCodeSent by remember { mutableStateOf(false) }
 
         EmailVerificationScreen(
             email = email,
+            code = code,
             emailVerifiedState = VerifiedState.Initial,
             codeVerifiedState = VerifiedState.Initial,
             onEmailChange = { email = it },
+            onCodeChange = { code = it },
             onSendCodeClick = { isCodeSent = !isCodeSent },
             onBackButtonClick = { },
             onKuMailClick = {},

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -76,7 +76,7 @@ internal fun EmailVerificationScreen(
 
         onDispose {
             with(viewModel) {
-                updateEmail("")
+                initVerifiedStates()
                 updateCode("")
             }
         }
@@ -114,7 +114,7 @@ internal fun EmailVerificationScreen(
     val coroutineScope = rememberCoroutineScope()
     val timer = remember { KuringTimer(coroutineScope) }
 
-    val codeInputFieldEnable by remember {
+    val codeInputFieldEnable by remember(emailVerifiedState) {
         derivedStateOf { emailVerifiedState is VerifiedState.Success }
     }
 
@@ -134,7 +134,7 @@ internal fun EmailVerificationScreen(
             text = email,
             onTextChange = onEmailChange,
             onSendButtonClick = onSendCodeClick,
-            verifiedState = VerifiedState.Initial,
+            verifiedState = emailVerifiedState,
             modifier = Modifier.padding(top = 45.dp)
         )
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -113,8 +114,8 @@ internal fun EmailVerificationScreen(
     val coroutineScope = rememberCoroutineScope()
     val timer = remember { KuringTimer(coroutineScope) }
 
-    val codeInputFieldEnable = remember(emailVerifiedState) {
-        emailVerifiedState is VerifiedState.Success
+    val codeInputFieldEnable by remember {
+        derivedStateOf { emailVerifiedState is VerifiedState.Success }
     }
 
     Column(

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -86,7 +86,7 @@ internal fun EmailVerificationScreen(
         onSendCodeClick = viewModel::sendVerificationCode,
         onBackButtonClick = onNavigateUp,
         onKuMailClick = { context.navigateToExternalBrowser(KU_MAIL_URL) },
-        onProceedButtonClick = viewModel::verifyVerificationCode,
+        onProceedButtonClick = { viewModel.verifyVerificationCode(code) },
         modifier = modifier,
     )
 }
@@ -102,7 +102,7 @@ internal fun EmailVerificationScreen(
     onSendCodeClick: () -> Unit,
     onBackButtonClick: () -> Unit,
     onKuMailClick: () -> Unit,
-    onProceedButtonClick: (String) -> Unit,
+    onProceedButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -173,7 +173,7 @@ internal fun EmailVerificationScreen(
 
         KuringCallToAction(
             text = stringResource(reset_password_verification_button_proceed),
-            onClick = { onProceedButtonClick(code) },
+            onClick = onProceedButtonClick,
             enabled = codeInputFieldEnable && code.isNotBlank(),
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -33,7 +33,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import com.ku_stacks.ku_ring.auth.compose.component.CodeInputField
 import com.ku_stacks.ku_ring.auth.compose.component.EmailInputGroup
-import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
 import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
 import com.ku_stacks.ku_ring.auth.compose.reset_password.ResetPasswordSideEffect
 import com.ku_stacks.ku_ring.auth.compose.reset_password.ResetPasswordViewModel
@@ -73,7 +72,7 @@ internal fun EmailVerificationScreen(
         email = viewModel.email,
         emailVerifiedState = viewModel.emailVerifiedState,
         codeVerifiedState = viewModel.codeVerifiedState,
-        onEmailChange = viewModel::updateEmail,
+        onEmailChange = { viewModel.email = it },
         onSendCodeClick = viewModel::sendVerificationCode,
         onBackButtonClick = onNavigateUp,
         onKuMailClick = { context.navigateToExternalBrowser(KU_MAIL_URL) },
@@ -167,17 +166,6 @@ internal fun EmailVerificationScreen(
                 .fillMaxWidth()
                 .padding(bottom = 20.dp)
         )
-    }
-}
-
-@Composable
-private fun rememberOutlinedTextFieldState(
-    verifiedState: VerifiedState
-) = remember(verifiedState) {
-    when (verifiedState) {
-        is VerifiedState.Initial -> OutlinedTextFieldState.Empty
-        is VerifiedState.Success -> OutlinedTextFieldState.Correct("")
-        is VerifiedState.Fail -> OutlinedTextFieldState.Error(verifiedState.message ?: "")
     }
 }
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/inner_screen/EmailVerificationScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -32,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import com.ku_stacks.ku_ring.auth.compose.component.CodeInputField
+import com.ku_stacks.ku_ring.auth.compose.component.CodeTimer
 import com.ku_stacks.ku_ring.auth.compose.component.EmailInputGroup
 import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
 import com.ku_stacks.ku_ring.auth.compose.reset_password.ResetPasswordSideEffect
@@ -45,6 +47,7 @@ import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_verification_b
 import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_verification_navigate_to_ku_mail
 import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_verification_top_bar_heading
 import com.ku_stacks.ku_ring.feature.auth.R.string.reset_password_verification_top_bar_sub_heading
+import com.ku_stacks.ku_ring.util.KuringTimer
 import com.ku_stacks.ku_ring.util.navigateToExternalBrowser
 
 private const val KU_MAIL_URL = "https://kumail.konkuk.ac.kr/"
@@ -102,6 +105,8 @@ internal fun EmailVerificationScreen(
     onProceedButtonClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val timer = remember { KuringTimer(coroutineScope) }
 
     val codeInputFieldEnable = remember(emailVerifiedState) {
         emailVerifiedState is VerifiedState.Success
@@ -111,7 +116,7 @@ internal fun EmailVerificationScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = KuringTheme.colors.background)
-            .imePadding()
+            .imePadding(),
     ) {
         AuthTopBar(
             headingText = stringResource(reset_password_verification_top_bar_heading),
@@ -124,8 +129,7 @@ internal fun EmailVerificationScreen(
             onTextChange = onEmailChange,
             onSendButtonClick = onSendCodeClick,
             verifiedState = VerifiedState.Initial,
-            modifier = Modifier
-                .padding(top = 45.dp)
+            modifier = Modifier.padding(top = 45.dp)
         )
 
         AnimatedVisibility(
@@ -137,8 +141,13 @@ internal fun EmailVerificationScreen(
                 text = code,
                 onTextChange = onCodeChange,
                 verifiedState = codeVerifiedState,
-                modifier = Modifier
-                    .padding(top = 8.dp)
+                modifier = Modifier.padding(top = 8.dp),
+                timeSuffix = {
+                    CodeTimer(
+                        timer = timer,
+                        enabled = codeInputFieldEnable
+                    )
+                }
             )
         }
 
@@ -168,7 +177,7 @@ internal fun EmailVerificationScreen(
             enabled = codeInputFieldEnable && code.isNotBlank(),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 20.dp)
+                .padding(bottom = 20.dp),
         )
     }
 }
@@ -190,7 +199,7 @@ private fun EmailVerificationScreenPreview() {
             onCodeChange = { code = it },
             onSendCodeClick = { isCodeSent = !isCodeSent },
             onBackButtonClick = { },
-            onKuMailClick = {},
+            onKuMailClick = { },
             onProceedButtonClick = { },
         )
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
 import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import com.ku_stacks.ku_ring.util.getHttpExceptionMessage
 import com.ku_stacks.ku_ring.verification.repository.VerificationRepository
@@ -64,10 +65,4 @@ class SignUpViewModel @Inject constructor(
                 _sideEffect.send(SignUpSideEffect.NavigateToComplete)
             }.onFailure(Timber::e)
     }
-}
-
-sealed class VerifiedState {
-    data object Initial : VerifiedState()
-    data object Success : VerifiedState()
-    data class Fail(val message: String?) : VerifiedState()
 }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
@@ -32,7 +32,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.ku_stacks.ku_ring.auth.compose.component.CodeInputField
 import com.ku_stacks.ku_ring.auth.compose.component.CodeTimer
 import com.ku_stacks.ku_ring.auth.compose.component.EmailInputGroup
-import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
 import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
 import com.ku_stacks.ku_ring.auth.compose.signup.SignUpViewModel
 import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
@@ -171,17 +170,6 @@ internal fun EmailVerificationScreen(
                 .fillMaxWidth()
                 .padding(bottom = 20.dp)
         )
-    }
-}
-
-@Composable
-private fun rememberOutlinedTextFieldState(
-    verifiedState: VerifiedState
-) = remember(verifiedState) {
-    when (verifiedState) {
-        is VerifiedState.Initial -> OutlinedTextFieldState.Empty
-        is VerifiedState.Success -> OutlinedTextFieldState.Correct("")
-        is VerifiedState.Fail -> OutlinedTextFieldState.Error(verifiedState.message ?: "")
     }
 }
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
@@ -35,7 +35,7 @@ import com.ku_stacks.ku_ring.auth.compose.component.EmailInputGroup
 import com.ku_stacks.ku_ring.auth.compose.component.textfield.OutlinedTextFieldState
 import com.ku_stacks.ku_ring.auth.compose.component.topbar.AuthTopBar
 import com.ku_stacks.ku_ring.auth.compose.signup.SignUpViewModel
-import com.ku_stacks.ku_ring.auth.compose.signup.VerifiedState
+import com.ku_stacks.ku_ring.auth.compose.state.VerifiedState
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
@@ -118,7 +118,7 @@ internal fun EmailVerificationScreen(
             text = email,
             onTextChange = onEmailChange,
             onSendButtonClick = onSendCodeClick,
-            verifiedState = VerifiedState.Initial,
+            verifiedState = emailVerifiedState,
             modifier = Modifier
                 .padding(top = 45.dp)
         )
@@ -131,7 +131,7 @@ internal fun EmailVerificationScreen(
             CodeInputField(
                 text = code,
                 onTextChange = onCodeChange,
-                verifiedState = VerifiedState.Initial,
+                verifiedState = codeVerifiedState,
                 modifier = Modifier.padding(top = 8.dp),
                 timeSuffix = {
                     CodeTimer(

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/EmailVerificationScreen.kt
@@ -57,10 +57,6 @@ internal fun EmailVerificationScreen(
     viewModel: SignUpViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-
-    val emailInputFieldState = rememberOutlinedTextFieldState(viewModel.emailVerifiedState)
-    val codeInputFieldState = rememberOutlinedTextFieldState(viewModel.codeVerifiedState)
-
     var code by rememberSaveable { mutableStateOf("") }
 
     LaunchedEffect(viewModel.codeVerifiedState) {
@@ -71,8 +67,8 @@ internal fun EmailVerificationScreen(
 
     EmailVerificationScreen(
         email = viewModel.email,
-        emailInputFieldState = emailInputFieldState,
-        codeInputFieldState = codeInputFieldState,
+        emailVerifiedState = viewModel.emailVerifiedState,
+        codeVerifiedState = viewModel.codeVerifiedState,
         onEmailChange = { viewModel.email = it },
         code = code,
         onCodeChange = { code = it },
@@ -91,8 +87,8 @@ internal fun EmailVerificationScreen(
 internal fun EmailVerificationScreen(
     email: String,
     code: String,
-    emailInputFieldState: OutlinedTextFieldState,
-    codeInputFieldState: OutlinedTextFieldState,
+    emailVerifiedState: VerifiedState,
+    codeVerifiedState: VerifiedState,
     onEmailChange: (String) -> Unit,
     onCodeChange: (String) -> Unit,
     onSendCodeClick: () -> Unit,
@@ -104,8 +100,8 @@ internal fun EmailVerificationScreen(
     val coroutineScope = rememberCoroutineScope()
     val timer = remember { KuringTimer(coroutineScope) }
 
-    val codeInputFieldEnable = remember(emailInputFieldState) {
-        emailInputFieldState is OutlinedTextFieldState.Correct
+    val codeInputFieldEnable = remember(emailVerifiedState) {
+        emailVerifiedState is VerifiedState.Success
     }
 
     Column(
@@ -123,7 +119,7 @@ internal fun EmailVerificationScreen(
             text = email,
             onTextChange = onEmailChange,
             onSendButtonClick = onSendCodeClick,
-            textFieldState = emailInputFieldState,
+            verifiedState = VerifiedState.Initial,
             modifier = Modifier
                 .padding(top = 45.dp)
         )
@@ -136,7 +132,7 @@ internal fun EmailVerificationScreen(
             CodeInputField(
                 text = code,
                 onTextChange = onCodeChange,
-                textFieldState = codeInputFieldState,
+                verifiedState = VerifiedState.Initial,
                 modifier = Modifier.padding(top = 8.dp),
                 timeSuffix = {
                     CodeTimer(
@@ -199,8 +195,8 @@ private fun EmailVerificationScreenPreview() {
 
         EmailVerificationScreen(
             email = email,
-            emailInputFieldState = OutlinedTextFieldState.Empty,
-            codeInputFieldState = OutlinedTextFieldState.Empty,
+            emailVerifiedState = VerifiedState.Initial,
+            codeVerifiedState = VerifiedState.Initial,
             onEmailChange = { email = it },
             onSendCodeClick = { codeInputFieldEnable = !codeInputFieldEnable },
             onBackButtonClick = { },

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/state/VerifiedState.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/state/VerifiedState.kt
@@ -1,0 +1,7 @@
+package com.ku_stacks.ku_ring.auth.compose.state
+
+sealed class VerifiedState {
+    data object Initial : VerifiedState()
+    data object Success : VerifiedState()
+    data class Fail(val message: String?) : VerifiedState()
+}


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-235?atlOrigin=eyJpIjoiMzk0M2EwZmZmMGRjNDQ1YWI4NTVkZGMyYTM1ZjUxZjgiLCJwIjoiaiJ9

## 요약

- 비밀번호 재설정 플로우에 API를 연결
- 이메일 인증 화면 내 상태 관리 방식 수정
- 엑세스 토큰이 없는 경우 HeaderInterceptor에서 제거

## 상세
-  회원가입 뷰모델 내 선언되어 있던 VerifiedState를 Auth 모듈 내에서 공용으로 사용하도록 수정했습니다.
   이 변경사항으로 인해 회원가입 코드 내에도 약간의 수정이 발생했습니다.
- 비밀번호 재설정 플로우에서 뒤로 가기 버튼에 대한 처리를 위하 상태관리 방식을 대폭 수정했습니다.
   - 인증코드 상태 값을 뷰모델 내부에서 관리
   - 뷰모델 내 모든 변수의 setter를 은닉화하고 update용 함수 구현
- 비밀번호 재설정 화면에서 이메일 인증화면으로 복귀할 경우, 모든 상태들이 초기화되도록 구현했습니다.
- 4/23 회의에서 의논한 비밀번호 재설정 API의 토큰 관련 문제를 조건문 추가로 해결했습니다. [b3012cc](https://github.com/ku-ring/KU-Ring-Android/pull/478/commits/b3012cc34127c48310f983df2e27b7edd11f3c0e)