### PR TITLE
kuring-152: Typography 테마 추가

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTheme.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTheme.kt
@@ -8,6 +8,10 @@ import androidx.compose.runtime.remember
 object KuringTheme {
     val colors: KuringColors
         @Composable get() = LocalKuringColors.current
+
+    val typography: KuringTypography
+        @Composable
+        get() = LocalKuringTypography.current
 }
 
 /**
@@ -31,16 +35,21 @@ fun KuringTheme(
  * 쿠링 테마이다. 현재 색깔 테마가 선언되어 있다.
  *
  * @param colors 쿠링 색깔 테마
+ * @param typography 쿠링 폰트 테마
  */
 @Composable
 internal fun ApplyKuringTheme(
     colors: KuringColors = KuringTheme.colors,
+    typography: KuringTypography = KuringTheme.typography,
     content: @Composable () -> Unit,
 ) {
     val rememberedKuringColors = remember {
         colors.copy()
     }.apply { updateColorsFrom(colors) }
-    CompositionLocalProvider(LocalKuringColors provides rememberedKuringColors) {
+    CompositionLocalProvider(
+        LocalKuringColors provides rememberedKuringColors,
+        LocalKuringTypography provides typography,
+    ) {
         // TODO: MaterialTheme.kt 보고 ProvideTextStyle() 추가하기
         content()
     }

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTheme.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTheme.kt
@@ -50,7 +50,6 @@ internal fun ApplyKuringTheme(
         LocalKuringColors provides rememberedKuringColors,
         LocalKuringTypography provides typography,
     ) {
-        // TODO: MaterialTheme.kt 보고 ProvideTextStyle() 추가하기
         content()
     }
 }

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
@@ -20,7 +20,7 @@ class KuringTypography(
     val body2: TextStyle = KuringTypographyTokens.Body2,
     val caption1: TextStyle = KuringTypographyTokens.Caption1,
     val caption1_1: TextStyle = KuringTypographyTokens.Caption1_1,
-    val caption2: TextStyle = KuringTypographyTokens.Caption1,
+    val caption2: TextStyle = KuringTypographyTokens.Caption2,
     val tag: TextStyle = KuringTypographyTokens.Tag,
     val tag2: TextStyle = KuringTypographyTokens.Tag,
     val inputField: TextStyle = KuringTypographyTokens.InputField,

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
@@ -1,8 +1,14 @@
 package com.ku_stacks.ku_ring.designsystem.kuringtheme
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.KuringTypographyTokens
 
 /**
@@ -108,3 +114,66 @@ class KuringTypography(
 }
 
 internal val LocalKuringTypography = staticCompositionLocalOf { KuringTypography() }
+
+@Preview(showBackground = true)
+@Composable
+private fun KuringTypographyPreview() {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            "KuringTheme NoticeTitle",
+            style = KuringTypography().noticeTitle,
+        )
+        Text(
+            "KuringTheme Title1",
+            style = KuringTypography().title1,
+        )
+        Text(
+            "KuringTheme Title2",
+            style = KuringTypography().title2,
+        )
+        Text(
+            "KuringTheme ViewTitle",
+            style = KuringTypography().viewTitle,
+        )
+        Text(
+            "KuringTheme TitleSB",
+            style = KuringTypography().titleSB,
+        )
+        Text(
+            "KuringTheme Body1",
+            style = KuringTypography().body1,
+        )
+        Text(
+            "KuringTheme Body2",
+            style = KuringTypography().body2,
+        )
+        Text(
+            "KuringTheme Caption1",
+            style = KuringTypography().caption1,
+        )
+        Text(
+            "KuringTheme Caption1_1",
+            style = KuringTypography().caption1_1,
+        )
+        Text(
+            "KuringTheme Caption2",
+            style = KuringTypography().caption2,
+        )
+        Text(
+            "KuringTheme Tag1",
+            style = KuringTypography().caption1,
+        )
+        Text(
+            "KuringTheme Tag2",
+            style = KuringTypography().caption1,
+        )
+        Text(
+            "KuringTheme InputField",
+            style = KuringTypography().inputField,
+        )
+        Text(
+            "KuringTheme BottomNavigationDefault",
+            style = KuringTypography().bottomNavigationDefault,
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/KuringTypography.kt
@@ -1,0 +1,110 @@
+package com.ku_stacks.ku_ring.designsystem.kuringtheme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.KuringTypographyTokens
+
+/**
+ * 쿠링 앱에서 사용하는 폰트 테마이다.
+ * [androidx.compose.material.Typography]를 참고하여 개발했다.
+ */
+@Immutable
+class KuringTypography(
+    val noticeTitle: TextStyle = KuringTypographyTokens.NoticeTitle,
+    val title1: TextStyle = KuringTypographyTokens.Title1,
+    val title2: TextStyle = KuringTypographyTokens.Title2,
+    val viewTitle: TextStyle = KuringTypographyTokens.ViewTitle,
+    val titleSB: TextStyle = KuringTypographyTokens.TitleSB,
+    val body1: TextStyle = KuringTypographyTokens.Body1,
+    val body2: TextStyle = KuringTypographyTokens.Body2,
+    val caption1: TextStyle = KuringTypographyTokens.Caption1,
+    val caption1_1: TextStyle = KuringTypographyTokens.Caption1_1,
+    val caption2: TextStyle = KuringTypographyTokens.Caption1,
+    val tag: TextStyle = KuringTypographyTokens.Tag,
+    val tag2: TextStyle = KuringTypographyTokens.Tag,
+    val inputField: TextStyle = KuringTypographyTokens.InputField,
+    val bottomNavigationDefault: TextStyle = KuringTypographyTokens.BottomNavigationDefault,
+) {
+    fun copy(
+        noticeTitle: TextStyle = this.noticeTitle,
+        title1: TextStyle = this.title1,
+        title2: TextStyle = this.title2,
+        viewTitle: TextStyle = this.viewTitle,
+        titleSB: TextStyle = this.titleSB,
+        body1: TextStyle = this.body1,
+        body2: TextStyle = this.body2,
+        caption1: TextStyle = this.caption1,
+        caption1_1: TextStyle = this.caption1_1,
+        caption2: TextStyle = this.caption2,
+        tag: TextStyle = this.tag,
+        tag2: TextStyle = this.tag2,
+        inputField: TextStyle = this.inputField,
+        bottomNavigationDefault: TextStyle = this.bottomNavigationDefault,
+    ): KuringTypography = KuringTypography(
+        noticeTitle = noticeTitle,
+        title1 = title1,
+        title2 = title2,
+        viewTitle = viewTitle,
+        titleSB = titleSB,
+        body1 = body1,
+        body2 = body2,
+        caption1 = caption1,
+        caption1_1 = caption1_1,
+        caption2 = caption2,
+        tag = tag,
+        tag2 = tag2,
+        inputField = inputField,
+        bottomNavigationDefault = bottomNavigationDefault,
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is KuringTypography) return false
+
+        if (noticeTitle != other.noticeTitle) return false
+        if (title1 != other.title1) return false
+        if (title2 != other.title2) return false
+        if (viewTitle != other.viewTitle) return false
+        if (titleSB != other.titleSB) return false
+        if (body1 != other.body1) return false
+        if (body2 != other.body2) return false
+        if (caption1 != other.caption1) return false
+        if (caption1_1 != other.caption1_1) return false
+        if (caption2 != other.caption2) return false
+        if (tag != other.tag) return false
+        if (tag2 != other.tag2) return false
+        if (inputField != other.inputField) return false
+        if (bottomNavigationDefault != other.bottomNavigationDefault) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = noticeTitle.hashCode()
+        result = 31 * result + title1.hashCode()
+        result = 31 * result + title2.hashCode()
+        result = 31 * result + viewTitle.hashCode()
+        result = 31 * result + titleSB.hashCode()
+        result = 31 * result + body1.hashCode()
+        result = 31 * result + body2.hashCode()
+        result = 31 * result + caption1.hashCode()
+        result = 31 * result + caption1_1.hashCode()
+        result = 31 * result + caption2.hashCode()
+        result = 31 * result + tag.hashCode()
+        result = 31 * result + tag2.hashCode()
+        result = 31 * result + inputField.hashCode()
+        result = 31 * result + bottomNavigationDefault.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "KuringTypography(noticeTitle=$noticeTitle, " +
+                "title1=$title1, title2=$title2, viewTitle=$viewTitle, titleSB=$titleSB, " +
+                "body1=$body1, body2=$body2, " +
+                "caption1=$caption1, caption1_1=$caption1_1, caption2=$caption2, " +
+                "tag=$tag, tag2=$tag2, inputField=$inputField, " +
+                "bottomNavigationDefault=$bottomNavigationDefault)"
+    }
+}
+
+internal val LocalKuringTypography = staticCompositionLocalOf { KuringTypography() }

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.R
 
@@ -25,59 +26,86 @@ val Pretendard = FontFamily(
     Font(R.font.pretendard_thin, FontWeight.Thin),
 )
 
-// fontSize, fontWeight, lineHeight, letterSpacing(optional)
+// fontFamily, fontSize, fontWeight, lineHeight, letterSpacing(optional)
+internal object KuringTypographyTokens {
+    val NoticeTitle =
+        KuringDefaultTextStyle.copy(
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 1.5.em,
+        )
+    val Title1 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 1.42.em,
+        )
+    val Title2 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 1.5.em,
+            letterSpacing = (-0.41).em,
+        )
+    val ViewTitle =
+        KuringDefaultTextStyle.copy(
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            lineHeight = 1.48.em,
+            letterSpacing = (-0.41).sp,
+        )
+    val TitleSB =
+        KuringDefaultTextStyle.copy(
+            fontSize = 24.sp,
+            fontWeight = FontWeight.SemiBold,
+            lineHeight = 1.5.em,
+        )
+    val Body1 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 15.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 1.63.em,
+        )
+    // Body2-Regular, Body2-SemiBold는  KuringTheme.typography.Body2.copy(fontWeight = FontWeight.Regular)처럼 사용
+    val Body2 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 1.5.em,
+        )
+    val Caption1 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Normal,
+            lineHeight = 1.63.em,
+        )
+    val Caption1_1 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 1.63.em,
+        )
+    val Tag =
+        KuringDefaultTextStyle.copy(
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            lineHeight = 1.5.em,
+        )
+    val InputField =
+        KuringDefaultTextStyle.copy(
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal,
+            lineHeight = 1.63.em,
+        )
+    val BottomNavigationDefault =
+        KuringDefaultTextStyle.copy(
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Medium,
+            lineHeight = 1.63.em,
+        )
+}
 
