### PR TITLE
kuring-234 댓글 UI 로직 (get)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation(projects.core.uiUtil)
     implementation(projects.core.thirdparty)
     implementation(projects.data.domain)
+    implementation(projects.data.noticecomment)
     implementation(projects.feature.editDepartments)
     implementation(projects.feature.editSubscription)
     implementation(projects.feature.feedback)

--- a/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/navigator/KuringNavigatorImpl.kt
@@ -48,10 +48,11 @@ class KuringNavigatorImpl @Inject constructor() : KuringNavigator {
         activity: Activity,
         url: String,
         articleId: String,
+        id: Int,
         category: String,
         subject: String,
     ) {
-        MainActivity.start(activity, url, articleId, category, subject)
+        MainActivity.start(activity, url, articleId, id, category, subject)
     }
 
     override fun navigateToSearch(activity: Activity) {
@@ -62,10 +63,11 @@ class KuringNavigatorImpl @Inject constructor() : KuringNavigator {
         context: Context,
         url: String?,
         articleId: String?,
+        id: Int?,
         category: String?,
         subject: String?,
     ): Intent {
-        return NoticeWebActivity.createIntent(context, url, articleId, category, subject)
+        return NoticeWebActivity.createIntent(context, url, articleId, id, category, subject)
     }
 
     override fun navigateToNoticeWeb(activity: Activity, notice: Notice) {

--- a/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RetrofitPlugin.kt
+++ b/build-logic/src/main/kotlin/com/ku_stacks/ku_ring/buildlogic/primitive/RetrofitPlugin.kt
@@ -14,6 +14,7 @@ class RetrofitPlugin: Plugin<Project> {
             implementationPlatform(libs.library("retrofit-bom"))
             implementation(libs.library("retrofit"))
             implementation(libs.library("retrofit-converter-gson"))
+            implementation(libs.library("retrofit-converter-kotlinx-serialization"))
         }
     }
 }

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -33,12 +34,19 @@ import com.ku_stacks.ku_ring.domain.PlainNoticeComment
 @Composable
 fun Comment(
     comment: NoticeComment,
+    isReplyComment: Boolean,
     onReplyIconClick: () -> Unit,
     onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val background = if (isReplyComment) {
+        KuringTheme.colors.mainPrimarySelected
+    } else {
+        Color.Transparent
+    }
+
     Column(
-        modifier = modifier.background(KuringTheme.colors.background),
+        modifier = modifier.background(background),
     ) {
         Comment(
             comment = comment.comment,
@@ -89,6 +97,7 @@ fun Comment(
             commentId = comment.id,
             username = comment.authorName,
             onReplyIconClick = onReplyIconClick,
+            isDeletable = comment.isMyComment,
             onDeleteComment = onDeleteComment,
         )
         Text(
@@ -119,6 +128,7 @@ private fun CommentHeader(
     commentId: Int,
     username: String,
     onReplyIconClick: () -> Unit,
+    isDeletable: Boolean,
     onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -149,13 +159,14 @@ private fun CommentHeader(
             modifier = Modifier.clickable { onReplyIconClick() },
             tint = KuringTheme.colors.textBody,
         )
-        // TODO: 자기 댓글에만 보여주기?
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
-            contentDescription = stringResource(R.string.comment_delete),
-            modifier = Modifier.clickable { onDeleteComment(commentId) },
-            tint = KuringTheme.colors.textBody,
-        )
+        if (isDeletable) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
+                contentDescription = stringResource(R.string.comment_delete),
+                modifier = Modifier.clickable { onDeleteComment(commentId) },
+                tint = KuringTheme.colors.textBody,
+            )
+        }
     }
 }
 
@@ -166,6 +177,7 @@ private val previewComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )
@@ -180,6 +192,7 @@ private fun CommentPreview() {
                 replies = List(3) { previewComment },
                 hasNext = false,
             ),
+            isReplyComment = true,
             onReplyIconClick = {},
             onDeleteComment = {},
             modifier = Modifier

--- a/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
+++ b/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
@@ -75,6 +75,7 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
                 body = categoryKr,
                 url = fullUrl,
                 articleId = articleId,
+                id = id,
                 category = category,
                 subject = subject,
             )
@@ -94,10 +95,11 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         body: String?,
         url: String?,
         articleId: String?,
+        id: Int?,
         category: String?,
         subject: String?,
     ) {
-        val intent = navigator.createNoticeWebIntent(this, url, articleId, category, subject)
+        val intent = navigator.createNoticeWebIntent(this, url, articleId, id, category, subject)
         KuringNotificationManager.showNotificationWithUrl(this, intent, title, body)
     }
 

