### PR TITLE
kuring-234 댓글/대댓글 작성 로직 구현

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -33,12 +34,19 @@ import com.ku_stacks.ku_ring.domain.PlainNoticeComment
 @Composable
 fun Comment(
     comment: NoticeComment,
+    isReplyComment: Boolean,
     onReplyIconClick: () -> Unit,
     onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val background = if (isReplyComment) {
+        KuringTheme.colors.mainPrimarySelected
+    } else {
+        Color.Transparent
+    }
+
     Column(
-        modifier = modifier.background(KuringTheme.colors.background),
+        modifier = modifier.background(background),
     ) {
         Comment(
             comment = comment.comment,
@@ -180,6 +188,7 @@ private fun CommentPreview() {
                 replies = List(3) { previewComment },
                 hasNext = false,
             ),
+            isReplyComment = true,
             onReplyIconClick = {},
             onDeleteComment = {},
             modifier = Modifier

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -97,6 +97,7 @@ fun Comment(
             commentId = comment.id,
             username = comment.authorName,
             onReplyIconClick = onReplyIconClick,
+            isDeletable = comment.isMyComment,
             onDeleteComment = onDeleteComment,
         )
         Text(
@@ -127,6 +128,7 @@ private fun CommentHeader(
     commentId: Int,
     username: String,
     onReplyIconClick: () -> Unit,
+    isDeletable: Boolean,
     onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -157,13 +159,14 @@ private fun CommentHeader(
             modifier = Modifier.clickable { onReplyIconClick() },
             tint = KuringTheme.colors.textBody,
         )
-        // TODO: 자기 댓글에만 보여주기?
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
-            contentDescription = stringResource(R.string.comment_delete),
-            modifier = Modifier.clickable { onDeleteComment(commentId) },
-            tint = KuringTheme.colors.textBody,
-        )
+        if (isDeletable) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
+                contentDescription = stringResource(R.string.comment_delete),
+                modifier = Modifier.clickable { onDeleteComment(commentId) },
+                tint = KuringTheme.colors.textBody,
+            )
+        }
     }
 }
 
