### PR TITLE
kuring-240 targetSdk 버전을 Android 15로 올림

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/LargeTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/LargeTopAppBar.kt
@@ -1,18 +1,18 @@
 package com.ku_stacks.ku_ring.designsystem.components
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
@@ -32,6 +32,7 @@ import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
  * @param onNavigationIconClick Navigation 아이콘을 클릭했을 때 실행할 콜백
  * @param iconDescription Navigation 아이콘을 설명하는 문자열. 접근성 서비스에 제공되는 값이다.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LargeTopAppBar(
     title: String,
@@ -41,28 +42,29 @@ fun LargeTopAppBar(
     iconDescription: String? = null,
     action: @Composable () -> Unit = {},
 ) {
-    Column(
-        modifier = modifier
-            .background(KuringTheme.colors.background)
-            .padding(start = 14.dp, top = 14.dp, end = 14.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = onNavigationIconClick) {
+    LargeTopAppBar(
+        title = {
+            LargeTopAppBarTitle(title = title)
+        },
+        navigationIcon = {
+            IconButton(
+                onClick = onNavigationIconClick,
+                modifier = Modifier.padding(start = 14.dp, top = 14.dp)
+            ) {
                 Icon(
                     painter = painterResource(id = navigationIconId),
                     contentDescription = iconDescription,
                     tint = KuringTheme.colors.textBody,
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
+        },
+        actions = {
             action()
-        }
-
-        LargeTopAppBarTitle(title = title)
-    }
+            Spacer(modifier = Modifier.width(14.dp))
+        },
+        colors = TopAppBarDefaults.largeTopAppBarColors(containerColor = KuringTheme.colors.background),
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/CenterTitleTopBar.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/CenterTitleTopBar.kt
@@ -1,18 +1,17 @@
 package com.ku_stacks.ku_ring.designsystem.components.topbar
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.Text
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -91,6 +90,7 @@ fun CenterTitleTopBar(
  * @param onActionClick 액션 텍스트를 클릭할 때 실행할 콜백.
  * @param actionClickLabel 액션 클릭 콜백을 설명하는 텍스트. 콜백이 null이 아니라면 접근성을 위해 제공하는 것이 좋다.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CenterTitleTopBar(
     title: String,
@@ -107,35 +107,41 @@ fun CenterTitleTopBar(
 ) {
     val backgroundColor = KuringTheme.colors.background
     val contentPadding = PaddingValues(horizontal = 20.dp, vertical = 18.dp)
-    Box(
-        modifier = modifier
-            .background(backgroundColor)
-            .fillMaxWidth(),
-    ) {
-        Navigation(
-            navigationIcon = navigation,
-            navigationContentColor = navigationContentColor,
-            onNavigationClick = onNavigationClick,
-            navigationClickLabel = navigationClickLabel,
-            contentPadding = contentPadding,
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .clip(RoundedCornerShape(50)),
-        )
-        TopBarTitle(
-            title = title,
-            modifier = Modifier.align(Alignment.Center),
-        )
-        Action(
-            action = action,
-            onActionClick = onActionClick,
-            actionClickLabel = actionClickLabel,
-            contentPadding = contentPadding,
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .clip(RoundedCornerShape(50)),
-        )
-    }
+    CenterAlignedTopAppBar(
+        title = {
+            TopBarTitle(
+                title = title,
+            )
+        },
+        navigationIcon = {
+            navigation?.let {
+                Navigation(
+                    navigationIcon = navigation,
+                    navigationContentColor = navigationContentColor,
+                    onNavigationClick = onNavigationClick,
+                    navigationClickLabel = navigationClickLabel,
+                    contentPadding = contentPadding,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(50)),
+                )
+            }
+        },
+        actions = {
+            Action(
+                action = action,
+                onActionClick = onActionClick,
+                actionClickLabel = actionClickLabel,
+                contentPadding = contentPadding,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50)),
+            )
+        },
+        modifier = modifier,
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = backgroundColor,
+            navigationIconContentColor = navigationContentColor,
+        ),
+    )
 }
 
 @Composable

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/KuringIconTopBar.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/topbar/KuringIconTopBar.kt
@@ -1,15 +1,16 @@
 package com.ku_stacks.ku_ring.designsystem.components.topbar
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -24,25 +25,30 @@ import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
  * @param modifier 적용할 [Modifier]
  * @param content 오른쪽 끝에 보여줄 composable
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KuringIconTopBar(
     modifier: Modifier = Modifier,
     content: @Composable RowScope.() -> Unit = {},
 ) {
-    Row(
-        modifier = modifier
-            .background(KuringTheme.colors.background)
-            .padding(vertical = 12.dp)
-            .padding(start = 20.dp, end = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_kuring_v2),
-            contentDescription = null,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        content()
-    }
+    CenterAlignedTopAppBar(
+        modifier = modifier,
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = KuringTheme.colors.background),
+        title = {
+            Row(
+                modifier = Modifier
+                    .padding(vertical = 12.dp)
+                    .padding(start = 20.dp, end = 10.dp)
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_kuring_v2),
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                content()
+            }
+        }
+    )
 }
 
 @LightAndDarkPreview

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/AuthActivity.kt
@@ -5,13 +5,12 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.ui.Modifier
 import com.ku_stacks.ku_ring.auth.compose.AuthDestination
 import com.ku_stacks.ku_ring.auth.compose.AuthScreen
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.feature.auth.R
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -20,7 +19,6 @@ class AuthActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         setContent {
             val startDestination = if (intent.getStringExtra(INTENT_KEY) == INTENT_SIGN_OUT) {
                 AuthDestination.SignOut
@@ -28,13 +26,13 @@ class AuthActivity : AppCompatActivity() {
                 AuthDestination.SignIn
             }
 
-            AuthScreen(
-                onNavigateUp = ::finish,
-                startDestination = startDestination,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .navigationBarsPadding()
-            )
+            KuringTheme {
+                AuthScreen(
+                    onNavigateUp = ::finish,
+                    startDestination = startDestination,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/AuthScreen.kt
@@ -2,7 +2,10 @@ package com.ku_stacks.ku_ring.auth.compose
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -17,6 +20,7 @@ import com.ku_stacks.ku_ring.auth.compose.reset_password.resetPasswordNavGraph
 import com.ku_stacks.ku_ring.auth.compose.signin.signInNavGraph
 import com.ku_stacks.ku_ring.auth.compose.signout.signOutNavGraph
 import com.ku_stacks.ku_ring.auth.compose.signup.signUpNavGraph
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 
 @Composable
 internal fun AuthScreen(
@@ -27,36 +31,42 @@ internal fun AuthScreen(
 ) {
     val navigationSpec = tween<IntOffset>(durationMillis = 200)
 
-    NavHost(
-        navController = navController,
-        startDestination = startDestination,
-        enterTransition = {
-            slideIntoContainer(
-                towards = animationDirection(initialState, targetState),
-                animationSpec = navigationSpec,
-            )
-        },
-        exitTransition = {
-            slideOutOfContainer(
-                towards = animationDirection(initialState, targetState),
-                animationSpec = navigationSpec,
-            )
-        },
-        modifier = modifier.fillMaxSize()
-    ) {
-        signInNavGraph(
+    Scaffold(
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier.fillMaxSize(),
+        contentWindowInsets = WindowInsets(0),
+    ) { paddingValues ->
+        NavHost(
             navController = navController,
-            onNavigateUp = onNavigateUp,
-        )
+            startDestination = startDestination,
+            enterTransition = {
+                slideIntoContainer(
+                    towards = animationDirection(initialState, targetState),
+                    animationSpec = navigationSpec,
+                )
+            },
+            exitTransition = {
+                slideOutOfContainer(
+                    towards = animationDirection(initialState, targetState),
+                    animationSpec = navigationSpec,
+                )
+            },
+            modifier = Modifier.padding(paddingValues),
+        ) {
+            signInNavGraph(
+                navController = navController,
+                onNavigateUp = onNavigateUp,
+            )
 
-        signUpNavGraph(navController = navController)
+            signUpNavGraph(navController = navController)
 
-        resetPasswordNavGraph(navController = navController)
+            resetPasswordNavGraph(navController = navController)
 
-        signOutNavGraph(
-            onNavigateUp = onNavigateUp,
-            navController = navController
-        )
+            signOutNavGraph(
+                onNavigateUp = onNavigateUp,
+                navController = navController
+            )
+        }
     }
 }
 

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/inner_screen/SignOutCompleteScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/inner_screen/SignOutCompleteScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
@@ -37,7 +38,8 @@ internal fun SignOutCompleteScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(KuringTheme.colors.background),
+            .background(KuringTheme.colors.background)
+            .systemBarsPadding(),
     ) {
         AuthTopBar(
             headingText = stringResource(sign_out_complete_top_bar_heading),

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/inner_screen/SignOutGuideScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signout/inner_screen/SignOutGuideScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -78,6 +79,7 @@ internal fun SignOutGuideScreen(
         modifier = modifier
             .fillMaxSize()
             .background(KuringTheme.colors.background)
+            .systemBarsPadding()
     ) {
         AuthTopBar(
             headingText = stringResource(sign_out_top_bar_heading),

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SetPasswordScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SetPasswordScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -67,6 +68,7 @@ private fun SetPasswordScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = KuringTheme.colors.background)
+            .navigationBarsPadding(),
     ) {
         AuthTopBar(
             headingText = stringResource(sign_up_password_top_bar_heading),

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SignUpCompleteScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/SignUpCompleteScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -40,7 +41,8 @@ internal fun SignUpCompleteScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
-            .background(KuringTheme.colors.background),
+            .background(KuringTheme.colors.background)
+            .navigationBarsPadding(),
     ) {
         Text(
             text = stringResource(sign_up_complete_heading),

--- a/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
+++ b/feature/auth/src/main/java/com/ku_stacks/ku_ring/auth/compose/signup/inner_screen/TermsAndConditionScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -80,7 +81,8 @@ private fun TermsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(KuringTheme.colors.background),
+            .background(KuringTheme.colors.background)
+            .navigationBarsPadding(),
     ) {
         AuthTopBar(
             headingText = stringResource(sign_up_terms_top_bar_heading),

--- a/feature/edit_departments/src/main/java/com/ku_stacks/ku_ring/edit_departments/compose/EditDepartmentsScreen.kt
+++ b/feature/edit_departments/src/main/java/com/ku_stacks/ku_ring/edit_departments/compose/EditDepartmentsScreen.kt
@@ -2,11 +2,17 @@ package com.ku_stacks.ku_ring.edit_departments.compose
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,7 +27,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.ku_stacks.ku_ring.designsystem.components.*
+import com.ku_stacks.ku_ring.designsystem.components.DarkPreview
+import com.ku_stacks.ku_ring.designsystem.components.DepartmentWithAddIcon
+import com.ku_stacks.ku_ring.designsystem.components.DepartmentWithCheckIcon
+import com.ku_stacks.ku_ring.designsystem.components.DepartmentWithDeleteIcon
+import com.ku_stacks.ku_ring.designsystem.components.LargeTopAppBar
+import com.ku_stacks.ku_ring.designsystem.components.LightPreview
+import com.ku_stacks.ku_ring.designsystem.components.SearchTextField
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.domain.Department
@@ -72,24 +84,30 @@ private fun EditDepartmentsScreen(
     val isDeleteAllButtonEnabled =
         (departmentsUiModel as? DepartmentsUiModel.SelectedDepartments)?.departments?.isNotEmpty()
             ?: false
-    Column(
+    Scaffold(
+        topBar = {
+            EditDepartmentsTitle(
+                onClose = onClose,
+                isDeleteAllButtonVisible = isDeleteAllButtonVisible,
+                isDeleteAllButtonEnabled = isDeleteAllButtonEnabled,
+                onDeleteAllButtonClick = onDeleteAllButtonClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 20.dp),
+            )
+        },
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
-        EditDepartmentsTitle(
-            onClose = onClose,
-            isDeleteAllButtonVisible = isDeleteAllButtonVisible,
-            isDeleteAllButtonEnabled = isDeleteAllButtonEnabled,
-            onDeleteAllButtonClick = onDeleteAllButtonClick,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        containerColor = KuringTheme.colors.background,
+    ) { paddingValues ->
         EditDepartmentsContents(
             query = query,
             onQueryUpdate = onQueryUpdate,
             departmentsUiModel = departmentsUiModel,
             onAddDepartment = onAddDepartment,
             onDeleteDepartment = onDeleteDepartment,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxWidth(),
         )
     }
 }

--- a/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
+++ b/feature/edit_subscription/src/main/java/com/ku_stacks/ku_ring/edit_subscription/compose/EditSubscriptionScreen.kt
@@ -3,7 +3,16 @@ package com.ku_stacks.ku_ring.edit_subscription.compose
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -18,6 +27,7 @@ import androidx.compose.material.TabRow
 import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,35 +101,40 @@ private fun EditSubscriptionScreen(
     onSubscriptionComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.background(KuringTheme.colors.background)
-    ) {
-        CenterTitleTopBar(
-            title = stringResource(id = R.string.app_bar_title),
-            action = stringResource(id = R.string.app_bar_action),
-            onActionClick = onSubscriptionComplete,
-            actionClickLabel = stringResource(id = R.string.department_subscription_complete),
-            navigation = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_back_v2),
-                    contentDescription = stringResource(id = R.string.app_bar_navigation),
-                    tint = KuringTheme.colors.gray600,
-                )
-            },
-            onNavigationClick = onNavigateToBack,
-        )
-        SubscriptionTitle(modifier = Modifier.padding(start = 32.dp, top = 30.dp))
-        SubscriptionTabs(
-            categories = categories,
-            departments = departments,
-            onCategoryClick = onCategoryClick,
-            onDepartmentClick = onDepartmentClick,
-            onAddDepartmentButtonClick = onAddDepartmentButtonClick,
-            onSubscriptionComplete = onSubscriptionComplete,
-            modifier = Modifier
-                .padding(top = 68.dp)
-                .weight(1f),
-        )
+    Scaffold(
+        topBar = {
+            CenterTitleTopBar(
+                title = stringResource(id = R.string.app_bar_title),
+                action = stringResource(id = R.string.app_bar_action),
+                onActionClick = onSubscriptionComplete,
+                actionClickLabel = stringResource(id = R.string.department_subscription_complete),
+                navigation = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_back_v2),
+                        contentDescription = stringResource(id = R.string.app_bar_navigation),
+                        tint = KuringTheme.colors.gray600,
+                    )
+                },
+                onNavigationClick = onNavigateToBack,
+            )
+        },
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier,
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            SubscriptionTitle(modifier = Modifier.padding(start = 32.dp, top = 30.dp))
+            SubscriptionTabs(
+                categories = categories,
+                departments = departments,
+                onCategoryClick = onCategoryClick,
+                onDepartmentClick = onDepartmentClick,
+                onAddDepartmentButtonClick = onAddDepartmentButtonClick,
+                onSubscriptionComplete = onSubscriptionComplete,
+                modifier = Modifier
+                    .padding(top = 68.dp)
+                    .weight(1f),
+            )
+        }
     }
 }
 

--- a/feature/feedback/src/main/java/com/ku_stacks/ku_ring/feedback/feedback/compose/FeedbackScreen.kt
+++ b/feature/feedback/src/main/java/com/ku_stacks/ku_ring/feedback/feedback/compose/FeedbackScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -96,12 +96,13 @@ private fun FeedbackScreen(
                 action = "",
             )
         },
-        modifier = modifier.background(KuringTheme.colors.background)
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier,
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
                 .padding(it)
+                .fillMaxSize()
                 .background(KuringTheme.colors.background)
                 .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
+++ b/feature/kuringbot/src/main/java/com/ku_stacks/ku_ring/kuringbot/compose/KuringBotScreen.kt
@@ -16,8 +16,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Icon
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -114,7 +114,7 @@ private fun KuringBotScreen(
             )
         },
         modifier = modifier.fillMaxSize(),
-        backgroundColor = KuringTheme.colors.background,
+        containerColor = KuringTheme.colors.background,
     ) { contentPadding ->
         Box(modifier = Modifier.padding(contentPadding)) {
             KuringBotScreenContents(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -7,14 +7,18 @@ import android.net.Uri
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -58,6 +62,8 @@ fun MainScreen(
                     modifier = Modifier.fillMaxWidth(),
                 )
             },
+            contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets(top = Int.MAX_VALUE.dp)),
+            containerColor = KuringTheme.colors.background,
             modifier = modifier,
         ) {
             NavHost(
@@ -140,16 +146,14 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onBackDoubleTap = {
                 activity.finish()
             },
-            modifier =
-            Modifier
+            modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
         )
     }
     composable<MainScreenRoute.Archive> {
         ArchiveScreen(
-            modifier =
-            Modifier
+            modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxSize(),
         )
@@ -192,9 +196,9 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onLogoutClick = viewModel::logout,
             onNavigateToSignOut = { navigator.navigateToSignOut(activity) },
             modifier =
-            Modifier
-                .fillMaxSize()
-                .background(KuringTheme.colors.background),
+                Modifier
+                    .fillMaxSize()
+                    .background(KuringTheme.colors.background),
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenNavigationBar.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreenNavigationBar.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,7 +38,10 @@ internal fun MainScreenNavigationBar(
     onNavigationItemClick: (MainScreenRoute) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier = modifier.background(KuringTheme.colors.background)) {
+    NavigationBar(
+        modifier = modifier,
+        containerColor = KuringTheme.colors.background,
+    ) {
         MainScreenRoute.entries.forEach { route ->
             val navigationItem = MainScreenNavigationBarItem.get(route)
             val label = stringResource(id = navigationItem.labelId)
@@ -46,7 +49,8 @@ internal fun MainScreenNavigationBar(
             MainScreenNavigationItem(
                 item = navigationItem,
                 isSelected = route == currentRoute,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier
+                    .weight(1f)
                     .clickable(
                         role = Role.Button,
                         onClickLabel = stringResource(
@@ -58,7 +62,8 @@ internal fun MainScreenNavigationBar(
                                 onNavigationItemClick(route)
                             }
                         },
-                    ).padding(vertical = 11.dp),
+                    )
+                    .padding(vertical = 11.dp),
             )
         }
     }
@@ -152,7 +157,9 @@ private fun MainScreenNavigationBarPreview() {
         MainScreenNavigationBar(
             currentRoute = selectedDestination,
             onNavigationItemClick = { selectedDestination = it },
-            modifier = Modifier.background(KuringTheme.colors.background).fillMaxWidth(),
+            modifier = Modifier
+                .background(KuringTheme.colors.background)
+                .fillMaxWidth(),
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/archive/compose/ArchiveScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/archive/compose/ArchiveScreen.kt
@@ -1,9 +1,10 @@
 package com.ku_stacks.ku_ring.main.archive.compose
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -92,36 +93,43 @@ private fun ArchiveScreen(
     onDismissDeleteAlertDialog: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .background(KuringTheme.colors.background)
-            .fillMaxSize(),
-    ) {
-        ArchiveScreenTopBar(
-            isSelectModeEnabled = isSelectModeEnabled,
-            onSelectModeEnabled = onSelectModeEnabled,
-            onSelectModeDisabled = onSelectModeDisabled,
-            onSelectAllNotices = onSelectAllNotices,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        ArchivedNotices(
-            notices = notices,
-            onNoticeClick = onNoticeClick,
-            isSelectModeEnabled = isSelectModeEnabled,
-            selectedNoticeIds = selectedNoticeIds,
-            toggleNoticeSelection = toggleNoticeSelection,
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-        )
-        if (isSelectModeEnabled) {
-            KuringCallToAction(
-                text = stringResource(id = R.string.cta_text),
-                onClick = onShowDeleteAlertDialog,
-                enabled = selectedNoticeIds.isNotEmpty(),
-                blur = true,
+    Scaffold(
+        topBar = {
+            ArchiveScreenTopBar(
+                isSelectModeEnabled = isSelectModeEnabled,
+                onSelectModeEnabled = onSelectModeEnabled,
+                onSelectModeDisabled = onSelectModeDisabled,
+                onSelectAllNotices = onSelectAllNotices,
                 modifier = Modifier.fillMaxWidth(),
             )
+        },
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize(),
+        ) {
+            ArchivedNotices(
+                notices = notices,
+                onNoticeClick = onNoticeClick,
+                isSelectModeEnabled = isSelectModeEnabled,
+                selectedNoticeIds = selectedNoticeIds,
+                toggleNoticeSelection = toggleNoticeSelection,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            )
+            if (isSelectModeEnabled) {
+                KuringCallToAction(
+                    text = stringResource(id = R.string.cta_text),
+                    onClick = onShowDeleteAlertDialog,
+                    enabled = selectedNoticeIds.isNotEmpty(),
+                    blur = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/campusmap/CampusMapScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/campusmap/CampusMapScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -14,7 +14,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.components.topbar.CenterTitleTopBar
@@ -32,11 +31,10 @@ fun CampusMapScreen(
                 title = stringResource(R.string.campus_map_title),
                 navigation = {},
                 action = {},
-                modifier = Modifier.padding(16.dp),
             )
         },
         modifier = modifier.fillMaxSize(),
-        backgroundColor = KuringTheme.colors.background,
+        containerColor = KuringTheme.colors.background,
     ) {
         Column(
             modifier = Modifier

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/NoticeScreen.kt
@@ -61,6 +61,7 @@ internal fun NoticeScreen(
                 }
             },
             modifier = modifier,
+            containerColor = KuringTheme.colors.background,
         ) { contentPadding ->
             NoticeTabScreens(
                 onNoticeClick = onNoticeClick,

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/search/compose/SearchScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/search/compose/SearchScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -110,83 +111,91 @@ private fun SearchScreen(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.background(KuringTheme.colors.background)
-    ) {
-        CenterTitleTopBar(
-            title = stringResource(id = R.string.search),
-            navigation = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_back_v2),
-                    contentDescription = null,
-                    tint = KuringTheme.colors.gray600,
-                )
-            },
-            onNavigationClick = { onNavigationClick() },
-            action = ""
-        )
-
-        SearchTextField(
-            query = searchState.query,
-            onQueryUpdate = { searchState.query = it },
-            placeholderText = stringResource(id = R.string.search_enter_keyword),
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Search
-            ),
-            keyboardActions = KeyboardActions(
-                onSearch = {
-                    keyboardController?.hide()
-                    onSearch(searchState)
-                }
-            ),
+    Scaffold(
+        topBar = {
+            CenterTitleTopBar(
+                title = stringResource(id = R.string.search),
+                navigation = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_back_v2),
+                        contentDescription = null,
+                        tint = KuringTheme.colors.gray600,
+                    )
+                },
+                onNavigationClick = { onNavigationClick() },
+                action = ""
+            )
+        },
+        modifier = modifier,
+        containerColor = KuringTheme.colors.background,
+    ) { paddingValues ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 0.dp)
-        )
-
-        AnimatedVisibility(
-            visible = keywordHistories.isNotEmpty(),
-            exit = fadeOut() + slideOutVertically(),
+                .padding(paddingValues)
+                .fillMaxSize(),
         ) {
-            KeywordHistorySection(
-                keywordHistories = keywordHistories,
-                onClickSearchHistory = {
-                    searchState.query = it
-                    onSearch(searchState)
-                },
-                onClickClearSearchHistory = {
-                    onClickClearSearchHistory()
-                },
-                modifier = Modifier.padding(top = 12.dp)
+            SearchTextField(
+                query = searchState.query,
+                onQueryUpdate = { searchState.query = it },
+                placeholderText = stringResource(id = R.string.search_enter_keyword),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Search
+                ),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        keyboardController?.hide()
+                        onSearch(searchState)
+                    }
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 20.dp, top = 20.dp, bottom = 0.dp)
+            )
+
+            AnimatedVisibility(
+                visible = keywordHistories.isNotEmpty(),
+                exit = fadeOut() + slideOutVertically(),
+            ) {
+                KeywordHistorySection(
+                    keywordHistories = keywordHistories,
+                    onClickSearchHistory = {
+                        searchState.query = it
+                        onSearch(searchState)
+                    },
+                    onClickClearSearchHistory = {
+                        onClickClearSearchHistory()
+                    },
+                    modifier = Modifier.padding(top = 12.dp)
+                )
+            }
+
+            SearchResultTitle()
+
+            val pagerState = rememberPagerState(pageCount = { tabPages.size })
+
+            LaunchedEffect(pagerState) {
+                snapshotFlow { pagerState.currentPage }.distinctUntilChanged()
+                    .collect { pageIndex ->
+                        searchState.tab = SearchTabInfo.values()[pageIndex]
+                    }
+            }
+
+            SearchTabRow(
+                pagerState = pagerState,
+                tabPages = tabPages,
+            )
+
+            SearchResultHorizontalPager(
+                searchState = searchState,
+                pagerState = pagerState,
+                tabPages = tabPages,
+                noticeList = noticeList,
+                staffList = staffList,
+                onClickNotice = onClickNotice,
             )
         }
-
-        SearchResultTitle()
-
-        val pagerState = rememberPagerState(pageCount = { tabPages.size })
-
-        LaunchedEffect(pagerState) {
-            snapshotFlow { pagerState.currentPage }.distinctUntilChanged()
-                .collect { pageIndex ->
-                    searchState.tab = SearchTabInfo.values()[pageIndex]
-                }
-        }
-
-        SearchTabRow(
-            pagerState = pagerState,
-            tabPages = tabPages,
-        )
-
-        SearchResultHorizontalPager(
-            searchState = searchState,
-            pagerState = pagerState,
-            tabPages = tabPages,
-            noticeList = noticeList,
-            staffList = staffList,
-            onClickNotice = onClickNotice,
-        )
     }
 }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/OpenSourceEmojiScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/OpenSourceEmojiScreen.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,7 +46,8 @@ internal fun OpenSourceEmojiScreen(
                 action = {},
             )
         },
-        modifier = modifier.background(KuringTheme.colors.background),
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier,
     ) {
         Column(
             modifier = Modifier

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/OpenSourceListScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/OpenSourceListScreen.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
-import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,7 +48,8 @@ internal fun OpenSourceListScreen(
                 action = {},
             )
         },
-        modifier = modifier.background(KuringTheme.colors.background),
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier,
     ) {
         Column(
             modifier = Modifier

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -72,17 +73,24 @@ internal fun SettingScreen(
 
     var isLogoutDialogVisible by rememberSaveable { mutableStateOf(false) }
 
-    Column(modifier = modifier) {
-        CenterTitleTopBar(
-            title = stringResource(id = R.string.setting_screen_top_app_bar_title),
-            action = {},
-            modifier = Modifier.padding(vertical = 16.dp),
-        )
-
+    Scaffold(
+        topBar = {
+            CenterTitleTopBar(
+                title = stringResource(id = R.string.setting_screen_top_app_bar_title),
+                action = {},
+            )
+        },
+        modifier = modifier,
+        containerColor = KuringTheme.colors.background,
+    ) {
         when (settingUiState) {
             is SettingUiState.Success -> {
                 with(settingUiState) {
-                    Column(modifier = Modifier.verticalScroll(scrollState)) {
+                    Column(
+                        modifier = Modifier
+                            .padding(it)
+                            .verticalScroll(scrollState),
+                    ) {
                         ProfileGroup(
                             userProfileState = userProfileState,
                             onNavigateToSignIn = onNavigateToSignIn,
@@ -128,7 +136,6 @@ internal fun SettingScreen(
             }
         }
     }
-
     if (isLogoutDialogVisible) {
         LogoutDialog(
             onDismiss = { isLogoutDialogVisible = false },

--- a/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/report/ReportCommentScreen.kt
+++ b/feature/notice_detail/src/main/java/com/ku_stacks/ku_ring/notice_detail/report/ReportCommentScreen.kt
@@ -118,7 +118,8 @@ private fun ReportCommentScreen(
                 action = "",
             )
         },
-        modifier = modifier.background(KuringTheme.colors.background)
+        containerColor = KuringTheme.colors.background,
+        modifier = modifier,
     ) {
         Column(
             modifier = Modifier

--- a/feature/notion/src/main/java/com/ku_stacks/ku_ring/notion/NotionScreen.kt
+++ b/feature/notion/src/main/java/com/ku_stacks/ku_ring/notion/NotionScreen.kt
@@ -3,7 +3,7 @@ package com.ku_stacks.ku_ring.notion
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Scaffold
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.ku_stacks.ku_ring.designsystem.components.KuringWebView
@@ -21,6 +21,7 @@ fun NotionScreen(
             KuringIconTopBar(modifier = Modifier.fillMaxWidth())
         },
         modifier = modifier,
+        containerColor = KuringTheme.colors.background,
     ) {
         val innerModifier = Modifier
             .padding(it)

--- a/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/ku_stacks/ku_ring/onboarding/compose/OnboardingScreen.kt
@@ -2,8 +2,9 @@ package com.ku_stacks.ku_ring.onboarding.compose
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
@@ -31,32 +32,35 @@ internal fun OnboardingScreen(
         durationMillis = 200,
     )
 
-    val background = KuringTheme.colors.background
-    NavHost(
-        navController = navController,
-        startDestination = OnboardingScreenDestinations.FEATURE_TABS,
-        modifier = modifier,
-        enterTransition = {
-            slideIntoContainer(
-                towards = animationDirection(initialState, targetState),
-                animationSpec = navigationSpec,
-            )
-        },
-        exitTransition = {
-            slideOutOfContainer(
-                towards = animationDirection(initialState, targetState),
-                animationSpec = navigationSpec,
+    Scaffold(
+        containerColor = KuringTheme.colors.background,
+    ) { paddingValues ->
+        NavHost(
+            navController = navController,
+            startDestination = OnboardingScreenDestinations.FEATURE_TABS,
+            modifier = modifier,
+            enterTransition = {
+                slideIntoContainer(
+                    towards = animationDirection(initialState, targetState),
+                    animationSpec = navigationSpec,
+                )
+            },
+            exitTransition = {
+                slideOutOfContainer(
+                    towards = animationDirection(initialState, targetState),
+                    animationSpec = navigationSpec,
+                )
+            }
+        ) {
+            onboardingNavGraph(
+                navHostController = navController,
+                onNavigateToMain = onNavigateToMain,
+                viewModel = viewModel,
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize()
             )
         }
-    ) {
-        onboardingNavGraph(
-            navHostController = navController,
-            onNavigateToMain = onNavigateToMain,
-            viewModel = viewModel,
-            modifier = Modifier
-                .background(background)
-                .fillMaxSize()
-        )
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ google-services = '4.4.3'
 firebase-gradle = '3.0.5'
 oss-licenses-version = '0.10.6'
 compileSdk = "35"
-targetSdk = "34"
+targetSdk = "35"
 minSdk = "24"
 # Update appVersion, versionCode both
 appVersion = "2.3.2"


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-240?atlOrigin=eyJpIjoiYzVmYzA3OTM4YjVjNDU0MmFmZjdjMjc4YWQ2ZTE0M2IiLCJwIjoiaiJ9

## 요약

Google Play 요구사항 준수를 위해, target sdk 레벨을 35(Android 15)로 올렸습니다.

Android 15를 target하는 앱은 기본적으로 edge-to-edge가 활성화됩니다. 이에 따라 레이아웃에서 window inset을 적절히 소비하도록 수정했습니다. (`Column`을 M3 `Scaffold`로 바꾸거나, `Modifier.systemBarsPadding()`을 추가)

이 외에 쿠링에 영향을 미치는 변경사항은 없는 것으로 확인했습니다.

참고: https://developer.android.com/about/versions/15/behavior-changes-15#window-insets

### as-is ↔ to-be


<img width="870" height="837" alt="공지화면" src="https://github.com/user-attachments/assets/6194cba2-6d70-4c6e-9837-035537c56368" />

<img width="870" height="837" alt="쿠링봇" src="https://github.com/user-attachments/assets/248d291c-62ef-4212-9b47-6f3921279890" />
