### PR TITLE
[댓글 QA] 공지 댓글 수 표시

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
@@ -82,8 +82,7 @@ fun NoticeItem(
         }
 
         NoticeItemCommentCount(
-            // FIXME: Dto와 Entity에 commentCount 추가한 후 수정
-            commentCount = 100,
+            commentCount = notice.commentCount,
             isRead = notice.isRead,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
@@ -242,6 +241,7 @@ private val notice = Notice(
     isReadOnStorage = false,
     isImportant = false,
     tag = listOf("지급"),
+    commentCount = 0
 )
 
 @LightAndDarkPreview

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/NoticeItem.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -18,8 +21,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,29 +54,41 @@ fun NoticeItem(
 ) {
     val background =
         if (notice.isImportant) KuringTheme.colors.mainPrimarySelected else KuringTheme.colors.background
-    Row(
-        modifier = modifier
-            .clickable { onClick(notice) }
-            .fillMaxWidth()
-            .background(background)
-            .padding(horizontal = 20.dp),
-        verticalAlignment = contentVerticalAlignment,
-    ) {
-        NoticeItemContent(
-            notice = notice,
+
+    Box(modifier = modifier) {
+        Row(
             modifier = Modifier
-                .padding(vertical = 12.dp)
-                .weight(1f),
-        )
-        if (content != null) {
-            content()
-        } else if (notice.isSaved) {
-            NoticeItemBookmarkIcon(
+                .clickable { onClick(notice) }
+                .fillMaxWidth()
+                .background(background)
+                .padding(horizontal = 20.dp),
+            verticalAlignment = contentVerticalAlignment,
+        ) {
+            NoticeItemContent(
+                notice = notice,
                 modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .align(Alignment.Top),
+                    .padding(vertical = 12.dp)
+                    .weight(1f),
             )
+            if (content != null) {
+                content()
+            } else if (notice.isSaved) {
+                NoticeItemBookmarkIcon(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .align(Alignment.Top),
+                )
+            }
         }
+
+        NoticeItemCommentCount(
+            // FIXME: Dto와 Entity에 commentCount 추가한 후 수정
+            commentCount = 100,
+            isRead = notice.isRead,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(end = 20.dp, bottom = 12.dp)
+        )
     }
 }
 
@@ -161,6 +178,41 @@ private fun NoticeItemDate(
         ),
         modifier = modifier,
     )
+}
+
+@Composable
+private fun NoticeItemCommentCount(
+    commentCount: Int,
+    isRead: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val commentCountText =
+        if (commentCount < 100) commentCount.toString()
+        else stringResource(R.string.notice_item_many_comments)
+    val color = if (isRead) KuringTheme.colors.textCaption1 else KuringTheme.colors.textBody
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_message_circle_v2),
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(14.dp),
+        )
+        Spacer(Modifier.width(2.dp))
+        Text(
+            text = commentCountText,
+            style = TextStyle(
+                fontFamily = Pretendard,
+                fontSize = 14.sp,
+                lineHeight = 22.82.sp,
+                fontWeight = FontWeight(500),
+                color = color,
+            ),
+        )
+    }
 }
 
 @Composable

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
 
     <!--  components  -->
     <string name="notice_item_important_tag">중요</string>
+    <string name="notice_item_many_comments">99+</string>
     <string name="notice_item_delete_button">삭제</string>
     <string name="notice_refresh_error_message">공지 로드 중 에러가 발생했어요.\n잠시 후 다시 시도해 주세요.</string>
     <string name="webview_url_null">페이지 로드 중 에러가 발생했어요.\n잠시 후 다시 시도해 주세요.</string>

--- a/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/preview_data/Notice.kt
+++ b/core/ui_util/src/main/java/com/ku_stacks/ku_ring/ui_util/preview_data/Notice.kt
@@ -17,5 +17,6 @@ val previewNotices = (1..10).map {
         isReadOnStorage = false,
         isImportant = it < 3,
         tag = listOf("장학", "취창업"),
+        commentCount = 0,
     )
 }

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/Notice.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/Notice.kt
@@ -9,6 +9,7 @@ data class Notice(
     val url: String,
     val articleId: String,
     val id: Int,
+    val commentCount: Int,
     var isNew: Boolean,
     var isRead: Boolean,
     var isSubscribing: Boolean,

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/di/DBModule.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/di/DBModule.kt
@@ -122,6 +122,16 @@ object DBModule {
         }
     }
 
