### PR TITLE
kuring-235: 회원정보 및 토큰 관리

### DIFF
--- a/core/util/src/main/java/com/ku_stacks/ku_ring/util/ThrowableUtil.kt
+++ b/core/util/src/main/java/com/ku_stacks/ku_ring/util/ThrowableUtil.kt
@@ -5,13 +5,13 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 
-fun Throwable.getHttpExceptionMessage(): String? = when (this) {
+fun Throwable.getHttpExceptionMessage(): HttpExceptionMessage? = when (this) {
     is HttpException -> {
         val errorBody = response()?.errorBody()?.string()
 
         if (!errorBody.isNullOrBlank()) {
             runCatching {
-                Json.decodeFromString<ErrorMessage>(errorBody).resultMessage
+                Json.decodeFromString<HttpExceptionMessage>(errorBody)
             }.fold(
                 onSuccess = { it },
                 onFailure = { null }
@@ -22,9 +22,11 @@ fun Throwable.getHttpExceptionMessage(): String? = when (this) {
 }
 
 @Serializable
-private data class ErrorMessage(
+data class HttpExceptionMessage(
     @SerialName("resultMsg")
-    val resultMessage: String,
-    val resultCode: Int,
+    val message: String,
+    @SerialName("resultCode")
+    val code: Int,
+    @SerialName("isSuccess")
     val isSuccess: Boolean,
 )

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.ku_stacks.ku_ring.remote.user.request.AuthorizeUserRequest
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.user.mapper.toDomain
 import com.ku_stacks.ku_ring.user.mapper.toEntity
+import com.ku_stacks.ku_ring.util.getHttpExceptionMessage
 import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -58,6 +59,9 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun getUserData(): Result<User> = runCatching {
         userClient.getUserData().toDomain()
+    }.onFailure { exception ->
+        val code = exception.getHttpExceptionMessage()?.code
+        if (code in (400..404)) pref.deleteAccessToken()
     }
 
     override suspend fun signUpUser(

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/reset_password/ResetPasswordViewModel.kt
@@ -60,7 +60,7 @@ class ResetPasswordViewModel @Inject constructor(
                 emailVerifiedState = VerifiedState.Success
             }
             .onFailure { exception ->
-                val message = exception.getHttpExceptionMessage()
+                val message = exception.getHttpExceptionMessage()?.message
                 emailVerifiedState = VerifiedState.Fail(message)
             }
     }
@@ -72,7 +72,7 @@ class ResetPasswordViewModel @Inject constructor(
                 _sideEffect.send(ResetPasswordSideEffect.NavigateToResetPassword)
             }
             .onFailure { exception ->
-                val message = exception.getHttpExceptionMessage()
+                val message = exception.getHttpExceptionMessage()?.message
                 codeVerifiedState = VerifiedState.Fail(message)
             }
     }

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpViewModel.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/SignUpViewModel.kt
@@ -43,7 +43,7 @@ class SignUpViewModel @Inject constructor(
                 emailVerifiedState = VerifiedState.Success
             }
             .onFailure { exception ->
-                val message = exception.getHttpExceptionMessage()
+                val message = exception.getHttpExceptionMessage()?.message
                 emailVerifiedState = VerifiedState.Fail(message)
             }
     }
@@ -54,7 +54,7 @@ class SignUpViewModel @Inject constructor(
                 codeVerifiedState = VerifiedState.Success
             }
             .onFailure { exception ->
-                val message = exception.getHttpExceptionMessage()
+                val message = exception.getHttpExceptionMessage()?.message
                 codeVerifiedState = VerifiedState.Fail(message)
             }
     }

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!--Email Input Group-->
-    <string name="email_input_group_placeholder_email">힉교 이메일 주소</string>
+    <string name="email_input_group_placeholder_email">학교 이메일 주소</string>
     <string name="email_input_group_button_resend">재전송</string>
     <string name="email_input_group_button_email">인증번호</string>
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
-import com.ku_stacks.ku_ring.util.getHttpExceptionMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,6 +13,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.net.UnknownHostException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -61,13 +61,10 @@ class SettingViewModel @Inject constructor(
                 _userProfileState.update { UserProfileState.LoggedIn(response.nickName) }
             }
             .onFailure { exception ->
-                val message = exception.getHttpExceptionMessage()
-
-                if (message != null) {
-                    // 쿠링 서버의 응답 형식에 맞게 파싱되었음을 의미
-                    _userProfileState.update { UserProfileState.NotLoggedIn }
-                } else {
+                if (exception is UnknownHostException) {
                     _userProfileState.update { UserProfileState.Error }
+                } else {
+                    _userProfileState.update { UserProfileState.NotLoggedIn }
                 }
             }
     }

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -2,7 +2,6 @@ import com.ku_stacks.ku_ring.buildlogic.dsl.setNameSpace
 
 plugins {
     kuring("compose")
-    kuring("view")
     kuringPrimitive("test")
 }
 
@@ -22,7 +21,6 @@ dependencies {
     implementation(projects.data.user)
     implementation(projects.domain.user)
 
-    implementation(libs.androidx.constraintlayout)
     implementation(libs.semver)
 
     implementation(libs.bundles.compose.interop)

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
@@ -70,6 +70,7 @@ class SplashActivity : AppCompatActivity() {
         }
 
         enqueueReengagementNotificationWork()
+        checkUserValidity()
         updateDepartmentsFromRemote()
         loadMinimumAppVersion()
         collectScreenState()
@@ -89,6 +90,10 @@ class SplashActivity : AppCompatActivity() {
             ExistingWorkPolicy.REPLACE,
             notificationWorkRequest,
         )
+    }
+
+    private fun checkUserValidity() {
+        viewModel.getUserData()
     }
 
     private fun updateDepartmentsFromRemote() {

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashViewModel.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
+import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import com.ku_stacks.ku_ring.space.repository.KuringSpaceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
     private val kuringSpaceRepository: KuringSpaceRepository,
     private val departmentRepository: DepartmentRepository,
+    private val userRepository: UserRepository,
 ) : ViewModel() {
 
     private val _splashScreenState = MutableStateFlow(SplashScreenState.INITIAL)
@@ -47,6 +49,10 @@ class SplashViewModel @Inject constructor(
         } catch (e: Exception) {
             "0.0.0"
         }
+    }
+
+    fun getUserData() = viewModelScope.launch {
+        userRepository.getUserData()
     }
 
     fun dismissUpdateNotification() {

--- a/feature/splash/src/test/java/com/ku_stacks/ku_ring/splash/SplashViewModelTest.kt
+++ b/feature/splash/src/test/java/com/ku_stacks/ku_ring/splash/SplashViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.splash
 
 import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
+import com.ku_stacks.ku_ring.domain.user.repository.UserRepository
 import com.ku_stacks.ku_ring.space.repository.KuringSpaceRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,13 +22,15 @@ class SplashViewModelTest {
         Mockito.mock(KuringSpaceRepository::class.java)
     private val departmentRepository: DepartmentRepository =
         Mockito.mock(DepartmentRepository::class.java)
+    private val userRepository: UserRepository =
+        Mockito.mock(UserRepository::class.java)
     private lateinit var viewModel: SplashViewModel
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun init() {
         Dispatchers.setMain(dispatcher)
-        viewModel = SplashViewModel(kuringSpaceRepository, departmentRepository)
+        viewModel = SplashViewModel(kuringSpaceRepository, departmentRepository, userRepository)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## 요약
- 회원정보 API에 토큰 관리 로직 추가
   - "계정 없음", "유효하지 않은 토큰"과 같은 오류 발생 시 기기 내 저장된 토큰 삭제
- Throwable 확장함수의 반환값을 문자열에서 데이터클래스로 수정
- 입력 필드 내 문자열 "힉교" -> "학교"로 수정

## 상세
- 설정화면 내 상태관리 방식을 Exception 타입에 따라 나누는 걸로 재수정했습니다.
   인터넷 연결 오류의 경우에만 에러화면을 띄우고, 나머지의 경우엔 토큰을 지우고 비로그인 화면이 띄워집니다.

- 기능 구현은 이것으로 끝입니다! 이번주동안 개인적으로 테스트해보고 미흡한 부분 있으면 fix PR 올리도록 할게요!