-internal val NoticeTitle = TextStyle(
-    fontSize = 20.sp,
-    fontWeight = FontWeight.Bold,
-    lineHeight = (20 * 1.5f).sp,
-)
-internal val Title1 = TextStyle(
-    fontSize = 24.sp,
-    fontWeight = FontWeight.Bold,
-    lineHeight = (24 * 1.42f).sp,
-)
-internal val Title2 = TextStyle(
-    fontSize = 18.sp,
-    fontWeight = FontWeight.Bold,
-    lineHeight = 27.sp,
-    letterSpacing = (-0.41).sp,
-)
-internal val ViewTitle = TextStyle(
-    fontSize = 18.sp,
-    fontWeight = FontWeight.SemiBold,
-    lineHeight = (18 * 1.48f).sp,
-    letterSpacing = (-0.41).sp,
-)
-internal val Body1 = TextStyle(
-    fontSize = 15.sp,
-    fontWeight = FontWeight.Medium,
-    lineHeight = (15 * 1.63f).sp,
-)
-
-// Body2-Regular 등은 KuringTheme.typography.Body2.copy(fontWeight = FontWeight.Regular)처럼 사용
-internal val Body2 = TextStyle(
-    fontSize = 16.sp,
-    fontWeight = FontWeight.Medium,
-    lineHeight = (16 * 1.5f).sp,
-)
-internal val Caption1 = TextStyle(
-    fontSize = 14.sp,
-    fontWeight = FontWeight.Normal,
-    lineHeight = (14 * 1.63f).sp,
-)
-internal val Tag = TextStyle(
-    fontSize = 12.sp,
-    fontWeight = FontWeight.SemiBold,
-    lineHeight = (12 * 1.63f).sp,
-)
-internal val TextInputField = TextStyle(
-    fontSize = 16.sp,
-    fontWeight = FontWeight.Normal,
-    lineHeight = (16 * 1.63f).sp,
-)
-internal val BottomNavigationDefault = TextStyle(
-    fontSize = 10.sp,
-    fontWeight = FontWeight.Medium,
-    lineHeight = (10 * 1.63f).sp,
-)
+internal val KuringDefaultTextStyle =
+    TextStyle.Default.copy(
+        fontFamily = Pretendard,
+    )

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
@@ -45,7 +45,7 @@ internal object KuringTypographyTokens {
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
             lineHeight = 1.5.em,
-            letterSpacing = (-0.41).em,
+            letterSpacing = (-0.41).sp,
         )
     val ViewTitle =
         KuringDefaultTextStyle.copy(

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/kuringtheme/values/Typography.kt
@@ -85,6 +85,12 @@ internal object KuringTypographyTokens {
             fontWeight = FontWeight.Medium,
             lineHeight = 1.63.em,
         )
+    val Caption2 =
+        KuringDefaultTextStyle.copy(
+            fontSize = 13.sp,
+            fontWeight = FontWeight.Light,
+            lineHeight = 1.5.em,
+        )
     val Tag =
         KuringDefaultTextStyle.copy(
             fontSize = 12.sp,

--- a/feature/library/src/main/java/com/ku_stacks/ku_ring/library/compose/LibrarySeatScreen.kt
+++ b/feature/library/src/main/java/com/ku_stacks/ku_ring/library/compose/LibrarySeatScreen.kt
@@ -23,18 +23,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.indicator.PagingLoadingIndicator
 import com.ku_stacks.ku_ring.designsystem.components.topbar.NavigateUpTopBar
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
-import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.domain.LibraryRoom
 import com.ku_stacks.ku_ring.feature.library.R
 import com.ku_stacks.ku_ring.library.LibrarySeatViewModel
@@ -111,11 +107,7 @@ private fun LibrarySeatScreen(
                 ) {
                     Text(
                         stringResource(R.string.library_seats_title),
-                        style = TextStyle(
-                            fontSize = 24.sp,
-                            lineHeight = 36.sp,
-                            fontFamily = Pretendard,
-                            fontWeight = FontWeight(700),
+                        style = KuringTheme.typography.title1.copy(
                             color = KuringTheme.colors.textTitle,
                         ),
                         modifier = Modifier.padding(top = 18.dp)
@@ -123,11 +115,8 @@ private fun LibrarySeatScreen(
 
                     Text(
                         text = stringResource(R.string.library_seats_description),
-                        style = TextStyle.Default.copy(
+                        style = KuringTheme.typography.body1.copy(
                             color = KuringTheme.colors.textCaption1,
-                            fontSize = 15.sp,
-                            fontWeight = FontWeight.Medium,
-                            lineHeight = (15 * 1.63f).sp,
                         ),
                         modifier = Modifier.padding(top = 8.dp)
                     )
@@ -172,14 +161,13 @@ private fun LoadingErrorText(modifier: Modifier = Modifier) {
     Box(modifier = modifier) {
         Text(
             text = stringResource(id = R.string.library_seats_load_fail),
-            fontFamily = Pretendard,
-            fontWeight = FontWeight.Normal,
-            fontSize = 14.sp,
-            color = KuringTheme.colors.textCaption1,
+            style = KuringTheme.typography.caption1.copy(
+                color = KuringTheme.colors.textCaption1,
+                textAlign = TextAlign.Center,
+            ),
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(top = 30.dp),
-            textAlign = TextAlign.Center,
         )
     }
 }

--- a/feature/library/src/main/java/com/ku_stacks/ku_ring/library/compose/component/SeatStatusGroup.kt
+++ b/feature/library/src/main/java/com/ku_stacks/ku_ring/library/compose/component/SeatStatusGroup.kt
@@ -11,13 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
-import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.feature.library.R
 
 @Composable
@@ -49,35 +46,24 @@ internal fun SeatStatusGroup(
             ) {
                 Text(
                     text = availableSeat.toString(),
-                    style = TextStyle.Default.copy(
-                        fontFamily = Pretendard,
-                        fontSize = 24.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        lineHeight = (24 * 1.5).sp,
+                    style = KuringTheme.typography.titleSB.copy(
+                        color = KuringTheme.colors.mainPrimary
                     ),
-                    color = KuringTheme.colors.mainPrimary
                 )
                 Text(
                     text = stringResource(R.string.library_seats_available_ratio, occupiedSeat, totalSeat),
-                    style = TextStyle.Default.copy(
-                        fontFamily = Pretendard,
-                        fontSize = 13.sp,
-                        fontWeight = FontWeight.Light,
-                        lineHeight = (14 * 1.5f).sp,
+                    style = KuringTheme.typography.caption2.copy(
+                        color = KuringTheme.colors.textCaption1
                     ),
-                    color = KuringTheme.colors.textCaption1
                 )
             }
         }
 
         Text(
             text = roomName,
-            style = TextStyle.Default.copy(
-                color = KuringTheme.colors.textBody,
-                fontSize = 16.sp,
+            style = KuringTheme.typography.body2.copy(
                 fontWeight = FontWeight.Normal,
-                fontFamily = Pretendard,
-                lineHeight = (16 * 1.5f).sp,
+                color = KuringTheme.colors.textBody,
             ),
             modifier = Modifier.padding(top = 12.dp)
         )


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-152?atlOrigin=eyJpIjoiOGJkZTJjYWM0MDU2NGIzMTg1YTU1NzRhZTNhZWUwMWIiLCJwIjoiaiJ9

## 요약

- **KuringTypography** 추가: 앞으로 `KuringTheme.typography.title1`과 같은 형태로 텍스트의 폰트스타일을 지정할 수 있습니다.

- **KuringTypography**의 프리뷰 추가: 폰트를 추가하거나 수정할 때 확인하기 편하게 프리뷰를 추가했습니다.
   
- 도서관 잔여 좌석 화면에 **KuringTypography** 적용: 실제로 잘 적용되는지 확인해보기 위해 도서관 잔여 좌석 화면에 텍스트 코드를 수정했습니다.

## Typography 프리뷰
<img width="233" height="407" alt="image" src="https://github.com/user-attachments/assets/34988c70-797c-4d02-9713-3e11f3ab6eda" />