+    private val MIGRATION_9_10 = object : Migration(9, 10) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                ALTER TABLE NoticeEntity ADD COLUMN commentCount INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+            )
+        }
+    }
+
     @Singleton
     @Provides
     fun provideKuRingDatabase(
@@ -140,6 +150,7 @@ object DBModule {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
+            MIGRATION_9_10,
             ).build()
 
     @Singleton

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/entity/NoticeEntity.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/entity/NoticeEntity.kt
@@ -19,4 +19,5 @@ data class NoticeEntity(
     @ColumnInfo(name = "isSaved") val isSaved: Boolean,
     @ColumnInfo(name = "isReadOnStorage") val isReadOnStorage: Boolean,
     @ColumnInfo(name = "isImportant") val isImportant: Boolean,
+    @ColumnInfo(name = "commentCount") val commentCount: Int = 0,
 )

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/KuRingDatabase.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/KuRingDatabase.kt
@@ -20,7 +20,7 @@ import com.ku_stacks.ku_ring.local.entity.SearchHistoryEntity
         KuringBotMessageEntity::class,
         CategoryOrderEntity::class,
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class KuRingDatabase : RoomDatabase() {

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/NoticeDao.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/NoticeDao.kt
@@ -64,6 +64,9 @@ interface NoticeDao {
     @Query("UPDATE NoticeEntity SET id = :id WHERE articleId = :articleId AND category = :category")
     suspend fun updateNoticeId(articleId: String, category: String, id: Int)
 
+    @Query("UPDATE NoticeEntity SET commentCount = :commentCount WHERE articleId = :articleId AND category = :category AND commentCount != :commentCount")
+    suspend fun updateNoticeCommentCount(articleId: String, category: String, commentCount: Int)
+
     @Query("UPDATE NoticeEntity SET isSaved = 0")
     suspend fun clearSavedNotices()
 
@@ -89,6 +92,13 @@ interface NoticeDao {
 
     @Query("UPDATE NoticeEntity SET id = :id WHERE articleId = :articleId AND department LIKE :shortName")
     suspend fun updateDepartmentNoticeId(articleId: String, shortName: String, id: Int)
+
+    @Query("UPDATE NoticeEntity SET commentCount = :commentCount WHERE articleId = :articleId AND department LIKE :shortName AND commentCount != :commentCount")
+    suspend fun updateDepartmentNoticeCommentCount(
+        articleId: String,
+        shortName: String,
+        commentCount: Int
+    )
 
     @Query("DELETE FROM NoticeEntity WHERE department LIKE :shortName")
     suspend fun clearDepartment(shortName: String)

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/DomainToEntity.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/DomainToEntity.kt
@@ -16,4 +16,5 @@ fun Notice.toEntity(): NoticeEntity = NoticeEntity(
     isSaved = isSaved,
     isReadOnStorage = isReadOnStorage,
     isImportant = isImportant,
+    commentCount = commentCount,
 )

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/EntityToDomain.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/EntityToDomain.kt
@@ -21,5 +21,6 @@ fun NoticeEntity.toNotice(): Notice {
         isReadOnStorage = isReadOnStorage,
         isImportant = isImportant,
         tag = emptyList(),
+        commentCount = commentCount,
     )
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToDomain.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToDomain.kt
@@ -29,6 +29,7 @@ fun NoticeListResponse.toNoticeList(type: String): List<Notice> {
                 isReadOnStorage = false,
                 isImportant = it.isImportant,
                 tag = emptyList(),
+                commentCount = it.commentCount
             )
         }
     } else {
@@ -47,6 +48,7 @@ fun NoticeListResponse.toNoticeList(type: String): List<Notice> {
                 isReadOnStorage = false,
                 isImportant = it.isImportant,
                 tag = emptyList(),
+                commentCount = it.commentCount,
             )
         }
     }
@@ -67,7 +69,8 @@ fun SearchNoticeListResponse.toNoticeList(): List<Notice> {
             isSaved = false,
             isReadOnStorage = false,
             isImportant = it.isImportant,
-            tag = emptyList()
+            tag = emptyList(),
+            commentCount = it.commentCount,
         )
     } ?: emptyList()
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToEntity.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/mapper/ResponseToEntity.kt
@@ -19,6 +19,7 @@ fun NoticeResponse.toNoticeEntity(startDate: String) = NoticeEntity(
     isSaved = false,
     isReadOnStorage = false,
     isImportant = isImportant,
+    commentCount = commentCount,
 )
 
 
