### PR TITLE
kuring-235: 설정화면 로직 구현

### DIFF
--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/User.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/User.kt
@@ -3,4 +3,11 @@ package com.ku_stacks.ku_ring.domain
 data class User(
     val email: String,
     val nickName: String,
-)
+) {
+    companion object {
+        val EMPTY = User(
+            email = "",
+            nickName = "",
+        )
+    }
+}

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -55,8 +55,5 @@ class UserClient @Inject constructor(
             request = request,
         )
 
-    suspend fun withdrawUser(accessToken: String): DefaultResponse =
-        userService.withdraw(
-            accessToken = accessToken
-        )
+    suspend fun withdrawUser(): DefaultResponse = userService.withdraw()
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -31,10 +31,8 @@ class UserClient @Inject constructor(
         }.getOrElse { 0 }
     }
 
-    suspend fun getUserData(accessToken: String): UserDataResponse =
-        userService.getUserData(
-            accessToken = accessToken
-        )
+    suspend fun getUserData(): UserDataResponse =
+        userService.getUserData()
 
     suspend fun signUp(token: String, request: AuthorizeUserRequest): DefaultResponse =
         userService.signUp(
@@ -48,11 +46,8 @@ class UserClient @Inject constructor(
             request = request
         )
 
-    suspend fun logout(token: String, accessToken: String): DefaultResponse =
-        userService.logout(
-            token = token,
-            accessToken = accessToken
-        )
+    suspend fun logout(): DefaultResponse =
+        userService.logout()
 
     suspend fun patchPassword(token: String, request: AuthorizeUserRequest): DefaultResponse =
         userService.patchPassword(

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -52,7 +52,5 @@ interface UserService {
     ): DefaultResponse
 
     @DELETE("v2/users/withdraw")
-    suspend fun withdraw(
-        @Header("Authorization") accessToken: String,
-    ): DefaultResponse
+    suspend fun withdraw(): DefaultResponse
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -28,9 +28,7 @@ interface UserService {
     suspend fun getKuringBotQueryCount(@Header("User-Token") token: String): KuringBotQueryCountResponse
 
     @GET("v2/users/user-me")
-    suspend fun getUserData(
-        @Header("Authorization") accessToken: String,
-    ): UserDataResponse
+    suspend fun getUserData(): UserDataResponse
 
     @POST("v2/users/signup")
     suspend fun signUp(
@@ -45,10 +43,7 @@ interface UserService {
     ): SignInResponse
 
     @POST("v2/users/logout")
-    suspend fun logout(
-        @Header("User-Token") token: String,
-        @Header("Authorization") accessToken: String,
-    ): DefaultResponse
+    suspend fun logout(): DefaultResponse
 
     @PATCH("v2/users/password")
     suspend fun patchPassword(

--- a/data/remote/src/test/java/com/ku_stacks/ku_ring/remote/UserServiceTest.kt
+++ b/data/remote/src/test/java/com/ku_stacks/ku_ring/remote/UserServiceTest.kt
@@ -48,11 +48,10 @@ class UserServiceTest : ApiAbstract<UserService>() {
         enqueueResponse("/UserDataResponse.json")
 
         // when
-        val token = "mockToken"
-
-        val response = service.getUserData(token)
+        val response = service.getUserData()
         mockWebServer.takeRequest()
 
+        // then
         assertEquals("test@konkuk.ac.kr", response.data.email)
         assertEquals("test1234", response.data.nickname)
     }

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -94,12 +94,10 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun withdrawUser(): Result<Unit> = runCatching {
-        userClient.withdrawUser(
-            accessToken = pref.accessToken,
-        ).run {
-            if (isSuccess) pref.deleteAccessToken()
-            else Timber.e(resultMsg)
-        }
+        userClient.withdrawUser()
+    }.map { response ->
+        if (response.resultCode == 204) pref.deleteAccessToken()
+        else Timber.e(response.resultMsg)
     }
 
     override suspend fun patchPassword(email: String, password: String): Result<Unit> =

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -57,7 +57,6 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserData(): Result<User> = runCatching {
-        if (pref.accessToken.isBlank()) return Result.success(User.EMPTY)
         userClient.getUserData().toDomain()
     }
 

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -57,6 +57,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserData(): Result<User> = runCatching {
+        if (pref.accessToken.isBlank()) return Result.success(User.EMPTY)
         userClient.getUserData().toDomain()
     }
 

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -57,7 +57,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserData(): Result<User> = runCatching {
-        userClient.getUserData(pref.accessToken).toDomain()
+        userClient.getUserData().toDomain()
     }
 
     override suspend fun signUpUser(
@@ -86,10 +86,7 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun logoutUser(): Result<Unit> = runCatching {
-        userClient.logout(
-            token = pref.fcmToken,
-            accessToken = pref.accessToken,
-        ).run {
+        userClient.logout().run {
             if (isSuccess) pref.deleteAccessToken()
             else Timber.e(resultMsg)
         }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
@@ -38,6 +38,19 @@ class AuthActivity : AppCompatActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(
+                OVERRIDE_TRANSITION_OPEN,
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_slide_right_exit
+            )
+        } else {
+            overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_slide_right_exit)
+        }
+    }
+
     override fun finish() {
         super.finish()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/SignInNavigation.kt
@@ -13,7 +13,7 @@ internal fun NavGraphBuilder.signInNavGraph(
     composable<AuthDestination.SignIn> {
         SignInScreen(
             onNavigateUp = onNavigateUp,
-            onNavigateToMain = navController::navigateUp,
+            onNavigateToMain = onNavigateUp,
             onNavigateToSignUp = { navController.navigate(AuthDestination.SignUp) },
             onNavigateToFindPassword = { navController.navigate(AuthDestination.ResetPassword) },
         )

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/inner_screen/SignInScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signin/inner_screen/SignInScreen.kt
@@ -67,7 +67,9 @@ internal fun SignInScreen(
         viewModel.sideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
             .collectLatest { sideEffect ->
                 when (sideEffect) {
-                    SignInSideEffect.NavigateToMain -> onNavigateToMain()
+                    SignInSideEffect.NavigateToMain -> {
+                        onNavigateToMain()
+                    }
                 }
             }
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/SignOutViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/SignOutViewModel.kt
@@ -2,20 +2,25 @@ package com.ku_stacks.ku_ring.auth.compose.signout
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class SignOutViewModel @Inject constructor(
+    private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _sideEffect = Channel<SignOutSideEffect>()
     val sideEffect = _sideEffect.receiveAsFlow()
 
     fun signOut() = viewModelScope.launch {
-        // TODO: 회원탈퇴 API 호출
-        _sideEffect.trySend(SignOutSideEffect.NavigateToSignOutComplete)
+        userRepository.withdrawUser()
+            .onSuccess {
+                _sideEffect.send(SignOutSideEffect.NavigateToSignOutComplete)
+            }.onFailure(Timber::e)
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -183,7 +183,7 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onNavigateToKuringInstagram = { activity.navigateToKuringInstagram() },
             onNavigateToFeedback = { navigator.navigateToFeedback(activity) },
             onLogoutClick = viewModel::logout,
-            onNavigateToSignOut = { /*TODO: 탈퇴 화면 이동 로직*/ },
+            onNavigateToSignOut = { navigator.navigateToSignOut(activity) },
             modifier =
             Modifier
                 .background(KuringTheme.colors.background)

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -186,9 +185,8 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onNavigateToSignOut = { navigator.navigateToSignOut(activity) },
             modifier =
             Modifier
-                .background(KuringTheme.colors.background)
-                .fillMaxWidth()
-                .wrapContentHeight(),
+                .fillMaxSize()
+                .background(KuringTheme.colors.background),
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -12,16 +12,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -39,7 +35,6 @@ import com.ku_stacks.ku_ring.thirdparty.di.LocalNavigator
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import com.ku_stacks.ku_ring.ui_util.showToast
 import com.ku_stacks.ku_ring.util.findActivity
-import kotlinx.coroutines.launch
 
 @Composable
 fun MainScreen(
@@ -166,19 +161,11 @@ fun NavGraphBuilder.mainScreenNavGraph(
         // TODO by mwy3055: SettingScreen 내부도 navigation으로 migrate해야 함
         val viewModel = hiltViewModel<SettingViewModel>()
         val settingsUiState by viewModel.settingUiState.collectAsStateWithLifecycle()
-        val lifecycleOwner = LocalLifecycleOwner.current
 
-        DisposableEffect(lifecycleOwner) {
-            val observer = LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_RESUME) {
-                    lifecycleOwner.lifecycleScope.launch {
-                        viewModel.getUserData()
-                    }
-                }
-            }
-            lifecycleOwner.lifecycle.addObserver(observer)
-            onDispose {
-                lifecycleOwner.lifecycle.removeObserver(observer)
+        LifecycleResumeEffect(Unit) {
+            viewModel.getUserData()
+            onPauseOrDispose {
+                // No resources to clean up
             }
         }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -43,10 +43,6 @@ class SettingViewModel @Inject constructor(
         initialValue = SettingUiState.Initial,
     )
 
-    init {
-        getUserData()
-    }
-
     fun setExtNotificationAllowed(value: Boolean) {
         pref.extNotificationAllowed = value
         _isExtNotificationAllowed.value = value

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -55,14 +55,14 @@ class SettingViewModel @Inject constructor(
     fun logout() = viewModelScope.launch {
         userRepository.logoutUser()
             .onSuccess { updateUserProfileState() }
-            .onFailure { _userProfileState.value = UserProfileState.Error }
+            .onFailure(Timber::e)
     }
 
     fun getUserData() = viewModelScope.launch {
         userRepository.getUserData()
             .onSuccess { updateUserProfileState(it.nickName) }
             .onFailure {
-                _userProfileState.value = UserProfileState.Error
+                updateUserProfileState()
                 Timber.e(it)
             }
     }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -57,8 +57,8 @@ class SettingViewModel @Inject constructor(
 
     fun getUserData() = viewModelScope.launch {
         userRepository.getUserData()
-            .onSuccess {
-                UserProfileState.LoggedIn(it.nickName)
+            .onSuccess { response ->
+                _userProfileState.update { UserProfileState.LoggedIn(response.nickName) }
             }
             .onFailure { exception ->
                 val message = exception.getHttpExceptionMessage()

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,16 +53,22 @@ class SettingViewModel @Inject constructor(
     }
 
     fun logout() = viewModelScope.launch {
-        //TODO: 로그아웃 API 연결
+        userRepository.logoutUser()
+            .onSuccess { updateUserProfileState() }
+            .onFailure { _userProfileState.value = UserProfileState.Error }
     }
 
     fun getUserData() = viewModelScope.launch {
-        //TODO: 유저 정보 API 연결
-        updateUserProfileState()
+        userRepository.getUserData()
+            .onSuccess { updateUserProfileState(it.nickName) }
+            .onFailure {
+                _userProfileState.value = UserProfileState.Error
+                Timber.e(it)
+            }
     }
 
     private fun updateUserProfileState(nickName: String? = null) = _userProfileState.update {
-        if (nickName == null) UserProfileState.NotLoggedIn
+        if (nickName.isNullOrBlank()) UserProfileState.NotLoggedIn
         else UserProfileState.LoggedIn(nickName)
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -63,16 +63,13 @@ class SettingViewModel @Inject constructor(
             .onFailure { exception ->
                 val message = exception.getHttpExceptionMessage()
 
-                if (message.equals(NO_USER_MESSAGE)) {
+                if (message != null) {
+                    // 쿠링 서버의 응답 형식에 맞게 파싱되었음을 의미
                     _userProfileState.update { UserProfileState.NotLoggedIn }
                 } else {
                     _userProfileState.update { UserProfileState.Error }
                 }
             }
-    }
-
-    companion object {
-        private const val NO_USER_MESSAGE = "계정을 찾을 수 없습니다."
     }
 }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -56,10 +56,11 @@ class SettingViewModel @Inject constructor(
 
     fun getUserData() = viewModelScope.launch {
         userRepository.getUserData()
-            .onSuccess { updateUserProfileState(it.nickName) }
+            .onSuccess {
+                updateUserProfileState(it.nickName)
+            }
             .onFailure {
-                updateUserProfileState()
-                Timber.e(it)
+                _userProfileState.update { UserProfileState.Error }
             }
     }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/ProfileGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/ProfileGroup.kt
@@ -23,7 +23,7 @@ internal fun ProfileGroup(
         if (loggedIn) (userProfileState as UserProfileState.LoggedIn).nickname
         else stringResource(setting_profile_sign_in)
     val onClick = onNavigateToSignIn.takeIf { !loggedIn }
-    val content: @Composable () -> Unit = { ChevronIcon().takeIf { !loggedIn } }
+    val content: @Composable () -> Unit = { if (!loggedIn) ChevronIcon() }
 
     SettingItem(
         iconId = ic_user_v2,
@@ -50,7 +50,7 @@ private fun LoggedInProfilePreview() {
 private fun NotLoggedInProfilePreview() {
     KuringTheme {
         ProfileGroup(
-            userProfileState = UserProfileState.LoggedIn("쿠링이"),
+            userProfileState = UserProfileState.NotLoggedIn,
             onNavigateToSignIn = {},
         )
     }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.main.setting.compose.inner_screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,17 +10,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
@@ -27,6 +32,7 @@ import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.SfProDisplay
 import com.ku_stacks.ku_ring.main.R
 import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_confirm
 import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_dismiss
@@ -69,42 +75,53 @@ internal fun SettingScreen(
             action = {},
             modifier = Modifier.padding(vertical = 16.dp),
         )
-        if (settingUiState is SettingUiState.Success) {
-            with(settingUiState) {
-                Column(modifier = Modifier.verticalScroll(scrollState)) {
-                    ProfileGroup(
-                        userProfileState = userProfileState,
-                        onNavigateToSignIn = onNavigateToSignIn,
-                    )
-                    SettingScreenDivider()
-                    SubscribeGroup(
-                        onNavigateToEditSubscription = onNavigateToEditSubscription,
-                        isExtNotificationEnabled = isExtNotificationEnabled,
-                        onExtNotificationEnabledToggle = onExtNotificationEnabledToggle,
-                    )
-                    SettingScreenDivider()
-                    InformationGroup(
-                        appVersion = appVersion,
-                        onNavigateToUpdateLog = onNavigateToUpdateLog,
-                        onNavigateToKuringTeam = onNavigateToKuringTeam,
-                        onNavigateToPrivacyPolicy = onNavigateToPrivacyPolicy,
-                        onNavigateToServiceTerms = onNavigateToServiceTerms,
-                        onNavigateToOpenSources = onNavigateToOpenSources,
-                    )
-                    SettingScreenDivider()
-                    KuringMemberText()
-                    SocialNetworkServiceGroup(onNavigateToKuringInstagram = onNavigateToKuringInstagram)
-                    SettingScreenDivider()
-                    FeedbackGroup(onNavigateToFeedback = onNavigateToFeedback)
-                    SettingScreenDivider()
-                    AccountExitGroup(
-                        userProfileState = userProfileState,
-                        onLogoutClick = { isLogoutDialogVisible = true },
-                        onNavigateToSignOut = onNavigateToSignOut,
-                    )
 
-                    Spacer(modifier = Modifier.height(100.dp))
+        when (settingUiState) {
+            is SettingUiState.Success -> {
+                with(settingUiState) {
+                    Column(modifier = Modifier.verticalScroll(scrollState)) {
+                        ProfileGroup(
+                            userProfileState = userProfileState,
+                            onNavigateToSignIn = onNavigateToSignIn,
+                        )
+                        SettingScreenDivider()
+                        SubscribeGroup(
+                            onNavigateToEditSubscription = onNavigateToEditSubscription,
+                            isExtNotificationEnabled = isExtNotificationEnabled,
+                            onExtNotificationEnabledToggle = onExtNotificationEnabledToggle,
+                        )
+                        SettingScreenDivider()
+                        InformationGroup(
+                            appVersion = appVersion,
+                            onNavigateToUpdateLog = onNavigateToUpdateLog,
+                            onNavigateToKuringTeam = onNavigateToKuringTeam,
+                            onNavigateToPrivacyPolicy = onNavigateToPrivacyPolicy,
+                            onNavigateToServiceTerms = onNavigateToServiceTerms,
+                            onNavigateToOpenSources = onNavigateToOpenSources,
+                        )
+                        SettingScreenDivider()
+                        KuringMemberText()
+                        SocialNetworkServiceGroup(onNavigateToKuringInstagram = onNavigateToKuringInstagram)
+                        SettingScreenDivider()
+                        FeedbackGroup(onNavigateToFeedback = onNavigateToFeedback)
+                        SettingScreenDivider()
+                        AccountExitGroup(
+                            userProfileState = userProfileState,
+                            onLogoutClick = { isLogoutDialogVisible = true },
+                            onNavigateToSignOut = onNavigateToSignOut,
+                        )
+
+                        Spacer(modifier = Modifier.height(100.dp))
+                    }
                 }
+            }
+
+            is SettingUiState.Initial -> {
+                LoadingScreen()
+            }
+
+            is SettingUiState.Error -> {
+                ErrorScreen()
             }
         }
     }
@@ -160,6 +177,31 @@ private fun LogoutDialog(
         cancelText = stringResource(setting_logout_dialog_dismiss),
         confirmTextColor = KuringTheme.colors.warning,
     )
+}
+
+@Composable
+private fun LoadingScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(
+            modifier = Modifier.align(Alignment.Center),
+            color = KuringTheme.colors.mainPrimary,
+        )
+    }
+}
+
+@Composable
+private fun ErrorScreen() {
+    Box(modifier = Modifier.fillMaxSize()) {
+        androidx.compose.material.Text(
+            text = stringResource(id = com.ku_stacks.ku_ring.designsystem.R.string.network_error),
+            fontFamily = SfProDisplay,
+            fontWeight = FontWeight.Normal,
+            fontSize = 14.sp,
+            color = colorResource(id = com.ku_stacks.ku_ring.designsystem.R.color.kus_label),
+            modifier = Modifier.align(Alignment.Center),
+            textAlign = TextAlign.Center,
+        )
+    }
 }
 
 @LightAndDarkPreview

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -18,11 +22,15 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_confirm
+import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_dismiss
+import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_title
 import com.ku_stacks.ku_ring.main.setting.SettingUiState
 import com.ku_stacks.ku_ring.main.setting.UserProfileState
 import com.ku_stacks.ku_ring.main.setting.compose.groups.AccountExitGroup
@@ -52,6 +60,8 @@ internal fun SettingScreen(
 ) {
     val scrollState = rememberScrollState()
     val appVersion = LocalContext.current.getAppVersionName()
+
+    var isLogoutDialogVisible by rememberSaveable { mutableStateOf(false) }
 
     Column(modifier = modifier) {
         CenterTitleTopBar(
@@ -89,7 +99,7 @@ internal fun SettingScreen(
                     SettingScreenDivider()
                     AccountExitGroup(
                         userProfileState = userProfileState,
-                        onLogoutClick = onLogoutClick,
+                        onLogoutClick = { isLogoutDialogVisible = true },
                         onNavigateToSignOut = onNavigateToSignOut,
                     )
 
@@ -97,6 +107,16 @@ internal fun SettingScreen(
                 }
             }
         }
+    }
+
+    if (isLogoutDialogVisible) {
+        LogoutDialog(
+            onDismiss = { isLogoutDialogVisible = false },
+            onConfirm = {
+                isLogoutDialogVisible = false
+                onLogoutClick()
+            }
+        )
     }
 }
 
@@ -123,6 +143,22 @@ private fun KuringMemberText(modifier: Modifier = Modifier) {
             letterSpacing = 0.15.sp,
         ),
         modifier = modifier.padding(20.dp)
+    )
+}
+
+@Composable
+private fun LogoutDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    KuringAlertDialog(
+        text = stringResource(setting_logout_dialog_title),
+        onConfirm = onConfirm,
+        onCancel = onDismiss,
+        onDismiss = onDismiss,
+        confirmText = stringResource(setting_logout_dialog_confirm),
+        cancelText = stringResource(setting_logout_dialog_dismiss),
+        confirmTextColor = KuringTheme.colors.warning,
     )
 }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.R.color.kus_label
+import com.ku_stacks.ku_ring.designsystem.R.string.network_error
 import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
@@ -34,6 +36,7 @@ import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.SfProDisplay
 import com.ku_stacks.ku_ring.main.R
+import com.ku_stacks.ku_ring.main.R.string.setting_kuring_members
 import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_confirm
 import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_dismiss
 import com.ku_stacks.ku_ring.main.R.string.setting_logout_dialog_title
@@ -151,7 +154,7 @@ private fun SettingScreenDivider(modifier: Modifier = Modifier) {
 @Composable
 private fun KuringMemberText(modifier: Modifier = Modifier) {
     Text(
-        text = stringResource(R.string.setting_kuring_members),
+        text = stringResource(setting_kuring_members),
         style = TextStyle(
             fontSize = 12.sp,
             fontFamily = Pretendard,
@@ -193,11 +196,11 @@ private fun LoadingScreen() {
 private fun ErrorScreen() {
     Box(modifier = Modifier.fillMaxSize()) {
         androidx.compose.material.Text(
-            text = stringResource(id = com.ku_stacks.ku_ring.designsystem.R.string.network_error),
+            text = stringResource(id = network_error),
             fontFamily = SfProDisplay,
             fontWeight = FontWeight.Normal,
             fontSize = 14.sp,
-            color = colorResource(id = com.ku_stacks.ku_ring.designsystem.R.color.kus_label),
+            color = colorResource(id = kus_label),
             modifier = Modifier.align(Alignment.Center),
             textAlign = TextAlign.Center,
         )

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -81,6 +81,9 @@
     <string name="setting_feedback_send_feedback">피드백 보내기</string>
 
     <string name="setting_logout">로그아웃하기</string>
+    <string name="setting_logout_dialog_title">정말 로그아웃 하시겠어요?</string>
+    <string name="setting_logout_dialog_confirm">로그아웃</string>
+    <string name="setting_logout_dialog_dismiss">취소</string>
     <string name="setting_sign_out">탈퇴하기</string>
 
     <string name="open_source_license">사용된 오픈소스</string>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-235?atlOrigin=eyJpIjoiZmNjZTk5OTMyOGU5NDRlMmE1NWM3ODEzMDgwNzdhZTIiLCJwIjoiaiJ9

## 요약
- 프로필 API 연결
   - API 성공 여부에 따른 성공/오류/로딩 화면을 구현했습니다.ca08fd4557c5d48bc967cb666c050fadfe93dae7
- 로그아웃, 탈퇴, 회원정보 api 파라미터 수정
   - 인터셉터 추가로 인해 잉여 파라미터가 된 토큰 헤더들을 삭제했습니다.
- AuthActivity 시작 애니메이션 추가 5f8006fd10da8b2572074dcfca8db8a2e9722a86
- 로그아웃 팝업 추가 46a51d80294f976337ab819d8b4fef08c2064175

## 영상

https://github.com/user-attachments/assets/4c3d768f-3e3d-4df1-b687-69f965539b2d