### PR TITLE
kuring-234 댓글 삭제 로직 구현

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -97,6 +97,7 @@ fun Comment(
             commentId = comment.id,
             username = comment.authorName,
             onReplyIconClick = onReplyIconClick,
+            isDeletable = comment.isMyComment,
             onDeleteComment = onDeleteComment,
         )
         Text(
@@ -127,6 +128,7 @@ private fun CommentHeader(
     commentId: Int,
     username: String,
     onReplyIconClick: () -> Unit,
+    isDeletable: Boolean,
     onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -157,13 +159,14 @@ private fun CommentHeader(
             modifier = Modifier.clickable { onReplyIconClick() },
             tint = KuringTheme.colors.textBody,
         )
-        // TODO: 자기 댓글에만 보여주기?
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
-            contentDescription = stringResource(R.string.comment_delete),
-            modifier = Modifier.clickable { onDeleteComment(commentId) },
-            tint = KuringTheme.colors.textBody,
-        )
+        if (isDeletable) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),
+                contentDescription = stringResource(R.string.comment_delete),
+                modifier = Modifier.clickable { onDeleteComment(commentId) },
+                tint = KuringTheme.colors.textBody,
+            )
+        }
     }
 }
 
@@ -174,6 +177,7 @@ private val previewComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/PlainNoticeComment.kt
@@ -7,6 +7,7 @@ data class PlainNoticeComment(
     val authorName: String,
     val noticeId: Int,
     val content: String,
+    val isMyComment: Boolean,
     val postedDatetime: String,
     val updatedDatetime: String,
     // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
+++ b/data/noticecomment/src/main/java/com/ku_stacks/ku_ring/noticecomment/mapper/ResponseToDomain.kt
@@ -22,6 +22,7 @@ internal fun NoticeCommentResponse.PlainNoticeCommentResponse.toDomain() = Plain
     authorName = authorName,
     noticeId = noticeId,
     content = content,
+    isMyComment = isMyComment,
     postedDatetime = createdAt,
     updatedDatetime = updatedAt,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/noticecomment/response/NoticeCommentResponse.kt
@@ -30,6 +30,7 @@ data class NoticeCommentResponse(
         @SerialName("nickName") val authorName: String,
         @SerialName("noticeId") val noticeId: Int,
         @SerialName("content") val content: String,
+        @SerialName("isMine") val isMyComment: Boolean,
         @SerialName("createdAt") val createdAt: String,
         @SerialName("updatedAt") val updatedAt: String,
         // TODO: Field "destroyedAt" is not used now. Add when needed.

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/NoticeWebViewModel.kt
@@ -42,6 +42,9 @@ class NoticeWebViewModel @Inject constructor(
      */
     val replyCommentId = _replyCommentId.asStateFlow()
 
+    private val _deleteCommentId = MutableStateFlow<Int?>(null)
+    val deleteCommentId = _deleteCommentId.asStateFlow()
+
     init {
         viewModelScope.launch {
             noticeRepository.getSavedNotices().collect { savedNotices ->
@@ -102,5 +105,32 @@ class NoticeWebViewModel @Inject constructor(
 
     fun setReplyCommentId(id: Int?) {
         _replyCommentId.value = id
+    }
+
+    fun showDeleteCommentPopup(commentId: Int) {
+        setDeleteCommentId(commentId)
+    }
+
+    fun hideDeleteCommentPopup() {
+        setDeleteCommentId(null)
+    }
+
+    private fun setDeleteCommentId(commentId: Int?) {
+        _deleteCommentId.value = commentId
+    }
+
+    fun deleteComment(
+        onSuccess: () -> Unit,
+        onFail: () -> Unit,
+    ) {
+        val noticeId = webViewNotice?.id
+        val deleteCommentId = deleteCommentId.value
+        if (noticeId != null && deleteCommentId != null) {
+            viewModelScope.launch {
+                deleteNoticeCommentUseCase(noticeId, deleteCommentId)
+                    .onSuccess { onSuccess() }
+                    .onFailure { onFail() }
+            }
+        }
     }
 }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/CommentsBottomSheet.kt
@@ -31,6 +31,7 @@ internal fun CommentsBottomSheet(
     replyCommentId: Int?,
     onCreateComment: (String) -> Unit,
     setReplyCommentId: (Int?) -> Unit,
+    onDeleteComment: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -58,7 +59,7 @@ internal fun CommentsBottomSheet(
                 comments = comments,
                 replyCommentId = replyCommentId,
                 setReplyCommentId = setReplyCommentId,
-                onDeleteIconClick = { /* TODO: implement */ },
+                onDeleteIconClick = onDeleteComment,
                 modifier = Modifier
                     .background(KuringTheme.colors.background)
                     .weight(1f),
@@ -93,6 +94,7 @@ private fun CommentsBottomSheetPreview() {
             replyCommentId = fakePagingData[0]!!.comment.id,
             onCreateComment = {},
             setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
@@ -109,6 +111,7 @@ private fun CommentsBottomSheetPreview_error() {
             replyCommentId = null,
             onCreateComment = {},
             setReplyCommentId = {},
+            onDeleteComment = {},
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/PreviewData.kt
@@ -10,6 +10,7 @@ internal val fakePlainComment = PlainNoticeComment(
     authorName = "쿠링",
     noticeId = 0,
     content = "쿠링 댓글 내용".repeat(10),
+    isMyComment = false,
     postedDatetime = "2025.03.23 20:27",
     updatedDatetime = "2025.03.23 20:27",
 )
@@ -17,7 +18,11 @@ internal const val size = 10
 internal val fakeComments: (Int) -> List<NoticeComment> = { size ->
     List(size) { index ->
         NoticeComment(
-            comment = fakePlainComment.copy(id = index, authorName = "쿠링 $index"),
+            comment = fakePlainComment.copy(
+                id = index,
+                authorName = "쿠링 $index",
+                isMyComment = (index % 2 == 0),
+            ),
             replies = List(2) {
                 fakePlainComment.copy(
                     id = index * 10 + it,

--- a/feature/notice_detail/src/main/res/values/strings.xml
+++ b/feature/notice_detail/src/main/res/values/strings.xml
@@ -18,4 +18,9 @@
     <string name="comment_bottom_sheet_textfield_description">댓글 추가</string>
     <string name="comment_bottom_sheet_create_success">댓글이 추가되었어요.</string>
     <string name="comment_bottom_sheet_create_fail">댓글 추가에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="comment_bottom_sheet_dialog_text">댓글을 삭제할까요?</string>
+    <string name="comment_bottom_sheet_dialog_cancel_text">취소</string>
+    <string name="comment_bottom_sheet_dialog_delete_text">삭제하기</string>
+    <string name="comment_bottom_sheet_delete_success">댓글이 삭제되었어요.</string>
+    <string name="comment_bottom_sheet_delete_fail">댓글 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-234?atlOrigin=eyJpIjoiMTEyZTA4M2E1MzAzNGY2NDgyMDU1NDQxODhlMWUwNGEiLCJwIjoiaiJ9

## 요약

댓글 삭제 로직을 구현했습니다.

**주의: 현재 댓글 추가/삭제 시 간헐적으로 UI가 업데이트되지 않는 문제가 있습니다. 해결 중입니다.**

## 상세

삭제 버튼을 누르면 팝업을 띄우고, 팝업의 `삭제하기` 버튼을 누르면 댓글이 삭제됩니다.

댓글 구현 끝!

## Note

~현재 댓글 API 응답으로는 댓글 작성자가 자신인지 확인할 수 없는 문제가 있습니다. 이 문제는 내일 회의에서 논의 예정입니다.~ API 응답에 bool 필드를 추가하기로 결정됐고,https://github.com/ku-ring/KU-Ring-Android/pull/492/commits/eda772bdf1c540368ccab6832780b6089412e7b0 에서 작업 완료했습니다.