@@ -43,5 +44,6 @@ fun DepartmentNoticeResponse.toNoticeEntity(shortName: String, startDate: String
         isSaved = false,
         isReadOnStorage = false,
         isImportant = important,
+        commentCount = commentCount!!,
     )
 }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/CategoryNoticeMediator.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/CategoryNoticeMediator.kt
@@ -51,12 +51,23 @@ class CategoryNoticeMediator(
         val entities = noticeResponses.toEntities(getAppStartedDate())
         noticeDao.insertNotices(entities)
         updateNoticesId(entities)
+        updateNoticesCommentCount(entities)
     }
 
     private suspend fun updateNoticesId(entities: List<NoticeEntity>) {
         entities.forEach { entity ->
             if (noticeDao.getNoticeId(entity.articleId, entity.category) == 0) {
                 noticeDao.updateNoticeId(entity.articleId, entity.category, entity.id)
+            }
+        }
+    }
+
+    private suspend fun updateNoticesCommentCount(entities: List<NoticeEntity>) {
+        entities.forEach { entity ->
+            if (noticeDao.getNoticeId(entity.articleId, entity.category) != null) {
+                noticeDao.updateNoticeCommentCount(
+                    entity.articleId, entity.category, entity.commentCount
+                )
             }
         }
     }

--- a/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/DepartmentNoticeMediator.kt
+++ b/data/notice/src/main/java/com/ku_stacks/ku_ring/notice/source/DepartmentNoticeMediator.kt
@@ -51,6 +51,7 @@ class DepartmentNoticeMediator(
             val entities = noticeResponse.data.toEntityList(shortName, startDate)
             insertNotices(entities, page)
             updateNoticesId(entities)
+            updateNoticesCommentCount(entities)
 
             val isPageEnd = noticeResponse.data.isEmpty()
             MediatorResult.Success(endOfPaginationReached = isPageEnd)
@@ -85,6 +86,17 @@ class DepartmentNoticeMediator(
             if (noticeDao.getDepartmentNoticeId(entity.articleId, entity.department) == 0) {
                 Timber.d("Update notice id ${entity.articleId}")
                 noticeDao.updateDepartmentNoticeId(entity.articleId, entity.department, entity.id)
+            }
+        }
+    }
+
+    private suspend fun updateNoticesCommentCount(entities: List<NoticeEntity>) {
+        entities.forEach { entity ->
+            val noticeId = noticeDao.getDepartmentNoticeId(entity.articleId, entity.department)
+            if (noticeId != null) {
+                noticeDao.updateDepartmentNoticeCommentCount(
+                    entity.articleId, entity.department, entity.commentCount
+                )
             }
         }
     }

