### PR TITLE
kuring-236 새 학과를 앱에서 볼 수 없던 문제 해결

### DIFF
--- a/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
+++ b/data/department/src/main/java/com/ku_stacks/ku_ring/department/repository/DepartmentRepositoryImpl.kt
@@ -34,7 +34,7 @@ class DepartmentRepositoryImpl @Inject constructor(
             if (departmentDao.isEmpty()) {
                 departmentDao.insertDepartments(departments.toEntityList())
             } else {
-                updateDepartmentsName(it)
+                updateDepartments(it)
             }
         }
         addUnsupportedDepartments()
@@ -44,6 +44,22 @@ class DepartmentRepositoryImpl @Inject constructor(
         return suspendRunCatching {
             departmentClient.fetchDepartmentList().data?.map { it.toDepartment() } ?: emptyList()
         }.getOrNull()
+    }
+
+    private suspend fun updateDepartments(departments: List<Department>) {
+        insertNewDepartments(departments)
+        updateDepartmentsName(departments)
+    }
+
+    private suspend fun insertNewDepartments(departments: List<Department>) {
+        val savedDepartmentsName = getAllDepartments().map { it.name }.toSet()
+        val insertTargets = departments.filter { department ->
+            department.name !in savedDepartmentsName
+        }
+
+        withContext(ioDispatcher) {
+            insertDepartments(insertTargets)
+        }
     }
 
     private suspend fun updateDepartmentsName(departments: List<Department>) {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-236?atlOrigin=eyJpIjoiNDRjNjNkNDkyZDk1NDZhNWExOGMxZjVmOGZmOWRjMjEiLCJwIjoiaiJ9

## 요약

DB에 새 학과를 넣지 않던 문제를 해결했습니다. 

학과 테이블의 key인 `name`을 비교하여, 로컬 DB에 `name`이 없는 entry를 추가하는 방식으로 구현했습니다.

## 검증

새 학과인 `KU자율전공학부`가 정상 추가되었고, 테이블의 다른 row에는 영향이 없음을 확인했습니다.

## 참고

**이 PR은 merge 즉시 출시되어야 합니다.**