### PR TITLE
kuring-239 미 로그인 상태일 때 쿠링봇 화면에서 팝업을 띄움

### DIFF
--- a/feature/kuringbot/build.gradle.kts
+++ b/feature/kuringbot/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.preferences)
+    implementation(projects.core.uiUtil)
     implementation(projects.core.util)
     implementation(projects.data.domain)
     implementation(projects.data.ai)

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotActivity.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotActivity.kt
@@ -9,10 +9,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.kuringbot.compose.KuringBotScreen
+import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class KuringBotActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var navigator: KuringNavigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -21,6 +26,7 @@ class KuringBotActivity : AppCompatActivity() {
             KuringTheme {
                 KuringBotScreen(
                     onBackButtonClick = ::finish,
+                    onMoveToLogin = { navigator.navigateToAuth(this) },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotUIState.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotUIState.kt
@@ -5,6 +5,8 @@ data class KuringBotUIState(
     val messages: List<KuringBotUIMessage>,
     val isSendQuestionDialogVisible: Boolean,
     val isReceivingResponse: Boolean,
+    val shouldShowLoginPopup: Boolean,
+    val isLoginPopupVisible: Boolean,
 ) {
     companion object {
         val Empty = KuringBotUIState(
@@ -12,6 +14,8 @@ data class KuringBotUIState(
             messages = emptyList(),
             isSendQuestionDialogVisible = false,
             isReceivingResponse = false,
+            shouldShowLoginPopup = false,
+            isLoginPopupVisible = false,
         )
     }
 }

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotViewModel.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/KuringBotViewModel.kt
@@ -21,7 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class KuringBotViewModel @Inject constructor(
     private val kuringBotRepository: KuringBotRepository,
-    preferences: PreferenceUtil,
+    private val preferences: PreferenceUtil,
 ) : ViewModel() {
     private val token = preferences.fcmToken
 
@@ -33,6 +33,14 @@ class KuringBotViewModel @Inject constructor(
 
     init {
         loadStoredMessages()
+    }
+
+    fun refreshLoginState() {
+        if (preferences.accessToken.isEmpty()) {
+            _uiState.update { it.copy(shouldShowLoginPopup = true, isLoginPopupVisible = true) }
+        } else {
+            _uiState.update { it.copy(shouldShowLoginPopup = false, isLoginPopupVisible = false) }
+        }
     }
 
     private fun loadStoredMessages() = viewModelScope.launch(Dispatchers.IO) {
@@ -154,6 +162,10 @@ class KuringBotViewModel @Inject constructor(
 
     fun setSendQuestionDialogVisibility(value: Boolean) {
         _uiState.update { it.copy(isSendQuestionDialogVisible = value) }
+    }
+
+    fun dismissLoginPopup() {
+        _uiState.update { it.copy(isLoginPopupVisible = false) }
     }
 
     override fun onCleared() {

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
@@ -2,7 +2,15 @@ package com.ku_stacks.ku_ring.kuringbot.compose
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -10,8 +18,12 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
@@ -35,7 +48,14 @@ import com.ku_stacks.ku_ring.kuringbot.KuringBotUIMessage
 import com.ku_stacks.ku_ring.kuringbot.KuringBotUIState
 import com.ku_stacks.ku_ring.kuringbot.KuringBotViewModel
 import com.ku_stacks.ku_ring.kuringbot.R
-import com.ku_stacks.ku_ring.kuringbot.compose.components.*
+import com.ku_stacks.ku_ring.kuringbot.compose.components.KuringBotInfoDialog
+import com.ku_stacks.ku_ring.kuringbot.compose.components.KuringBotLoginPopup
+import com.ku_stacks.ku_ring.kuringbot.compose.components.KuringBotTextField
+import com.ku_stacks.ku_ring.kuringbot.compose.components.LoadingMessage
+import com.ku_stacks.ku_ring.kuringbot.compose.components.QuestionMessage
+import com.ku_stacks.ku_ring.kuringbot.compose.components.QuestionsRemainingMessage
+import com.ku_stacks.ku_ring.kuringbot.compose.components.ResponseMessage
+import com.ku_stacks.ku_ring.kuringbot.compose.components.SendQuestionDialog
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
@@ -43,10 +63,16 @@ import java.time.Month
 @Composable
 internal fun KuringBotScreen(
     onBackButtonClick: () -> Unit,
+    onMoveToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: KuringBotViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LifecycleResumeEffect(Unit) {
+        viewModel.refreshLoginState()
+        onPauseOrDispose {}
+    }
 
     KuringBotScreen(
         uiState = state,
@@ -59,6 +85,8 @@ internal fun KuringBotScreen(
             viewModel.sendQuestion()
         },
         onHideQuestionDialog = { viewModel.setSendQuestionDialogVisibility(false) },
+        onLoginPopupDismiss = viewModel::dismissLoginPopup,
+        onMoveToLogin = onMoveToLogin,
         modifier = modifier,
     )
 }
@@ -72,6 +100,8 @@ private fun KuringBotScreen(
     onStopIconClick: () -> Unit,
     onSendQuestion: () -> Unit,
     onHideQuestionDialog: () -> Unit,
+    onLoginPopupDismiss: () -> Unit,
+    onMoveToLogin: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isInfoDialogVisible by rememberSaveable { mutableStateOf(false) }
@@ -92,6 +122,8 @@ private fun KuringBotScreen(
                 onQuestionValueChange = onQuestionValueChange,
                 onSendIconClick = onSendIconClick,
                 onStopIconClick = onStopIconClick,
+                onLoginPopupDismiss = onLoginPopupDismiss,
+                onMoveToLogin = onMoveToLogin,
             )
 
             KuringBotInfoDialog(
@@ -116,16 +148,33 @@ private fun KuringBotScreenContents(
     onQuestionValueChange: (String) -> Unit,
     onSendIconClick: () -> Unit,
     onStopIconClick: () -> Unit,
+    onLoginPopupDismiss: () -> Unit,
+    onMoveToLogin: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        if (uiState.messages.isEmpty()) {
-            NoMessageIndicator(modifier = Modifier.weight(1f))
-        } else {
-            KuringBotMessages(uiState.messages, modifier = Modifier.weight(1f))
+        Box(modifier = Modifier.weight(1f)) {
+            if (uiState.messages.isEmpty()) {
+                NoMessageIndicator(modifier = Modifier.align(Alignment.Center))
+            } else {
+                KuringBotMessages(
+                    messages = uiState.messages,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                )
+            }
+
+            if (uiState.isLoginPopupVisible) {
+                KuringBotLoginPopup(
+                    onDismiss = onLoginPopupDismiss,
+                    onLogin = onMoveToLogin,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(start = 20.dp, end = 20.dp, bottom = 17.dp),
+                )
+            }
         }
 
         KuringBotQuestionInput(
@@ -346,6 +395,8 @@ private fun KuringBotScreenPreview() {
                 messages = previewMessages,
                 isSendQuestionDialogVisible = false,
                 isReceivingResponse = false,
+                shouldShowLoginPopup = true,
+                isLoginPopupVisible = true,
             ),
             onBackButtonClick = {},
             onQuestionValueChange = { question = it },
@@ -353,6 +404,8 @@ private fun KuringBotScreenPreview() {
             onStopIconClick = {},
             onSendQuestion = {},
             onHideQuestionDialog = {},
+            onLoginPopupDismiss = {},
+            onMoveToLogin = {},
             modifier = Modifier.fillMaxSize(),
         )
     }
@@ -404,6 +457,8 @@ private fun KuringBotScreenPreview_Empty() {
                 messages = emptyList(),
                 isSendQuestionDialogVisible = false,
                 isReceivingResponse = false,
+                shouldShowLoginPopup = true,
+                isLoginPopupVisible = true,
             ),
             onBackButtonClick = {},
             onQuestionValueChange = { question = it },
@@ -411,6 +466,8 @@ private fun KuringBotScreenPreview_Empty() {
             onStopIconClick = {},
             onSendQuestion = {},
             onHideQuestionDialog = {},
+            onLoginPopupDismiss = {},
+            onMoveToLogin = {},
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotLoginPopup.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotLoginPopup.kt
@@ -40,7 +40,7 @@ internal fun KuringBotLoginPopup(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(15.dp))
-            .background(KuringTheme.colors.gray300)
+            .background(KuringTheme.colors.gray200)
             .padding(17.dp),
         verticalArrangement = Arrangement.spacedBy(13.dp),
     ) {
@@ -52,7 +52,7 @@ internal fun KuringBotLoginPopup(
                     lineHeight = 21.sp,
                     fontFamily = Pretendard,
                     fontWeight = FontWeight(500),
-                    color = KuringTheme.colors.gray100,
+                    color = KuringTheme.colors.textTitle,
                 )
             )
             Spacer(modifier = Modifier.weight(1f))
@@ -69,7 +69,7 @@ internal fun KuringBotLoginPopup(
         TextButton(
             onClick = onLogin,
             shape = RoundedCornerShape(100),
-            colors = ButtonDefaults.textButtonColors(KuringTheme.colors.mainPrimarySelected),
+            colors = ButtonDefaults.textButtonColors(KuringTheme.colors.mainPrimary),
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
@@ -79,7 +79,7 @@ internal fun KuringBotLoginPopup(
                     lineHeight = 24.sp,
                     fontFamily = Pretendard,
                     fontWeight = FontWeight(500),
-                    color = KuringTheme.colors.mainPrimary,
+                    color = KuringTheme.colors.textTitle,
                 ),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(vertical = 3.dp),

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotLoginPopup.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/components/KuringBotLoginPopup.kt
@@ -1,0 +1,100 @@
+package com.ku_stacks.ku_ring.kuringbot.compose.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.kuringbot.R
+
+@Composable
+internal fun KuringBotLoginPopup(
+    onDismiss: () -> Unit,
+    onLogin: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(15.dp))
+            .background(KuringTheme.colors.gray300)
+            .padding(17.dp),
+        verticalArrangement = Arrangement.spacedBy(13.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = stringResource(R.string.kuringbot_login_popup_title),
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    lineHeight = 21.sp,
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight(500),
+                    color = KuringTheme.colors.gray100,
+                )
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.size(17.dp),
+            ) {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_x_v2),
+                    contentDescription = stringResource(R.string.kuringbot_login_popup_close),
+                )
+            }
+        }
+        TextButton(
+            onClick = onLogin,
+            shape = RoundedCornerShape(100),
+            colors = ButtonDefaults.textButtonColors(KuringTheme.colors.mainPrimarySelected),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(R.string.kuringbot_login_popup_cta),
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    lineHeight = 24.sp,
+                    fontFamily = Pretendard,
+                    fontWeight = FontWeight(500),
+                    color = KuringTheme.colors.mainPrimary,
+                ),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(vertical = 3.dp),
+            )
+        }
+    }
+}
+
+@LightAndDarkPreview
+@Composable
+private fun KuringBotLoginPopupPreview() {
+    KuringTheme {
+        KuringBotLoginPopup(
+            onDismiss = {},
+            onLogin = {},
+        )
+    }
+}

--- a/feature/kuringbot/src/main/res/values/strings.xml
+++ b/feature/kuringbot/src/main/res/values/strings.xml
@@ -16,4 +16,8 @@
     <string name="kuringbot_send_dialog_cancel">취소하기</string>
 
     <string name="kuringbot_disclaimer">쿠링봇은 실수를 할 수 있습니다. 중요한 정보를 확인하세요.</string>
+
+    <string name="kuringbot_login_popup_title">쿠링봇은 로그인 시 더 많은 답변을 제공해요.</string>
+    <string name="kuringbot_login_popup_cta">로그인하기 ></string>
+    <string name="kuringbot_login_popup_close">로그인 팝업 닫기</string>
 </resources>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-239?atlOrigin=eyJpIjoiYTM1MjhiM2JhNmFlNDI4OGFhYTg0MWU5ZjQwNjQ5ZjgiLCJwIjoiaiJ9

## 요약

사용자가 로그인하지 않았을 때, 쿠링봇 화면에 팝업을 띄웁니다.

<img width="870" height="837" alt="image" src="https://github.com/user-attachments/assets/b5fbd02d-b836-4cc1-b825-dd231df137d4" />


`로그인하기` 버튼을 눌러 로그인한 후 다시 돌아오면 팝업이 사라집니다.

<img width="432" height="837" alt="image" src="https://github.com/user-attachments/assets/53ea0cfc-5056-4bb1-a310-1076e5b8d510" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a login popup in the KuringBot chat UI that prompts users to log in for more answers and provides a login action.

* **User Interface**
  * Displays a dismissible login popup over chat messages, aligned at the bottom.
  * Added localized text for the popup title, CTA, and close label.

* **Improvements**
  * Popup is lifecycle-aware, reflects auth state, and navigates to login when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->