--- a/data/notice/test/src/main/java/com/ku_stacks/ku_ring/notice/test/NoticeTestUtil.kt
+++ b/data/notice/test/src/main/java/com/ku_stacks/ku_ring/notice/test/NoticeTestUtil.kt
@@ -25,6 +25,7 @@ object NoticeTestUtil {
         isSaved = false,
         isReadOnStorage = false,
         isImportant = false,
+        commentCount = 0,
     )
 
     fun fakeNotice() = Notice(
@@ -42,6 +43,7 @@ object NoticeTestUtil {
         isImportant = false,
         isSubscribing = false,
         tag = emptyList(),
+        commentCount = 0,
     )
 
     fun fakeSubscribeListResponse() = SubscribeListResponse(
@@ -77,6 +79,7 @@ object NoticeTestUtil {
         subject = "2023학년도 전과 선발자 안내",
         postedDate = "20230208",
         url = "http://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?forum=notice&sort=6&id=5b4f972&cat=0000300001",
+        commentCount = 0,
     )
 
     fun fakeEmptyNoticeListResponse() = NoticeListResponse(
@@ -97,6 +100,7 @@ object NoticeTestUtil {
                 postedDate = "20230208",
                 url = "http://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?forum=notice&sort=6&id=5b4f972&cat=0000300001",
                 important = false,
+                commentCount = 0,
             )
         }
     )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/DepartmentNoticeResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/DepartmentNoticeResponse.kt
@@ -8,4 +8,5 @@ data class DepartmentNoticeResponse(
     val url: String?,
     val category: String?,
     val important: Boolean,
+    val commentCount: Int?,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/NoticeResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/NoticeResponse.kt
@@ -17,4 +17,6 @@ data class NoticeResponse(
     val category: String,
     @SerializedName("important")
     val isImportant: Boolean,
+    @SerializedName("commentCount")
+    val commentCount: Int,
 )

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/SearchNoticeResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/notice/response/SearchNoticeResponse.kt
@@ -10,4 +10,5 @@ data class SearchNoticeResponse(
     @SerializedName("baseUrl") val baseUrl: String,
     @SerializedName("category") val category: String,
     @SerializedName("important") val isImportant: Boolean,
+    @SerializedName("commentCount") val commentCount: Int,
 )

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/search/compose/SearchScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/search/compose/SearchScreen.kt
@@ -3,7 +3,6 @@ package com.ku_stacks.ku_ring.main.search.compose
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -47,6 +46,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.SearchTextField
@@ -76,6 +76,11 @@ fun SearchScreen(
     val staffList by viewModel.staffSearchResult.collectAsStateWithLifecycle(initialValue = emptyList())
     val keywordHistories by viewModel.searchHistories.collectAsStateWithLifecycle(initialValue = emptyList())
 
+    LifecycleResumeEffect(Unit) {
+        viewModel.onSearch(searchState)
+        onPauseOrDispose { /*no resource to be released*/ }
+    }
+
     SearchScreen(
         onNavigationClick = onNavigationClick,
         onSearch = viewModel::onSearch,
@@ -90,7 +95,6 @@ fun SearchScreen(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SearchScreen(
     onNavigationClick: () -> Unit,
@@ -299,7 +303,6 @@ private fun SearchResultTitle(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SearchTabRow(
     pagerState: PagerState,
@@ -347,7 +350,6 @@ private fun SearchTabRow(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SearchResultHorizontalPager(
     searchState: SearchState,


### PR DESCRIPTION
## 요약

- NoticeItem에 댓글 수를 표시할 수 있도록 컴포넌트를 추가하고 구조를 변경했습니다. 7da26dbac6dc171284f6b9714076fad1ce0a8473
- 공지 API의 응답에 포함된 commentCount를 수신할 수 있도록 dto에 속성을 추가했습니다. 5a1beeab0055dc8bbc03063f57e01935d61c5c6a
- RoomDB에 commentCount 속성을 추가하고 버전 마이그레이션을 진행했습니다. 121a2c309d14e8caf8051ab8d07c27394b843aee
- 서버에 공지 API를 요청할 때마다 댓글 수가 갱신될 수 있도록 Room에 쿼리를 추가하고 Paging 로직을 수정했습니다. 95b5160c518768194917a53b14a693faf14c1a81
- 공지웹뷰에서 검색화면으로 복귀했을 때 변경사항이 반영되도록 수정했습니다. 582623685b0482dcef83dddfefa70d2f14db97ba

## 주요 기능 영상
| 메인화면 댓글 수 | 검색화면 댓글 수 |
|:-------------:|:---------------:|
| <video src="https://github.com/user-attachments/assets/20ff2535-71a0-48fa-85d9-d0f80e551445" width="300"></video> | <video src="https://github.com/user-attachments/assets/1ec4a04f-d209-423a-8e5e-21b801a96e16" width="300"></video> |







