### PR TITLE
[댓글 QA] 구분선, 대댓글 아이콘

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -96,6 +96,7 @@ fun Comment(
         CommentHeader(
             commentId = comment.id,
             username = comment.authorName,
+            isReply = (comment.parentCommentId != null),
             onReplyIconClick = onReplyIconClick,
             isDeletable = comment.isMyComment,
             onDeleteComment = onDeleteComment,
@@ -127,6 +128,7 @@ fun Comment(
 private fun CommentHeader(
     commentId: Int,
     username: String,
+    isReply: Boolean,
     onReplyIconClick: () -> Unit,
     isDeletable: Boolean,
     onDeleteComment: (Int) -> Unit,
@@ -153,12 +155,14 @@ private fun CommentHeader(
             )
         )
         Spacer(modifier = Modifier.weight(1f))
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_message_circle_v2),
-            contentDescription = stringResource(R.string.comment_reply_icon),
-            modifier = Modifier.clickable { onReplyIconClick() },
-            tint = KuringTheme.colors.textBody,
-        )
+        if (!isReply) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_message_circle_v2),
+                contentDescription = stringResource(R.string.comment_reply_icon),
+                modifier = Modifier.clickable { onReplyIconClick() },
+                tint = KuringTheme.colors.textBody,
+            )
+        }
         if (isDeletable) {
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_trashcan_v2),

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/comment/Comment.kt
@@ -159,7 +159,7 @@ private fun CommentHeader(
             Icon(
                 imageVector = ImageVector.vectorResource(R.drawable.ic_message_circle_v2),
                 contentDescription = stringResource(R.string.comment_reply_icon),
-                modifier = Modifier.clickable { onReplyIconClick() },
+                modifier = Modifier.clickable(onReplyIconClick),
                 tint = KuringTheme.colors.textBody,
             )
         }

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/component/LazyPagingCommentColumn.kt
@@ -124,7 +124,7 @@ private fun LazyListScope.commentItems(
                             color = borderColor,
                             start = Offset(0f, size.height),
                             end = Offset(size.width, size.height),
-                            strokeWidth = 1.dp.toPx(),
+                            strokeWidth = 0.3.dp.toPx(),
                         )
                     },
             )


### PR DESCRIPTION
## 구분선

구분선 굵기를 얇게 수정했습니다. (as-is → to-be)

![image](https://github.com/user-attachments/assets/0f2bae13-fd35-4e9d-8be4-4e3b1841569f)

## 대댓글 아이콘

대댓글에는 대댓글 아이콘을 보여주지 않습니다.

![image](https://github.com/user-attachments/assets/a339639d-65f4-4943-a49b-b5ab7b001891)