--- a/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
+++ b/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/KuringNavigator.kt
@@ -12,12 +12,20 @@ interface KuringNavigator {
     fun navigateToFeedback(activity: Activity)
     fun createMainIntent(context: Context): Intent
     fun navigateToMain(activity: Activity)
-    fun navigateToMain(activity: Activity, url: String, articleId: String, category: String, subject: String)
+    fun navigateToMain(
+        activity: Activity,
+        url: String,
+        articleId: String,
+        id: Int,
+        category: String,
+        subject: String
+    )
     fun navigateToSearch(activity: Activity)
     fun createNoticeWebIntent(
         context: Context,
         url: String?,
         articleId: String?,
+        id: Int?,
         category: String?,
         subject: String?,
     ): Intent

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -7,6 +7,7 @@ data class PlainNoticeComment(
     val authorName: String,
     val noticeId: Int,
     val content: String,
+    val isMyComment: Boolean,
     val postedDatetime: String,
     val updatedDatetime: String,
     // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -2,7 +2,7 @@ package com.ku_stacks.ku_ring.domain
 
 data class PlainNoticeComment(
     val id: Int,
-    val parentCommentId: Int,
+    val parentCommentId: Int?,
     val authorId: Int,
     val authorName: String,
     val noticeId: Int,

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/WebViewNotice.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/WebViewNotice.kt
@@ -5,6 +5,7 @@ import java.io.Serializable
 data class WebViewNotice(
     val url: String,
     val articleId: String,
+    val id: Int,
     val category: String,
     val subject: String,
 ): Serializable {

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/mapper/ModelToModelMapper.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/mapper/ModelToModelMapper.kt
@@ -6,6 +6,7 @@ import com.ku_stacks.ku_ring.domain.WebViewNotice
 fun Notice.toWebViewNotice() = WebViewNotice(
     url = url,
     articleId = articleId,
+    id = id,
     category = category,
     subject = subject,
 )

--- a/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/di/RepositoryModule.kt
+++ b/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.ku_stacks.ku_ring.noticecomment.di
+
+import com.ku_stacks.ku_ring.domain.noticecomment.repository.NoticeCommentRepository
+import com.ku_stacks.ku_ring.noticecomment.NoticeCommentRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun provideNoticeCommentRepository(repositoryImpl: NoticeCommentRepositoryImpl): NoticeCommentRepository
+}

--- a/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
+++ b/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
@@ -22,6 +22,7 @@ internal fun NoticeCommentResponse.PlainNoticeCommentResponse.toDomain() = Plain
     authorName = authorName,
     noticeId = noticeId,
     content = content,
+    isMyComment = isMyComment,
     postedDatetime = createdAt,
     updatedDatetime = updatedAt,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/di/NoticeCommentModule.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/di/NoticeCommentModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 object NoticeCommentModule {
     @Provides
     @Singleton
-    fun provideNoticeCommentService(@Named("Default") retrofit: Retrofit): NoticeCommentService {
+    fun provideNoticeCommentService(@Named("KotlinxSerialization") retrofit: Retrofit): NoticeCommentService {
         return retrofit.create(NoticeCommentService::class.java)
     }
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/request/NoticeCommentCreateRequest.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/request/NoticeCommentCreateRequest.kt
@@ -1,17 +1,19 @@
 package com.ku_stacks.ku_ring.remote.noticecomment.request
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class NoticeCommentCreateRequest(
     /**
      * If null, create a common comment.
      * If not null, create a reply comment.
      */
-    @SerializedName("parentId")
+    @SerialName("parentId")
     val parentId: Int?,
     /**
      * Content of the comment.
      */
-    @SerializedName("content")
+    @SerialName("content")
     val content: String,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/request/NoticeCommentEditRequest.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/request/NoticeCommentEditRequest.kt
@@ -1,11 +1,13 @@
 package com.ku_stacks.ku_ring.remote.noticecomment.request
 
-import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class NoticeCommentEditRequest(
     /**
      * Updated content of the comment.
      */
-    @SerializedName("content")
+    @SerialName("content")
     val content: String,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
@@ -12,7 +12,7 @@ data class NoticeCommentResponse(
     @Serializable
     data class NoticeCommentResponseData(
         @SerialName("comments") val comments: List<NoticeCommentWithReplyResponse>,
-        @SerialName("endCursor") val lastCommentId: String,
+        @SerialName("endCursor") val lastCommentId: String?,
         @SerialName("hasNext") val hasNext: Boolean,
     )
 
@@ -25,7 +25,7 @@ data class NoticeCommentResponse(
     @Serializable
     data class PlainNoticeCommentResponse(
         @SerialName("id") val commentId: Int,
-        @SerialName("parentId") val parentCommentId: Int,
+        @SerialName("parentId") val parentCommentId: Int?,
         @SerialName("userId") val authorId: Int,
         @SerialName("nickName") val authorName: String,
         @SerialName("noticeId") val noticeId: Int,

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
@@ -30,6 +30,7 @@ data class NoticeCommentResponse(
         @SerialName("nickName") val authorName: String,
         @SerialName("noticeId") val noticeId: Int,
         @SerialName("content") val content: String,
+        @SerialName("isMine") val isMyComment: Boolean,
         @SerialName("createdAt") val createdAt: String,
         @SerialName("updatedAt") val updatedAt: String,
         // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/DefaultResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/DefaultResponse.kt
@@ -1,11 +1,20 @@
 package com.ku_stacks.ku_ring.remote.util
 
 import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+// TODO by mwy3055: kotlinx serialization으로 통일하기
+@Serializable
 data class DefaultResponse(
-    @SerializedName("code") val resultCode: Int,
-    @SerializedName("message") val resultMsg: String,
-    val data: Any?,
+    @SerializedName("code")
+    @SerialName("code")
+    val resultCode: Int,
+    @SerializedName("message")
+    @SerialName("message")
+    val resultMsg: String,
+    @Contextual val data: Any?,
 ) {
     val isSuccess: Boolean
         get() = (resultCode == 200)

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/NetworkModule.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/NetworkModule.kt
@@ -12,10 +12,13 @@ import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.sse.SSE
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -46,6 +49,19 @@ object NetworkModule {
             .client(okHttpClient)
             .baseUrl(BuildConfig.API_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    private val kotlinxJson = Json { ignoreUnknownKeys = true }
+
+    @Provides
+    @Singleton
+    @Named("KotlinxSerialization")
+    fun provideKotlinxSerializationRetrofit(@Named("Default") okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .client(okHttpClient)
+            .baseUrl(BuildConfig.API_BASE_URL)
+            .addConverterFactory(kotlinxJson.asConverterFactory("application/json; charset=UTF8".toMediaType()))
             .build()
     }
 

--- a/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentUseCase.kt
+++ b/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentUseCase.kt
@@ -2,10 +2,8 @@ package com.ku_stacks.ku_ring.domain.noticecomment.usecase
 
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
-import androidx.paging.PagingData
 import com.ku_stacks.ku_ring.domain.NoticeComment
 import com.ku_stacks.ku_ring.domain.noticecomment.repository.NoticeCommentRepository
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetNoticeCommentUseCase @Inject constructor(
@@ -18,8 +16,8 @@ class GetNoticeCommentUseCase @Inject constructor(
      *
      * @returns A list of comments.
      */
-    operator fun invoke(noticeId: Int): Flow<PagingData<NoticeComment>> =
+    operator fun invoke(noticeId: Int): Pager<Int, NoticeComment> =
         Pager(PagingConfig(GetNoticeCommentPagingSource.PAGE_SIZE)) {
             GetNoticeCommentPagingSource(noticeCommentRepository, noticeId)
-        }.flow
+        }
 }

--- a/domain/noticecomment/src/test/java/com/ku_stacks/ku_ring/domain/noticecomment/util/NoticeCommentFactory.kt
+++ b/domain/noticecomment/src/test/java/com/ku_stacks/ku_ring/domain/noticecomment/util/NoticeCommentFactory.kt
@@ -21,6 +21,7 @@ class NoticeCommentFactory {
         content = "Test comment $lastCommentId",
         postedDatetime = "test posted time",
         updatedDatetime = "test updated time",
+        isMyComment = (lastCommentId % 2 == 0),
     )
 
     companion object {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
@@ -72,13 +72,14 @@ class MainActivity : AppCompatActivity() {
             activity: Activity,
             url: String,
             articleId: String,
+            id: Int,
             category: String,
             subject: String,
         ) {
             val intent = createIntent(activity).apply {
                 putExtra(
                     WebViewNotice.EXTRA_KEY,
-                    WebViewNotice(url, articleId, category, subject),
+                    WebViewNotice(url, articleId, id, category, subject),
                 )
             }
             activity.startActivity(intent)

--- a/feature/notice_detail/build.gradle.kts
+++ b/feature/notice_detail/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.data.domain)
     implementation(projects.data.notice)
+    implementation(projects.domain.noticecomment)
 
     implementation(libs.bundles.compose.interop)
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebActivity.kt
@@ -41,8 +41,8 @@ class NoticeWebActivity : AppCompatActivity() {
     companion object {
 
         fun start(activity: Activity, webViewNotice: WebViewNotice) {
-            val (url, articleId, category, subject) = webViewNotice
-            val intent = createIntent(activity, url, articleId, category, subject)
+            val (url, articleId, id, category, subject) = webViewNotice
+            val intent = createIntent(activity, url, articleId, id, category, subject)
             activity.apply {
                 startActivity(intent)
                 overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
@@ -53,17 +53,19 @@ class NoticeWebActivity : AppCompatActivity() {
             context: Context,
             url: String?,
             articleId: String?,
+            id: Int?,
             category: String?,
             subject: String?,
         ): Intent {
-            if (url == null || articleId == null || category == null) {
-                throw IllegalArgumentException("intent parameters shouldn't be null: $url, $articleId, $category")
+            if (url == null || articleId == null || category == null || id == null) {
+                throw IllegalArgumentException("intent parameters shouldn't be null: $url, $articleId, $id, $category")
             }
             return Intent(context, NoticeWebActivity::class.java).apply {
                 putExtra(
                     WebViewNotice.EXTRA_KEY, WebViewNotice(
                         url = url,
                         articleId = articleId,
+                        id = id,
                         category = category,
                         subject = subject.orEmpty(),
                     )

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -93,12 +93,6 @@ private fun NoticeWebScreen(
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val isBottomSheetVisible by rememberUpdatedState(newValue = bottomSheetState.isVisible || bottomSheetState.targetValue == SheetValue.Expanded)
 
-    LaunchedEffect(isBottomSheetVisible) {
-        if (isBottomSheetVisible) {
-            onCommentSheetOpen()
-        }
-    }
-
     Scaffold(
         topBar = {
             CenterTitleTopBar(
@@ -122,7 +116,10 @@ private fun NoticeWebScreen(
         },
         floatingActionButton = {
             NoticeWebScreenFab(
-                onClick = { coroutineScope.launch { bottomSheetState.show() } },
+                onClick = {
+                    onCommentSheetOpen()
+                    coroutineScope.launch { bottomSheetState.show() }
+                },
             )
         },
         modifier = modifier,

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.notice_detail
 
 import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -41,6 +42,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.Pager
 import androidx.paging.compose.collectAsLazyPagingItems
+import com.ku_stacks.ku_ring.designsystem.components.KuringAlertDialog
 import com.ku_stacks.ku_ring.designsystem.components.KuringWebView
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
@@ -60,6 +62,19 @@ fun NoticeWebScreen(
 ) {
     val isSaved by viewModel.isSaved.collectAsStateWithLifecycle()
     val commentPager by viewModel.commentsPager.collectAsStateWithLifecycle()
+    val replyCommentId by viewModel.replyCommentId.collectAsStateWithLifecycle()
+    val deleteCommentId by viewModel.deleteCommentId.collectAsStateWithLifecycle()
+
+    val context = LocalContext.current
+    val makeToast: (String) -> Unit = {
+        Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+    }
+
+    val onCreateCommentSuccessMessage = stringResource(R.string.comment_bottom_sheet_create_success)
+    val onCreateCommentFailMessage = stringResource(R.string.comment_bottom_sheet_create_fail)
+
+    val onDeleteCommentSuccessMessage = stringResource(R.string.comment_bottom_sheet_delete_success)
+    val onDeleteCommentFailMessage = stringResource(R.string.comment_bottom_sheet_delete_fail)
 
     NoticeWebScreen(
         webViewNotice = webViewNotice,
@@ -67,8 +82,26 @@ fun NoticeWebScreen(
         onNavigateBack = onNavigateBack,
         onSaveButtonClick = viewModel::onSaveButtonClick,
         doAfterPageLoaded = viewModel::updateNoticeTobeRead,
-        commentsPager = commentPager,
+        commentPager = commentPager,
         onCommentSheetOpen = viewModel::onCommentBottomSheetOpen,
+        onCreateComment = { comment ->
+            viewModel.createComment(
+                comment = comment,
+                onSuccess = { makeToast(onCreateCommentSuccessMessage) },
+                onFail = { makeToast(onCreateCommentFailMessage) },
+            )
+        },
+        setReplyCommentId = viewModel::setReplyCommentId,
+        replyCommentId = replyCommentId,
+        deleteCommentId = deleteCommentId,
+        deleteComment = {
+            viewModel.deleteComment(
+                onSuccess = { makeToast(onDeleteCommentSuccessMessage) },
+                onFail = { makeToast(onDeleteCommentFailMessage) }
+            )
+        },
+        onShowDeleteCommentPopup = viewModel::showDeleteCommentPopup,
+        onHideDeleteCommentPopup = viewModel::hideDeleteCommentPopup,
         modifier = modifier,
     )
 }
@@ -81,8 +114,15 @@ private fun NoticeWebScreen(
     onNavigateBack: () -> Unit,
     onSaveButtonClick: () -> Unit,
     doAfterPageLoaded: (WebViewNotice) -> Unit,
-    commentsPager: Pager<Int, NoticeComment>?,
+    commentPager: Pager<Int, NoticeComment>?,
     onCommentSheetOpen: () -> Unit,
+    onCreateComment: (String) -> Unit,
+    setReplyCommentId: (Int?) -> Unit,
+    replyCommentId: Int?,
+    deleteCommentId: Int?,
+    deleteComment: () -> Unit,
+    onShowDeleteCommentPopup: (Int) -> Unit,
+    onHideDeleteCommentPopup: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(webViewNotice) {
@@ -92,6 +132,7 @@ private fun NoticeWebScreen(
     val coroutineScope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val isBottomSheetVisible by rememberUpdatedState(newValue = bottomSheetState.isVisible || bottomSheetState.targetValue == SheetValue.Expanded)
+    val commentPagingItems = commentPager?.flow?.collectAsLazyPagingItems()
 
     Scaffold(
         topBar = {
@@ -136,16 +177,40 @@ private fun NoticeWebScreen(
 
         if (isBottomSheetVisible) {
             ModalBottomSheet(
-                onDismissRequest = { coroutineScope.launch { bottomSheetState.hide() } },
+                onDismissRequest = {
+                    coroutineScope.launch {
+                        bottomSheetState.hide()
+                        setReplyCommentId(null)
+                    }
+                },
                 sheetState = bottomSheetState,
                 containerColor = KuringTheme.colors.background,
             ) {
                 CommentsBottomSheet(
-                    comments = commentsPager?.flow?.collectAsLazyPagingItems(),
+                    comments = commentPagingItems,
+                    replyCommentId = replyCommentId,
+                    onCreateComment = onCreateComment,
+                    setReplyCommentId = setReplyCommentId,
+                    onDeleteComment = onShowDeleteCommentPopup,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
         }
+    }
+
+    if (deleteCommentId != null) {
+        KuringAlertDialog(
+            text = stringResource(R.string.comment_bottom_sheet_dialog_text),
+            onConfirm = {
+                deleteComment()
+                commentPagingItems?.refresh()
+                onHideDeleteCommentPopup()
+            },
+            onCancel = { onHideDeleteCommentPopup() },
+            confirmText = stringResource(R.string.comment_bottom_sheet_dialog_delete_text),
+            cancelText = stringResource(R.string.comment_bottom_sheet_dialog_cancel_text),
+            confirmTextColor = KuringTheme.colors.warning,
+        )
     }
 }
 
@@ -233,8 +298,15 @@ private fun NoticeWebScreenPreview() {
             onNavigateBack = {},
             onSaveButtonClick = { isSaved = !isSaved },
             doAfterPageLoaded = {},
-            commentsPager = null,
+            commentPager = null,
             onCommentSheetOpen = {},
+            onCreateComment = {},
+            setReplyCommentId = {},
+            replyCommentId = null,
+            deleteCommentId = null,
+            deleteComment = {},
+            onShowDeleteCommentPopup = {},
+            onHideDeleteCommentPopup = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -228,6 +228,7 @@ private fun NoticeWebScreenPreview() {
             webViewNotice = WebViewNotice(
                 url = "https://www.google.com",
                 articleId = "123",
+                id = 1234,
                 category = "학사",
                 subject = "쿠링 발전의 건에 대하여",
             ),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -74,7 +74,7 @@ class NoticeWebViewModel @Inject constructor(
 
     fun onCommentBottomSheetOpen() {
         webViewNotice?.id?.let { id ->
-            if (commentsPager.value != null) {
+            if (commentsPager.value == null) {
                 _commentsPager.value = getNoticeCommentUseCase(id)
             }
         }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -3,12 +3,18 @@ package com.ku_stacks.ku_ring.notice_detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import com.ku_stacks.ku_ring.domain.NoticeComment
 import com.ku_stacks.ku_ring.domain.WebViewNotice
+import com.ku_stacks.ku_ring.domain.noticecomment.usecase.CreateNoticeCommentUseCase
+import com.ku_stacks.ku_ring.domain.noticecomment.usecase.DeleteNoticeCommentUseCase
+import com.ku_stacks.ku_ring.domain.noticecomment.usecase.GetNoticeCommentUseCase
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
 import com.ku_stacks.ku_ring.util.suspendRunCatching
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -16,6 +22,9 @@ import javax.inject.Inject
 @HiltViewModel
 class NoticeWebViewModel @Inject constructor(
     private val noticeRepository: NoticeRepository,
+    private val createNoticeCommentUseCase: CreateNoticeCommentUseCase,
+    private val deleteNoticeCommentUseCase: DeleteNoticeCommentUseCase,
+    private val getNoticeCommentUseCase: GetNoticeCommentUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val webViewNotice: WebViewNotice? by lazy { savedStateHandle[WebViewNotice.EXTRA_KEY] }
@@ -23,6 +32,9 @@ class NoticeWebViewModel @Inject constructor(
     private val _isSaved = MutableStateFlow(false)
     val isSaved: StateFlow<Boolean>
         get() = _isSaved
+
+    private val _commentsPager = MutableStateFlow<Pager<Int, NoticeComment>?>(null)
+    val commentsPager = _commentsPager.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -35,7 +47,10 @@ class NoticeWebViewModel @Inject constructor(
     fun updateNoticeTobeRead(webViewNotice: WebViewNotice) {
         viewModelScope.launch {
             suspendRunCatching {
-                noticeRepository.updateNoticeToBeReadOnStorage(webViewNotice.articleId, webViewNotice.category)
+                noticeRepository.updateNoticeToBeReadOnStorage(
+                    webViewNotice.articleId,
+                    webViewNotice.category
+                )
                 noticeRepository.updateNoticeToBeRead(
                     webViewNotice.articleId,
                     webViewNotice.category
@@ -54,6 +69,14 @@ class NoticeWebViewModel @Inject constructor(
                 webViewNotice?.category.orEmpty(),
                 !isSaved.value
             )
+        }
+    }
+
+    fun onCommentBottomSheetOpen() {
+        webViewNotice?.id?.let { id ->
+            if (commentsPager.value == null) {
+                _commentsPager.value = getNoticeCommentUseCase(id)
+            }
         }
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -74,7 +74,7 @@ class NoticeWebViewModel @Inject constructor(
 
     fun onCommentBottomSheetOpen() {
         webViewNotice?.id?.let { id ->
-            if (commentsPager.value == null) {
+            if (commentsPager.value != null) {
                 _commentsPager.value = getNoticeCommentUseCase(id)
             }
         }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
@@ -1,0 +1,193 @@
+package com.ku_stacks.ku_ring.notice_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.notice_detail.R
+
+@Composable
+internal fun CommentTextField(
+    onCreateComment: (String) -> Unit,
+    isReply: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var comment by remember { mutableStateOf("") }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CommentTextField(
+            comment = comment,
+            onCommentUpdate = { comment = it },
+            isReply = isReply,
+            modifier = Modifier.weight(1f),
+        )
+        CreateCommentButton(
+            onClick = {
+                onCreateComment(comment)
+                comment = ""
+            },
+            enabled = comment.isNotEmpty(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun CommentTextField(
+    comment: String,
+    onCommentUpdate: (String) -> Unit,
+    isReply: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(20.dp)
+    val textColor = KuringTheme.colors.textBody
+
+    val textStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 24.45.sp,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight(500),
+        color = textColor,
+    )
+
+    val placeholderText = if (isReply) {
+        stringResource(R.string.comment_bottom_sheet_textfield_reply_placeholder)
+    } else {
+        stringResource(R.string.comment_bottom_sheet_textfield_placeholder)
+    }
+
+    val interactionSource = remember { MutableInteractionSource() }
+
+    BasicTextField(
+        value = comment,
+        onValueChange = onCommentUpdate,
+        modifier = modifier
+            .clip(shape)
+            .border(width = 1.dp, color = KuringTheme.colors.gray200, shape = shape),
+        textStyle = textStyle,
+        decorationBox = { innerTextField ->
+            TextFieldDefaults.TextFieldDecorationBox(
+                value = comment,
+                innerTextField = innerTextField,
+                enabled = true,
+                singleLine = false,
+                visualTransformation = VisualTransformation.None,
+                placeholder = {
+                    Placeholder(
+                        placeholderText = placeholderText,
+                        style = textStyle.copy(color = KuringTheme.colors.textCaption3),
+                    )
+                },
+                colors = TextFieldDefaults.textFieldColors(
+                    textColor = textColor,
+                    backgroundColor = KuringTheme.colors.background,
+                    cursorColor = textColor,
+                ),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp),
+                interactionSource = interactionSource,
+            )
+        },
+        singleLine = false,
+        interactionSource = interactionSource,
+        maxLines = 5,
+        cursorBrush = SolidColor(textColor),
+    )
+}
+
+@Composable
+private fun Placeholder(
+    placeholderText: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = placeholderText,
+        modifier = modifier,
+        style = style,
+    )
+}
+
+
+@Composable
+private fun CreateCommentButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(R.string.comment_bottom_sheet_textfield_description)
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(KuringTheme.colors.gray400)
+            .clickable(
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .clearAndSetSemantics {
+                contentDescription = description
+            },
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_up_v2),
+            contentDescription = null,
+            modifier = Modifier.padding(8.dp),
+            tint = KuringTheme.colors.background,
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SearchTextFieldPreview() {
+    KuringTheme {
+        CommentTextField(
+            onCreateComment = {},
+            isReply = true,
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .padding(16.dp)
+                .fillMaxWidth(),
+        )
+    }
+}

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -2,6 +2,7 @@ package com.ku_stacks.ku_ring.notice_detail.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -44,14 +45,21 @@ internal fun CommentsBottomSheet(
             ),
             modifier = Modifier.padding(vertical = 10.dp),
         )
-        LazyPagingCommentColumn(
-            comments = comments,
-            onReplyIconClick = { /* TODO: implement */ },
-            onDeleteIconClick = { /* TODO: implement */ },
-            modifier = Modifier
-                .background(KuringTheme.colors.background)
-                .weight(1f),
-        )
+
+        if (comments == null) {
+            Spacer(Modifier.weight(1f))
+            CommentErrorText()
+            Spacer(Modifier.weight(1f))
+        } else {
+            LazyPagingCommentColumn(
+                comments = comments,
+                onReplyIconClick = { /* TODO: implement */ },
+                onDeleteIconClick = { /* TODO: implement */ },
+                modifier = Modifier
+                    .background(KuringTheme.colors.background)
+                    .weight(1f),
+            )
+        }
     }
 }
 
@@ -64,6 +72,19 @@ private fun CommentsBottomSheetPreview() {
     KuringTheme {
         CommentsBottomSheet(
             comments = fakePagingData,
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxSize(),
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun CommentsBottomSheetPreview_error() {
+    KuringTheme {
+        CommentsBottomSheet(
+            comments = null,
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -28,6 +28,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 internal fun CommentsBottomSheet(
     comments: LazyPagingItems<NoticeComment>?,
+    replyCommentId: Int?,
+    onCreateComment: (String) -> Unit,
+    setReplyCommentId: (Int?) -> Unit,
+    onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -53,13 +57,28 @@ internal fun CommentsBottomSheet(
         } else {
             LazyPagingCommentColumn(
                 comments = comments,
-                onReplyIconClick = { /* TODO: implement */ },
-                onDeleteIconClick = { /* TODO: implement */ },
+                replyCommentId = replyCommentId,
+                setReplyCommentId = setReplyCommentId,
+                onDeleteIconClick = onDeleteComment,
                 modifier = Modifier
                     .background(KuringTheme.colors.background)
                     .weight(1f),
             )
         }
+
+        CommentTextField(
+            onCreateComment = {
+                onCreateComment(it)
+                if (replyCommentId != null) {
+                    comments?.refresh()
+                } else {
+                    comments?.retry()
+                }
+                setReplyCommentId(null)
+            },
+            isReply = (replyCommentId != null),
+            modifier = Modifier.padding(vertical = 11.dp, horizontal = 20.dp),
+        )
     }
 }
 
@@ -72,6 +91,10 @@ private fun CommentsBottomSheetPreview() {
     KuringTheme {
         CommentsBottomSheet(
             comments = fakePagingData,
+            replyCommentId = fakePagingData[0]!!.comment.id,
+            onCreateComment = {},
+            setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
@@ -85,6 +108,10 @@ private fun CommentsBottomSheetPreview_error() {
     KuringTheme {
         CommentsBottomSheet(
             comments = null,
+            replyCommentId = null,
+            onCreateComment = {},
+            setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -3,8 +3,10 @@ package com.ku_stacks.ku_ring.notice_detail.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,7 +38,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 fun LazyPagingCommentColumn(
-    comments: LazyPagingItems<NoticeComment>?,
+    comments: LazyPagingItems<NoticeComment>,
     onReplyIconClick: () -> Unit,
     onDeleteIconClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -47,64 +49,77 @@ fun LazyPagingCommentColumn(
             .fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        when (comments?.loadState?.refresh) {
-            LoadState.Loading -> {
-                item {
-                    PagingLoadingIndicator(
-                        modifier = Modifier.size(50.dp),
-                    )
-                }
+        if (comments.itemCount == 0) {
+            item {
+                Text(
+                    text = stringResource(R.string.comment_bottom_sheet_empty),
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    color = colorResource(id = R.color.kus_label),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(top = 100.dp)
+                )
             }
+        } else {
+            commentItems(
+                comments = comments,
+                onReplyIconClick = onReplyIconClick,
+                onDeleteIconClick = onDeleteIconClick,
+            )
+        }
 
-            is LoadState.Error -> {
-                item {
-                    Text(
-                        text = stringResource(id = R.string.comment_bottom_sheet_error_loading),
-                        fontFamily = Pretendard,
-                        fontWeight = FontWeight.Normal,
-                        fontSize = 14.sp,
-                        color = colorResource(id = R.color.kus_label),
-                        textAlign = TextAlign.Center,
-                    )
-                }
+        if (comments.loadState.append == LoadState.Loading) {
+            item {
+                PagingLoadingIndicator(
+                    modifier = Modifier.size(40.dp),
+                )
             }
+        }
+    }
+}
 
-            else -> {
-                comments?.let { comments ->
-                    items(
-                        count = comments.itemCount,
-                        key = comments.itemKey { it.comment.id },
-                        contentType = comments.itemContentType { it.javaClass },
-                    ) { index ->
-                        comments[index]?.let { comment ->
-                            val borderColor = KuringTheme.colors.gray600
-                            Comment(
-                                comment = comment,
-                                onReplyIconClick = onReplyIconClick,
-                                onDeleteComment = onDeleteIconClick,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .drawBehind {
-                                        drawLine(
-                                            color = borderColor,
-                                            start = Offset(0f, size.height),
-                                            end = Offset(size.width, size.height),
-                                            strokeWidth = 1.dp.toPx(),
-                                        )
-                                    },
-                            )
-                        }
-                    }
+@Composable
+internal fun CommentErrorText(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(id = R.string.comment_bottom_sheet_error_loading),
+        fontFamily = Pretendard,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        color = colorResource(id = R.color.kus_label),
+        textAlign = TextAlign.Center,
+        modifier = modifier,
+    )
+}
 
-                    if (comments.loadState.append == LoadState.Loading) {
-                        item {
-                            PagingLoadingIndicator(
-                                modifier = Modifier.size(40.dp),
-                            )
-                        }
-                    }
-                }
-            }
+private fun LazyListScope.commentItems(
+    comments: LazyPagingItems<NoticeComment>,
+    onReplyIconClick: () -> Unit,
+    onDeleteIconClick: (Int) -> Unit,
+) {
+    items(
+        count = comments.itemCount,
+        key = comments.itemKey { it.comment.id },
+        contentType = comments.itemContentType { it.javaClass },
+    ) { index ->
+        comments[index]?.let { comment ->
+            val borderColor = KuringTheme.colors.gray600
+            Comment(
+                comment = comment,
+                onReplyIconClick = onReplyIconClick,
+                onDeleteComment = onDeleteIconClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 1.dp)
+                    .drawBehind {
+                        drawLine(
+                            color = borderColor,
+                            start = Offset(0f, size.height),
+                            end = Offset(size.width, size.height),
+                            strokeWidth = 1.dp.toPx(),
+                        )
+                    },
+            )
         }
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -67,13 +67,15 @@ fun LazyPagingCommentColumn(
                 onReplyIconClick = onReplyIconClick,
                 onDeleteIconClick = onDeleteIconClick,
             )
-        }
 
-        if (comments.loadState.append == LoadState.Loading) {
-            item {
-                PagingLoadingIndicator(
-                    modifier = Modifier.size(40.dp),
-                )
+            if (comments.loadState.append == LoadState.Loading) {
+                item {
+                    PagingLoadingIndicator(
+                        modifier = Modifier
+                            .padding(vertical = 10.dp)
+                            .size(40.dp),
+                    )
+                }
             }
         }
     }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -39,7 +39,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 fun LazyPagingCommentColumn(
     comments: LazyPagingItems<NoticeComment>,
-    onReplyIconClick: () -> Unit,
+    replyCommentId: Int?,
+    setReplyCommentId: (Int?) -> Unit,
     onDeleteIconClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -64,7 +65,8 @@ fun LazyPagingCommentColumn(
         } else {
             commentItems(
                 comments = comments,
-                onReplyIconClick = onReplyIconClick,
+                replyCommentId = replyCommentId,
+                setReplyCommentId = setReplyCommentId,
                 onDeleteIconClick = onDeleteIconClick,
             )
 
@@ -96,7 +98,8 @@ internal fun CommentErrorText(modifier: Modifier = Modifier) {
 
 private fun LazyListScope.commentItems(
     comments: LazyPagingItems<NoticeComment>,
-    onReplyIconClick: () -> Unit,
+    replyCommentId: Int?,
+    setReplyCommentId: (Int?) -> Unit,
     onDeleteIconClick: (Int) -> Unit,
 ) {
     items(
@@ -108,7 +111,10 @@ private fun LazyListScope.commentItems(
             val borderColor = KuringTheme.colors.gray600
             Comment(
                 comment = comment,
-                onReplyIconClick = onReplyIconClick,
+                isReplyComment = (replyCommentId == comment.comment.id),
+                onReplyIconClick = {
+                    setReplyCommentId(if (replyCommentId == null) comment.comment.id else null)
+                },
                 onDeleteComment = onDeleteIconClick,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -134,7 +140,8 @@ private fun LazyPagingCommentColumnPreview() {
     KuringTheme {
         LazyPagingCommentColumn(
             comments = fakePagingData,
-            onReplyIconClick = {},
+            replyCommentId = fakePagingData[0]!!.comment.id,
+            setReplyCommentId = {},
             onDeleteIconClick = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
@@ -10,6 +10,7 @@ internal val fakePlainComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )
@@ -17,7 +18,11 @@ internal const val size = 10
 internal val fakeComments: (Int) -> List<NoticeComment> = { size ->
     List(size) { index ->
         NoticeComment(
-            comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
+            comment = fakePlainComment.copy(
+                id = index,
+                authorName = "쿠링 $index",
+                isMyComment = (index % 2 == 0),
+            ),
             replies = List(2) {
                 fakePlainComment.copy(
                     id = index * 10 + it,

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="see_comment">댓글 보기</string>
     <string name="comment_bottom_sheet_title">댓글</string>
     <string name="comment_bottom_sheet_error_loading">댓글 로드 중 에러가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="comment_bottom_sheet_empty">등록된 댓글이 없어요.</string>
 </resources>

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -13,4 +13,14 @@
     <string name="comment_bottom_sheet_title">댓글</string>
     <string name="comment_bottom_sheet_error_loading">댓글 로드 중 에러가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="comment_bottom_sheet_empty">등록된 댓글이 없어요.</string>
+    <string name="comment_bottom_sheet_textfield_placeholder">댓글 추가</string>
+    <string name="comment_bottom_sheet_textfield_reply_placeholder">대댓글 추가</string>
+    <string name="comment_bottom_sheet_textfield_description">댓글 추가</string>
+    <string name="comment_bottom_sheet_create_success">댓글이 추가되었어요.</string>
+    <string name="comment_bottom_sheet_create_fail">댓글 추가에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="comment_bottom_sheet_dialog_text">댓글을 삭제할까요?</string>
+    <string name="comment_bottom_sheet_dialog_cancel_text">취소</string>
+    <string name="comment_bottom_sheet_dialog_delete_text">삭제하기</string>
+    <string name="comment_bottom_sheet_delete_success">댓글이 삭제되었어요.</string>
+    <string name="comment_bottom_sheet_delete_fail">댓글 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 </resources>

--- a/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
+++ b/feature/splash/src/main/java/com/ku_stacks/ku_ring/splash/SplashActivity.kt
@@ -187,6 +187,7 @@ class SplashActivity : AppCompatActivity() {
                 activity = this@SplashActivity,
                 url = fullUrl,
                 articleId = articleId,
+                id = id,
                 category = category,
                 subject = subject,
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,6 +180,7 @@ play-services-auth = 'com.google.android.gms:play-services-auth:21.3.0'
 retrofit-bom = { module = 'com.squareup.retrofit2:retrofit-bom', version.ref = 'retrofit' }
 retrofit = { module = 'com.squareup.retrofit2:retrofit' }
 retrofit-converter-gson = { module = 'com.squareup.retrofit2:converter-gson' }
+retrofit-converter-kotlinx-serialization = { module = 'com.squareup.retrofit2:converter-kotlinx-serialization' }
 
 # Ktor
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -199,6 +200,7 @@ semver = "net.swiftzer.semver:semver:2.1.0"
 retrofit = [
     'retrofit',
     'retrofit-converter-gson',
+    'retrofit-converter-kotlinx-serialization',
 ]
 compose = [
     'compose-foundation',


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-233?atlOrigin=eyJpIjoiZTc5MTI0MzdiNDgyNGVjMzljNDc4NTYxY2U2YTdlMzIiLCJwIjoiaiJ9

## 요약

댓글 UI 로직중 get 로직을 구현했습니다.

* https://github.com/ku-ring/KU-Ring-Android/commit/4415c5e1656db671b2982267bf27cdbfa7066576: 댓글 FAB, 댓글 바텀시트 추가
* https://github.com/ku-ring/KU-Ring-Android/commit/0e0efe9202e2531fde86561c46a017d657401304: 댓글 UI 구현
* https://github.com/ku-ring/KU-Ring-Android/commit/819c9b7a5875be0588e46d826a43be29f46d5e11: `kotlinx-serialization` 전용 Retrofit converter 추가
  * Gson converter가 `@SerialName`을 인식하지 못해서, 대신 kotlinx converter를 사용했습니다.

## 향후 작업

* 댓글 작성 로직 구현
* 댓글 삭제 로직 구현

_note: 댓글 수정 로직은 지난 회의에서 구현하지 않기로 결정되어, 이번에는 구현하지 않습니다._

## 스크린샷

컴퓨터공학과 공지 중 `2025학년도 하계방학 현장실습학기제 안내` 공지를 보시면 됩니다. (맨 위 공지입니다)

![image](https://github.com/user-attachments/assets/db0dc3b7-72b1-4e10-abed-44dc96758fe8)