@@ -174,6 +177,7 @@ private val previewComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -7,6 +7,7 @@ data class PlainNoticeComment(
     val authorName: String,
     val noticeId: Int,
     val content: String,
+    val isMyComment: Boolean,
     val postedDatetime: String,
     val updatedDatetime: String,
     // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
+++ b/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
@@ -22,6 +22,7 @@ internal fun NoticeCommentResponse.PlainNoticeCommentResponse.toDomain() = Plain
     authorName = authorName,
     noticeId = noticeId,
     content = content,
+    isMyComment = isMyComment,
     postedDatetime = createdAt,
     updatedDatetime = updatedAt,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
@@ -30,6 +30,7 @@ data class NoticeCommentResponse(
         @SerialName("nickName") val authorName: String,
         @SerialName("noticeId") val noticeId: Int,
         @SerialName("content") val content: String,
+        @SerialName("isMine") val isMyComment: Boolean,
         @SerialName("createdAt") val createdAt: String,
         @SerialName("updatedAt") val updatedAt: String,
         // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentPagingSource.kt
+++ b/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentPagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.ku_stacks.ku_ring.domain.NoticeComment
 import com.ku_stacks.ku_ring.domain.noticecomment.repository.NoticeCommentRepository
+import timber.log.Timber
 
 /**
  * Paging source which loads comments. This class should be instantiated per notice.
@@ -58,7 +59,9 @@ internal class GetNoticeCommentPagingSource(
 
     private fun assertPageCanBeLoaded(key: Int) {
         if (!canBeLoaded(key)) {
-            throw IllegalAccessException()
+            val message = "Page $key cannot be loaded."
+            Timber.e(message)
+            throw IllegalAccessException(message)
         }
     }
 

--- a/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentPagingSource.kt
+++ b/domain/noticecomment/src/main/java/com/ku_stacks/ku_ring/domain/noticecomment/usecase/GetNoticeCommentPagingSource.kt
@@ -20,6 +20,9 @@ internal class GetNoticeCommentPagingSource(
 
     private var lastCommentId: Int = 0
 
+    // page cursor, last loaded time (epoch)
+    private val lastLoadedTime = mutableMapOf<Int, Long>()
+
     override fun getRefreshKey(state: PagingState<Int, NoticeComment>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             val anchorItem = state.closestItemToPosition(anchorPosition)
@@ -29,8 +32,13 @@ internal class GetNoticeCommentPagingSource(
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NoticeComment> {
         return try {
-            val response = noticeCommentRepository.getComment(noticeId, lastCommentId.nextCursor)
-            val (comments, hasNext) = response.getOrThrow()
+            val cursor = lastCommentId.nextCursor
+            assertPageCanBeLoaded(cursor)
+
+            val response = noticeCommentRepository.getComment(noticeId, cursor)
+            val (comments, _) = response.getOrThrow()
+
+            updateLastLoadedTime(cursor)
 
             comments.maxOfOrNull { it.comment.id }?.let { maxCommentId ->
                 lastCommentId = maxCommentId
@@ -38,7 +46,7 @@ internal class GetNoticeCommentPagingSource(
             LoadResult.Page(
                 data = comments,
                 prevKey = null, // Only paging forward
-                nextKey = if (hasNext) lastCommentId.nextCursor else null,
+                nextKey = lastCommentId.nextCursor, // always have next key; fail if same load
             )
         } catch (e: Exception) {
             LoadResult.Error(e)
@@ -48,7 +56,29 @@ internal class GetNoticeCommentPagingSource(
     private val Int.nextCursor
         get() = this + 1
 
+    private fun assertPageCanBeLoaded(key: Int) {
+        if (!canBeLoaded(key)) {
+            throw IllegalAccessException()
+        }
+    }
+
+    private fun canBeLoaded(key: Int): Boolean {
+        return if (key !in lastLoadedTime) {
+            true
+        } else {
+            lastLoadedTime[key]!! + TIME_INTERVAL <= System.currentTimeMillis()
+        }
+    }
+
+    private fun updateLastLoadedTime(key: Int) {
+        lastLoadedTime[key] = System.currentTimeMillis()
+    }
+
+    override val keyReuseSupported: Boolean
+        get() = true
+
     companion object {
         const val PAGE_SIZE = NoticeCommentRepository.PAGE_SIZE
+        private const val TIME_INTERVAL = 3000L // ms
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebScreen.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.notice_detail
 
 import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -61,6 +62,13 @@ fun NoticeWebScreen(
     val isSaved by viewModel.isSaved.collectAsStateWithLifecycle()
     val commentPager by viewModel.commentsPager.collectAsStateWithLifecycle()
 
+    val context = LocalContext.current
+    val onCreateCommentSuccessMessage = stringResource(R.string.comment_bottom_sheet_create_success)
+    val onCreateCommentFailMessage = stringResource(R.string.comment_bottom_sheet_create_fail)
+    val makeToast: (String) -> Unit = {
+        Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+    }
+
     NoticeWebScreen(
         webViewNotice = webViewNotice,
         isSaved = isSaved,
@@ -69,6 +77,14 @@ fun NoticeWebScreen(
         doAfterPageLoaded = viewModel::updateNoticeTobeRead,
         commentsPager = commentPager,
         onCommentSheetOpen = viewModel::onCommentBottomSheetOpen,
+        onCreateComment = { parentCommentId, comment ->
+            viewModel.createComment(
+                parentCommentId = parentCommentId,
+                comment = comment,
+                onSuccess = { makeToast(onCreateCommentSuccessMessage) },
+                onFail = { makeToast(onCreateCommentFailMessage) },
+            )
+        },
         modifier = modifier,
     )
 }
@@ -83,6 +99,7 @@ private fun NoticeWebScreen(
     doAfterPageLoaded: (WebViewNotice) -> Unit,
     commentsPager: Pager<Int, NoticeComment>?,
     onCommentSheetOpen: () -> Unit,
+    onCreateComment: (Int?, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(webViewNotice) {
@@ -142,6 +159,7 @@ private fun NoticeWebScreen(
             ) {
                 CommentsBottomSheet(
                     comments = commentsPager?.flow?.collectAsLazyPagingItems(),
+                    onCreateComment = onCreateComment,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -235,6 +253,7 @@ private fun NoticeWebScreenPreview() {
             doAfterPageLoaded = {},
             commentsPager = null,
             onCommentSheetOpen = {},
+            onCreateComment = { _, _ -> },
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -79,4 +79,18 @@ class NoticeWebViewModel @Inject constructor(
             }
         }
     }
+
+    fun createComment(
+        parentCommentId: Int?, comment: String,
+        onSuccess: () -> Unit,
+        onFail: () -> Unit,
+    ) {
+        webViewNotice?.id?.let { id ->
+            viewModelScope.launch {
+                createNoticeCommentUseCase(id, parentCommentId, comment)
+                    .onSuccess { onSuccess() }
+                    .onFailure { onFail() }
+            }
+        }
+    }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -42,6 +42,9 @@ class NoticeWebViewModel @Inject constructor(
      */
     val replyCommentId = _replyCommentId.asStateFlow()
 
+    private val _deleteCommentId = MutableStateFlow<Int?>(null)
+    val deleteCommentId = _deleteCommentId.asStateFlow()
+
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->
@@ -102,5 +105,32 @@ class NoticeWebViewModel @Inject constructor(
 
     fun setReplyCommentId(id: Int?) {
         _replyCommentId.value = id
+    }
+
+    fun showDeleteCommentPopup(commentId: Int) {
+        setDeleteCommentId(commentId)
+    }
+
+    fun hideDeleteCommentPopup() {
+        setDeleteCommentId(null)
+    }
+
+    private fun setDeleteCommentId(commentId: Int?) {
+        _deleteCommentId.value = commentId
+    }
+
+    fun deleteComment(
+        onSuccess: () -> Unit,
+        onFail: () -> Unit,
+    ) {
+        val noticeId = webViewNotice?.id
+        val deleteCommentId = deleteCommentId.value
+        if (noticeId != null && deleteCommentId != null) {
+            viewModelScope.launch {
+                deleteNoticeCommentUseCase(noticeId, deleteCommentId)
+                    .onSuccess { onSuccess() }
+                    .onFailure { onFail() }
+            }
+        }
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -36,6 +36,12 @@ class NoticeWebViewModel @Inject constructor(
     private val _commentsPager = MutableStateFlow<Pager<Int, NoticeComment>?>(null)
     val commentsPager = _commentsPager.asStateFlow()
 
+    private val _replyCommentId = MutableStateFlow<Int?>(null)
+    /**
+     * Reply if not null, otherwise a common comment.
+     */
+    val replyCommentId = _replyCommentId.asStateFlow()
+
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->
@@ -81,16 +87,20 @@ class NoticeWebViewModel @Inject constructor(
     }
 
     fun createComment(
-        parentCommentId: Int?, comment: String,
+        comment: String,
         onSuccess: () -> Unit,
         onFail: () -> Unit,
     ) {
         webViewNotice?.id?.let { id ->
             viewModelScope.launch {
-                createNoticeCommentUseCase(id, parentCommentId, comment)
+                createNoticeCommentUseCase(id, replyCommentId.value, comment)
                     .onSuccess { onSuccess() }
                     .onFailure { onFail() }
             }
         }
+    }
+
+    fun setReplyCommentId(id: Int?) {
+        _replyCommentId.value = id
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
@@ -45,6 +45,7 @@ import com.ku_stacks.ku_ring.notice_detail.R
 @Composable
 internal fun CommentTextField(
     onCreateComment: (String) -> Unit,
+    isReply: Boolean,
     modifier: Modifier = Modifier,
 ) {
     var comment by remember { mutableStateOf("") }
@@ -57,6 +58,7 @@ internal fun CommentTextField(
         CommentTextField(
             comment = comment,
             onCommentUpdate = { comment = it },
+            isReply = isReply,
             modifier = Modifier.weight(1f),
         )
         CreateCommentButton(
@@ -74,6 +76,7 @@ internal fun CommentTextField(
 private fun CommentTextField(
     comment: String,
     onCommentUpdate: (String) -> Unit,
+    isReply: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(20.dp)
@@ -87,7 +90,11 @@ private fun CommentTextField(
         color = textColor,
     )
 
-    val placeholderText = stringResource(id = R.string.comment_bottom_sheet_textfield_placeholder)
+    val placeholderText = if (isReply) {
+        stringResource(R.string.comment_bottom_sheet_textfield_reply_placeholder)
+    } else {
+        stringResource(R.string.comment_bottom_sheet_textfield_placeholder)
+    }
 
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -176,6 +183,7 @@ private fun SearchTextFieldPreview() {
     KuringTheme {
         CommentTextField(
             onCreateComment = {},
+            isReply = true,
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .padding(16.dp)

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentTextField.kt
@@ -1,0 +1,185 @@
+package com.ku_stacks.ku_ring.notice_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.notice_detail.R
+
+@Composable
+internal fun CommentTextField(
+    onCreateComment: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var comment by remember { mutableStateOf("") }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CommentTextField(
+            comment = comment,
+            onCommentUpdate = { comment = it },
+            modifier = Modifier.weight(1f),
+        )
+        CreateCommentButton(
+            onClick = {
+                onCreateComment(comment)
+                comment = ""
+            },
+            enabled = comment.isNotEmpty(),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun CommentTextField(
+    comment: String,
+    onCommentUpdate: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(20.dp)
+    val textColor = KuringTheme.colors.textBody
+
+    val textStyle = TextStyle(
+        fontSize = 15.sp,
+        lineHeight = 24.45.sp,
+        fontFamily = Pretendard,
+        fontWeight = FontWeight(500),
+        color = textColor,
+    )
+
+    val placeholderText = stringResource(id = R.string.comment_bottom_sheet_textfield_placeholder)
+
+    val interactionSource = remember { MutableInteractionSource() }
+
+    BasicTextField(
+        value = comment,
+        onValueChange = onCommentUpdate,
+        modifier = modifier
+            .clip(shape)
+            .border(width = 1.dp, color = KuringTheme.colors.gray200, shape = shape),
+        textStyle = textStyle,
+        decorationBox = { innerTextField ->
+            TextFieldDefaults.TextFieldDecorationBox(
+                value = comment,
+                innerTextField = innerTextField,
+                enabled = true,
+                singleLine = false,
+                visualTransformation = VisualTransformation.None,
+                placeholder = {
+                    Placeholder(
+                        placeholderText = placeholderText,
+                        style = textStyle.copy(color = KuringTheme.colors.textCaption3),
+                    )
+                },
+                colors = TextFieldDefaults.textFieldColors(
+                    textColor = textColor,
+                    backgroundColor = KuringTheme.colors.background,
+                    cursorColor = textColor,
+                ),
+                contentPadding = PaddingValues(horizontal = 20.dp, vertical = 10.dp),
+                interactionSource = interactionSource,
+            )
+        },
+        singleLine = false,
+        interactionSource = interactionSource,
+        maxLines = 5,
+        cursorBrush = SolidColor(textColor),
+    )
+}
+
+@Composable
+private fun Placeholder(
+    placeholderText: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = placeholderText,
+        modifier = modifier,
+        style = style,
+    )
+}
+
+
+@Composable
+private fun CreateCommentButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(R.string.comment_bottom_sheet_textfield_description)
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(KuringTheme.colors.gray400)
+            .clickable(
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
+            .clearAndSetSemantics {
+                contentDescription = description
+            },
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_up_v2),
+            contentDescription = null,
+            modifier = Modifier.padding(8.dp),
+            tint = KuringTheme.colors.background,
+        )
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun SearchTextFieldPreview() {
+    KuringTheme {
+        CommentTextField(
+            onCreateComment = {},
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .padding(16.dp)
+                .fillMaxWidth(),
+        )
+    }
+}

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -28,7 +28,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 internal fun CommentsBottomSheet(
     comments: LazyPagingItems<NoticeComment>?,
-    onCreateComment: (Int?, String) -> Unit,
+    replyCommentId: Int?,
+    onCreateComment: (String) -> Unit,
+    setReplyCommentId: (Int?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -54,7 +56,8 @@ internal fun CommentsBottomSheet(
         } else {
             LazyPagingCommentColumn(
                 comments = comments,
-                onReplyIconClick = { /* TODO: implement */ },
+                replyCommentId = replyCommentId,
+                setReplyCommentId = setReplyCommentId,
                 onDeleteIconClick = { /* TODO: implement */ },
                 modifier = Modifier
                     .background(KuringTheme.colors.background)
@@ -64,9 +67,15 @@ internal fun CommentsBottomSheet(
 
         CommentTextField(
             onCreateComment = {
-                onCreateComment(null, it)
-                comments?.retry()
+                onCreateComment(it)
+                if (replyCommentId != null) {
+                    comments?.refresh()
+                } else {
+                    comments?.retry()
+                }
+                setReplyCommentId(null)
             },
+            isReply = (replyCommentId != null),
             modifier = Modifier.padding(vertical = 11.dp, horizontal = 20.dp),
         )
     }
@@ -81,7 +90,9 @@ private fun CommentsBottomSheetPreview() {
     KuringTheme {
         CommentsBottomSheet(
             comments = fakePagingData,
-            onCreateComment = { _, _ -> },
+            replyCommentId = fakePagingData[0]!!.comment.id,
+            onCreateComment = {},
+            setReplyCommentId = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
@@ -95,7 +106,9 @@ private fun CommentsBottomSheetPreview_error() {
     KuringTheme {
         CommentsBottomSheet(
             comments = null,
-            onCreateComment = { _, _ -> },
+            replyCommentId = null,
+            onCreateComment = {},
+            setReplyCommentId = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 internal fun CommentsBottomSheet(
     comments: LazyPagingItems<NoticeComment>?,
+    onCreateComment: (Int?, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -60,6 +61,14 @@ internal fun CommentsBottomSheet(
                     .weight(1f),
             )
         }
+
+        CommentTextField(
+            onCreateComment = {
+                onCreateComment(null, it)
+                comments?.retry()
+            },
+            modifier = Modifier.padding(vertical = 11.dp, horizontal = 20.dp),
+        )
     }
 }
 
@@ -72,6 +81,7 @@ private fun CommentsBottomSheetPreview() {
     KuringTheme {
         CommentsBottomSheet(
             comments = fakePagingData,
+            onCreateComment = { _, _ -> },
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
@@ -85,6 +95,7 @@ private fun CommentsBottomSheetPreview_error() {
     KuringTheme {
         CommentsBottomSheet(
             comments = null,
+            onCreateComment = { _, _ -> },
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -31,6 +31,7 @@ internal fun CommentsBottomSheet(
     replyCommentId: Int?,
     onCreateComment: (String) -> Unit,
     setReplyCommentId: (Int?) -> Unit,
+    onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -58,7 +59,7 @@ internal fun CommentsBottomSheet(
                 comments = comments,
                 replyCommentId = replyCommentId,
                 setReplyCommentId = setReplyCommentId,
-                onDeleteIconClick = { /* TODO: implement */ },
+                onDeleteIconClick = onDeleteComment,
                 modifier = Modifier
                     .background(KuringTheme.colors.background)
                     .weight(1f),
@@ -93,6 +94,7 @@ private fun CommentsBottomSheetPreview() {
             replyCommentId = fakePagingData[0]!!.comment.id,
             onCreateComment = {},
             setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
@@ -109,6 +111,7 @@ private fun CommentsBottomSheetPreview_error() {
             replyCommentId = null,
             onCreateComment = {},
             setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -39,7 +39,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 fun LazyPagingCommentColumn(
     comments: LazyPagingItems<NoticeComment>,
-    onReplyIconClick: () -> Unit,
+    replyCommentId: Int?,
+    setReplyCommentId: (Int?) -> Unit,
     onDeleteIconClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -64,7 +65,8 @@ fun LazyPagingCommentColumn(
         } else {
             commentItems(
                 comments = comments,
-                onReplyIconClick = onReplyIconClick,
+                replyCommentId = replyCommentId,
+                setReplyCommentId = setReplyCommentId,
                 onDeleteIconClick = onDeleteIconClick,
             )
 
@@ -96,7 +98,8 @@ internal fun CommentErrorText(modifier: Modifier = Modifier) {
 
 private fun LazyListScope.commentItems(
     comments: LazyPagingItems<NoticeComment>,
-    onReplyIconClick: () -> Unit,
+    replyCommentId: Int?,
+    setReplyCommentId: (Int?) -> Unit,
     onDeleteIconClick: (Int) -> Unit,
 ) {
     items(
@@ -108,7 +111,10 @@ private fun LazyListScope.commentItems(
             val borderColor = KuringTheme.colors.gray600
             Comment(
                 comment = comment,
-                onReplyIconClick = onReplyIconClick,
+                isReplyComment = (replyCommentId == comment.comment.id),
+                onReplyIconClick = {
+                    setReplyCommentId(if (replyCommentId == null) comment.comment.id else null)
+                },
                 onDeleteComment = onDeleteIconClick,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -134,7 +140,8 @@ private fun LazyPagingCommentColumnPreview() {
     KuringTheme {
         LazyPagingCommentColumn(
             comments = fakePagingData,
-            onReplyIconClick = {},
+            replyCommentId = fakePagingData[0]!!.comment.id,
+            setReplyCommentId = {},
             onDeleteIconClick = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
@@ -10,6 +10,7 @@ internal val fakePlainComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )
@@ -17,7 +18,11 @@ internal const val size = 10
 internal val fakeComments: (Int) -> List<NoticeComment> = { size ->
     List(size) { index ->
         NoticeComment(
-            comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
+            comment = fakePlainComment.copy(
+                id = index,
+                authorName = "쿠링 $index",
+                isMyComment = (index % 2 == 0),
+            ),
             replies = List(2) {
                 fakePlainComment.copy(
                     id = index * 10 + it,

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -18,4 +18,9 @@
     <string name="comment_bottom_sheet_textfield_description">댓글 추가</string>
     <string name="comment_bottom_sheet_create_success">댓글이 추가되었어요.</string>
     <string name="comment_bottom_sheet_create_fail">댓글 추가에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="comment_bottom_sheet_dialog_text">댓글을 삭제할까요?</string>
+    <string name="comment_bottom_sheet_dialog_cancel_text">취소</string>
+    <string name="comment_bottom_sheet_dialog_delete_text">삭제하기</string>
+    <string name="comment_bottom_sheet_delete_success">댓글이 삭제되었어요.</string>
+    <string name="comment_bottom_sheet_delete_fail">댓글 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 </resources>

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="comment_bottom_sheet_error_loading">댓글 로드 중 에러가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="comment_bottom_sheet_empty">등록된 댓글이 없어요.</string>
     <string name="comment_bottom_sheet_textfield_placeholder">댓글 추가</string>
+    <string name="comment_bottom_sheet_textfield_reply_placeholder">대댓글 추가</string>
     <string name="comment_bottom_sheet_textfield_description">댓글 추가</string>
     <string name="comment_bottom_sheet_create_success">댓글이 추가되었어요.</string>
     <string name="comment_bottom_sheet_create_fail">댓글 추가에 실패했어요. 잠시 후 다시 시도해 주세요.</string>

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -13,4 +13,8 @@
     <string name="comment_bottom_sheet_title">댓글</string>
     <string name="comment_bottom_sheet_error_loading">댓글 로드 중 에러가 발생했어요. 잠시 후 다시 시도해 주세요.</string>
     <string name="comment_bottom_sheet_empty">등록된 댓글이 없어요.</string>
+    <string name="comment_bottom_sheet_textfield_placeholder">댓글 추가</string>
+    <string name="comment_bottom_sheet_textfield_description">댓글 추가</string>
+    <string name="comment_bottom_sheet_create_success">댓글이 추가되었어요.</string>
+    <string name="comment_bottom_sheet_create_fail">댓글 추가에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-234?atlOrigin=eyJpIjoiMTEyZTA4M2E1MzAzNGY2NDgyMDU1NDQxODhlMWUwNGEiLCJwIjoiaiJ9

## 요약

댓글/대댓글 작성 로직을 구현했습니다.

## 상세

### PagingSource 변경사항

댓글 작성 로직을 살펴보기 전에, `GetNoticeCommentPagingSource`의 변경점을 살펴보겠습니다. 이 변경점은 매우 중요합니다.

이제 페이지를 로드한 후, 다음 페이지가 항상 로드됩니다. 그러나 3초 안에 같은 페이지 로드를 반복할 경우 로드가 즉시 실패합니다. **실패된 로드는 `LazyPagingItems#retry`를 호출하여 재시도할 수 있습니다.**

### 댓글 작성

댓글을 작성하면 `LazyPagingItems#retry`가 호출됩니다. 이 함수는 직전에 실패한 로드를 재실행합니다. 직전에 실패한 로드는 항상 '다음 페이지 로드'이므로, 새로 작성한 댓글이 항상 로드될 수 있습니다.

### 대댓글 작성

대댓글을 작성하면 `LazyPagingItems#refresh`가 호출됩니다. 이 함수는 `PagingSource`와 `PagingData` 인스턴스를 새로 만드는 역할을 합니다. 쉽게 말하면 데이터를 다시 로드하는 역할입니다. 따라서 대댓글이 UI에 로드되어 보이게 됩니다.

## 테스트 방법

`HeaderInterceptor.kt`의 48번 라인을, 노션 `Android > 회원가입/댓글 API 임시 토큰` 문서의 `액세스 토큰`으로 수정하고, `:data:remote`의 build.gradle에서 debug API 주소를 release와 같은 주소로 변경하면 댓글 추가 기능을 테스트할 수 있습니다.

## 스크린샷

![1](https://github.com/user-attachments/assets/d1a8b8bc-4983-4785-96dc-a0c79eea13cd)

![2](https://github.com/user-attachments/assets/64671da5-8b6e-4f64-87d2-873acfba5cdd)
