### PR TITLE
kuring-244 학사일정 알림 수신 API 및 UI 구현

### DIFF
--- a/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
+++ b/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
@@ -2,9 +2,9 @@ package com.ku_stacks.ku_ring.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.qualifiers.ApplicationContext
-import androidx.core.content.edit
 
 class PreferenceUtil(@ApplicationContext context: Context) {
 
@@ -34,6 +34,10 @@ class PreferenceUtil(@ApplicationContext context: Context) {
     var extNotificationAllowed: Boolean
         get() = prefs.getBoolean(DEFAULT_NOTIFICATION, true)
         set(value) = prefs.edit().putBoolean(DEFAULT_NOTIFICATION, value).apply()
+
+    var academicEventNotificationAllowed: Boolean
+        get() = prefs.getBoolean(ACADEMIC_EVENT_NOTIFICATION, true)
+        set(value) = prefs.edit { putBoolean(ACADEMIC_EVENT_NOTIFICATION, value) }
 
     var campusUserId: String
         get() = prefs.getString(CAMPUS_USER_ID, null) ?: ""
@@ -66,6 +70,7 @@ class PreferenceUtil(@ApplicationContext context: Context) {
         const val FCM_TOKEN = "FCM_TOKEN"
         const val SUBSCRIPTION = "SUBSCRIPTION"
         const val DEFAULT_NOTIFICATION = "DEFAULT_NOTIFICATION"
+        const val ACADEMIC_EVENT_NOTIFICATION = "ACADEMIC_EVENT_NOTIFICATION"
         const val CAMPUS_USER_ID = "CAMPUS_USER_ID"
         const val SURVEY_2024_COMPLETE = "SURVEY_2024_COMPLETE"
     }

--- a/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
+++ b/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
@@ -13,11 +13,11 @@ class PreferenceUtil(@ApplicationContext context: Context) {
 
     var firstRunFlag: Boolean
         get() = prefs.getBoolean(FIRST_RUN, true)
-        set(value) = prefs.edit().putBoolean(FIRST_RUN, value).apply()
+        set(value) = prefs.edit { putBoolean(FIRST_RUN, value) }
 
     var startDate: String?
         get() = prefs.getString(START_DATE, "")
-        set(value) = prefs.edit().putString(START_DATE, value).apply()
+        set(value) = prefs.edit { putString(START_DATE, value) }
 
     var accessToken: String
         get() = prefs.getString(ACCESS_TOKEN, "") ?: ""
@@ -25,15 +25,15 @@ class PreferenceUtil(@ApplicationContext context: Context) {
 
     var fcmToken: String
         get() = prefs.getString(FCM_TOKEN, "") ?: ""
-        set(value) = prefs.edit().putString(FCM_TOKEN, value).apply()
+        set(value) = prefs.edit { putString(FCM_TOKEN, value) }
 
     var subscription: Set<String>
         get() = prefs.getStringSet(SUBSCRIPTION, emptySet()) ?: emptySet()
-        private set(stringSet) = prefs.edit().putStringSet(SUBSCRIPTION, stringSet).apply()
+        private set(stringSet) = prefs.edit { putStringSet(SUBSCRIPTION, stringSet) }
 
     var extNotificationAllowed: Boolean
         get() = prefs.getBoolean(DEFAULT_NOTIFICATION, true)
-        set(value) = prefs.edit().putBoolean(DEFAULT_NOTIFICATION, value).apply()
+        set(value) = prefs.edit { putBoolean(DEFAULT_NOTIFICATION, value) }
 
     var academicEventNotificationAllowed: Boolean
         get() = prefs.getBoolean(ACADEMIC_EVENT_NOTIFICATION, true)
@@ -41,14 +41,14 @@ class PreferenceUtil(@ApplicationContext context: Context) {
 
     var campusUserId: String
         get() = prefs.getString(CAMPUS_USER_ID, null) ?: ""
-        set(value) = prefs.edit().putString(CAMPUS_USER_ID, value).apply()
+        set(value) = prefs.edit { putString(CAMPUS_USER_ID, value) }
 
     var is2024SurveyComplete: Boolean
         get() = prefs.getBoolean(SURVEY_2024_COMPLETE, false)
-        set(value) = prefs.edit().putBoolean(SURVEY_2024_COMPLETE, value).apply()
+        set(value) = prefs.edit { putBoolean(SURVEY_2024_COMPLETE, value) }
 
     fun deleteStartDate() {
-        prefs.edit().remove(START_DATE).apply()
+        prefs.edit { remove(START_DATE) }
     }
 
     fun deleteAccessToken() {

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -14,14 +14,8 @@ class UserClient @Inject constructor(
     private val userService: UserService
 ) {
     suspend fun setAcademicEventNotification(
-        token: String,
         request: AcademicEventNotificationRequest,
-    ): DefaultResponse {
-        return userService.patchAcademicEventNotification(
-            token = token,
-            request = request
-        )
-    }
+    ): DefaultResponse = userService.patchAcademicEventNotification(request)
 
     suspend fun sendFeedback(
         token: String,

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserClient.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.remote.user
 
+import com.ku_stacks.ku_ring.remote.user.request.AcademicEventNotificationRequest
 import com.ku_stacks.ku_ring.remote.user.request.AuthorizeUserRequest
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.remote.user.request.RegisterUserRequest
@@ -12,6 +13,16 @@ import javax.inject.Inject
 class UserClient @Inject constructor(
     private val userService: UserService
 ) {
+    suspend fun setAcademicEventNotification(
+        token: String,
+        request: AcademicEventNotificationRequest,
+    ): DefaultResponse {
+        return userService.patchAcademicEventNotification(
+            token = token,
+            request = request
+        )
+    }
+
     suspend fun sendFeedback(
         token: String,
         feedbackRequest: FeedbackRequest,

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.ku_stacks.ku_ring.remote.user
 
+import com.ku_stacks.ku_ring.remote.user.request.AcademicEventNotificationRequest
 import com.ku_stacks.ku_ring.remote.user.request.AuthorizeUserRequest
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.remote.user.request.RegisterUserRequest
@@ -15,6 +16,12 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 
 interface UserService {
+    @PATCH("v2/users/notifications/academic-events")
+    suspend fun patchAcademicEventNotification(
+        @Header("User-Token") token: String,
+        @Body request: AcademicEventNotificationRequest,
+    ): DefaultResponse
+
     @POST("v2/users/feedbacks")
     suspend fun sendFeedback(
         @Header("User-Token") token: String,

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/UserService.kt
@@ -18,7 +18,6 @@ import retrofit2.http.POST
 interface UserService {
     @PATCH("v2/users/notifications/academic-events")
     suspend fun patchAcademicEventNotification(
-        @Header("User-Token") token: String,
         @Body request: AcademicEventNotificationRequest,
     ): DefaultResponse
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/request/AcademicEventNotificationRequest.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/user/request/AcademicEventNotificationRequest.kt
@@ -1,0 +1,7 @@
+package com.ku_stacks.ku_ring.remote.user.request
+
+import kotlinx.serialization.SerialName
+
+data class AcademicEventNotificationRequest(
+    @SerialName("enabled") val enabled: Boolean,
+)

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.ku_stacks.ku_ring.local.room.BlackUserDao
 import com.ku_stacks.ku_ring.local.room.CategoryOrderDao
 import com.ku_stacks.ku_ring.preferences.PreferenceUtil
 import com.ku_stacks.ku_ring.remote.user.UserClient
+import com.ku_stacks.ku_ring.remote.user.request.AcademicEventNotificationRequest
 import com.ku_stacks.ku_ring.remote.user.request.AuthorizeUserRequest
 import com.ku_stacks.ku_ring.remote.user.request.FeedbackRequest
 import com.ku_stacks.ku_ring.user.mapper.toDomain
@@ -55,6 +56,15 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun registerUser(token: String) {
         userClient.registerUser(token)
+    }
+
+    override suspend fun setAcademicEventNotification(enabled: Boolean): Result<Boolean> {
+        return suspendRunCatching {
+            userClient.setAcademicEventNotification(
+                token = pref.fcmToken,
+                request = AcademicEventNotificationRequest(enabled),
+            ).isSuccess
+        }
     }
 
     override suspend fun getUserData(): Result<User> = runCatching {

--- a/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
+++ b/data/user/src/main/java/com/ku_stacks/ku_ring/user/repository/UserRepositoryImpl.kt
@@ -61,7 +61,6 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun setAcademicEventNotification(enabled: Boolean): Result<Boolean> {
         return suspendRunCatching {
             userClient.setAcademicEventNotification(
-                token = pref.fcmToken,
                 request = AcademicEventNotificationRequest(enabled),
             ).isSuccess
         }

--- a/domain/user/src/main/java/com/ku_stacks/ku_ring/domain/user/repository/UserRepository.kt
+++ b/domain/user/src/main/java/com/ku_stacks/ku_ring/domain/user/repository/UserRepository.kt
@@ -14,6 +14,14 @@ interface UserRepository {
     suspend fun sendFeedback(feedback: String): Result<Pair<Boolean, String>>
     suspend fun registerUser(token: String)
 
+    /**
+     * Sets whether academic event notification is enabled.
+     *
+     * @param enabled Whether academic event notification is enabled
+     * @return `true` if the request is successful, `false` otherwise
+     */
+    suspend fun setAcademicEventNotification(enabled: Boolean): Result<Boolean>
+
     suspend fun getUserData(): Result<User>
     suspend fun signUpUser(email: String, password: String): Result<Unit>
     suspend fun signInUser(email: String, password: String): Result<Unit>

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainScreen.kt
@@ -180,6 +180,12 @@ fun NavGraphBuilder.mainScreenNavGraph(
             onNavigateToSignIn = { navigator.navigateToAuth(activity) },
             onNavigateToEditSubscription = { navigator.navigateToEditSubscription(activity) },
             onExtNotificationEnabledToggle = viewModel::setExtNotificationAllowed,
+            onAcademicEventNotificationEnabledToggle = { value ->
+                viewModel.setAcademicEventNotificationAllowed(
+                    value = value,
+                    onFail = { activity.showToast(R.string.setting_subscribe_academic_events_fail) },
+                )
+            },
             onNavigateToUpdateLog = {
                 activity.startWebView(navigator, R.string.notion_new_contents_url)
             },

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -55,7 +55,7 @@ class SettingViewModel @Inject constructor(
 
     fun setAcademicEventNotificationAllowed(value: Boolean, onFail: () -> Unit) {
         viewModelScope.launch {
-            if (userRepository.setAcademicEventNotification(value).isSuccess) {
+            if (userRepository.setAcademicEventNotification(value).getOrNull() == true) {
                 pref.academicEventNotificationAllowed = value
                 _isAcademicEventNotificationAllowed.value = value
             } else {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/SettingViewModel.kt
@@ -22,20 +22,24 @@ class SettingViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _isExtNotificationAllowed = MutableStateFlow(pref.extNotificationAllowed)
+    private val _isAcademicEventNotificationAllowed =
+        MutableStateFlow(pref.academicEventNotificationAllowed)
     private val _userProfileState: MutableStateFlow<UserProfileState> =
         MutableStateFlow(UserProfileState.InitialLoading)
 
     val settingUiState: StateFlow<SettingUiState> = combine(
         _isExtNotificationAllowed,
+        _isAcademicEventNotificationAllowed,
         _userProfileState,
-    ) { isExtNotificationAllowed, userProfileState ->
+    ) { isExtNotificationAllowed, isAcademicEventNotificationAllowed, userProfileState ->
         when (userProfileState) {
             is UserProfileState.InitialLoading -> SettingUiState.Initial
             is UserProfileState.Error -> SettingUiState.Error
             is UserProfileState.NotLoggedIn,
             is UserProfileState.LoggedIn -> SettingUiState.Success(
-                isExtNotificationEnabled = isExtNotificationAllowed,
                 userProfileState = userProfileState,
+                isExtNotificationEnabled = isExtNotificationAllowed,
+                isAcademicEventNotificationEnabled = isAcademicEventNotificationAllowed,
             )
         }
     }.stateIn(
@@ -47,6 +51,17 @@ class SettingViewModel @Inject constructor(
     fun setExtNotificationAllowed(value: Boolean) {
         pref.extNotificationAllowed = value
         _isExtNotificationAllowed.value = value
+    }
+
+    fun setAcademicEventNotificationAllowed(value: Boolean, onFail: () -> Unit) {
+        viewModelScope.launch {
+            if (userRepository.setAcademicEventNotification(value).isSuccess) {
+                pref.academicEventNotificationAllowed = value
+                _isAcademicEventNotificationAllowed.value = value
+            } else {
+                onFail()
+            }
+        }
     }
 
     fun logout() = viewModelScope.launch {
@@ -76,6 +91,7 @@ sealed class SettingUiState {
     data class Success(
         val userProfileState: UserProfileState,
         val isExtNotificationEnabled: Boolean,
+        val isAcademicEventNotificationEnabled: Boolean,
     ) : SettingUiState()
 }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/SettingNavHost.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/SettingNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
@@ -17,6 +18,7 @@ import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.main.R
 import com.ku_stacks.ku_ring.main.setting.SettingViewModel
 import com.ku_stacks.ku_ring.main.setting.compose.inner_screen.SettingScreen
+import com.ku_stacks.ku_ring.ui_util.showToast
 
 // TODO: 향후 compose 완전 migration 시 사용
 @Composable
@@ -74,12 +76,19 @@ private fun NavGraphBuilder.settingNavGraph(
 ) {
     composable(SettingDestinations.SETTING_SCREEN) {
         val settingsUiState by viewModel.settingUiState.collectAsStateWithLifecycle()
+        val context = LocalContext.current
 
         SettingScreen(
             settingUiState = settingsUiState,
             onNavigateToSignIn = navigateToSignIn,
             onNavigateToEditSubscription = navigateToEditSubscription,
             onExtNotificationEnabledToggle = viewModel::setExtNotificationAllowed,
+            onAcademicEventNotificationEnabledToggle = { value ->
+                viewModel.setAcademicEventNotificationAllowed(
+                    value = value,
+                    onFail = { context.showToast(R.string.setting_subscribe_academic_events_fail) },
+                )
+            },
             onNavigateToUpdateLog = { startWebViewActivity(R.string.notion_new_contents_url) },
             onNavigateToKuringTeam = { startWebViewActivity(R.string.notion_kuring_team_url) },
             onNavigateToPrivacyPolicy = { startWebViewActivity(R.string.notion_privacy_policy_url) },

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
@@ -8,10 +8,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.KuringSwitch
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 
@@ -36,11 +34,7 @@ internal fun SettingSwitch(
     )
     Text(
         text = stringResource(descriptionId),
-        style = KuringTheme.typography.tag.copy(
-            color = KuringTheme.colors.textCaption1,
-            letterSpacing = 0.15.sp,
-            fontWeight = FontWeight.Normal,
-        ),
+        style = KuringTheme.typography.tag2,
         modifier = Modifier
             .padding(start = 56.dp)
             .offset { IntOffset(0, -(10.dp.roundToPx())) },

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
@@ -8,14 +8,12 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ku_stacks.ku_ring.designsystem.components.KuringSwitch
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
-import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 
 @Composable
 internal fun SettingSwitch(
@@ -38,12 +36,10 @@ internal fun SettingSwitch(
     )
     Text(
         text = stringResource(descriptionId),
-        style = TextStyle(
-            fontSize = 12.sp,
-            fontFamily = Pretendard,
-            fontWeight = FontWeight(400),
+        style = KuringTheme.typography.tag.copy(
             color = KuringTheme.colors.textCaption1,
             letterSpacing = 0.15.sp,
+            fontWeight = FontWeight.Normal,
         ),
         modifier = Modifier
             .padding(start = 56.dp)

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/components/SettingSwitch.kt
@@ -1,0 +1,52 @@
+package com.ku_stacks.ku_ring.main.setting.compose.components
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ku_stacks.ku_ring.designsystem.components.KuringSwitch
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
+import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+
+@Composable
+internal fun SettingSwitch(
+    @DrawableRes iconId: Int,
+    @StringRes titleId: Int,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    @StringRes descriptionId: Int,
+) {
+    SettingItem(
+        iconId = iconId,
+        title = stringResource(titleId),
+        onClick = null,
+        content = {
+            KuringSwitch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+        }
+    )
+    Text(
+        text = stringResource(descriptionId),
+        style = TextStyle(
+            fontSize = 12.sp,
+            fontFamily = Pretendard,
+            fontWeight = FontWeight(400),
+            color = KuringTheme.colors.textCaption1,
+            letterSpacing = 0.15.sp,
+        ),
+        modifier = Modifier
+            .padding(start = 56.dp)
+            .offset { IntOffset(0, -(10.dp.roundToPx())) },
+    )
+}

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
@@ -23,8 +23,8 @@ internal fun SubscribeGroup(
     onNavigateToEditSubscription: () -> Unit,
     isExtNotificationEnabled: Boolean,
     onExtNotificationEnabledToggle: (Boolean) -> Unit,
-    isAcademicNotificationEnabled: Boolean,
-    onAcademicNotificationEnabledToggle: (Boolean) -> Unit,
+    isAcademicEventNotificationEnabled: Boolean,
+    onAcademicEventNotificationEnabledToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -46,8 +46,8 @@ internal fun SubscribeGroup(
             SettingSwitch(
                 iconId = R.drawable.ic_bell_v2,
                 titleId = R.string.setting_subscribe_academic_events,
-                checked = isAcademicNotificationEnabled,
-                onCheckedChange = onAcademicNotificationEnabledToggle,
+                checked = isAcademicEventNotificationEnabled,
+                onCheckedChange = onAcademicEventNotificationEnabledToggle,
                 descriptionId = R.string.setting_subscribe_academic_events_caption,
             )
         }
@@ -66,8 +66,8 @@ private fun SubscribeGroupPreview() {
             onExtNotificationEnabledToggle = {
                 isExtNotificationEnabled = !isExtNotificationEnabled
             },
-            isAcademicNotificationEnabled = isAcademicNotificationEnabled,
-            onAcademicNotificationEnabledToggle = {
+            isAcademicEventNotificationEnabled = isAcademicNotificationEnabled,
+            onAcademicEventNotificationEnabledToggle = {
                 isAcademicNotificationEnabled = !isAcademicNotificationEnabled
             },
             modifier = Modifier

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/groups/SubscribeGroup.kt
@@ -3,9 +3,6 @@ package com.ku_stacks.ku_ring.main.setting.compose.groups
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,25 +10,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.ku_stacks.ku_ring.designsystem.components.KuringSwitch
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
-import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
 import com.ku_stacks.ku_ring.main.R
 import com.ku_stacks.ku_ring.main.setting.compose.components.ChevronIcon
 import com.ku_stacks.ku_ring.main.setting.compose.components.SettingGroup
 import com.ku_stacks.ku_ring.main.setting.compose.components.SettingItem
+import com.ku_stacks.ku_ring.main.setting.compose.components.SettingSwitch
 
 @Composable
 internal fun SubscribeGroup(
     onNavigateToEditSubscription: () -> Unit,
     isExtNotificationEnabled: Boolean,
     onExtNotificationEnabledToggle: (Boolean) -> Unit,
+    isAcademicNotificationEnabled: Boolean,
+    onAcademicNotificationEnabledToggle: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -42,46 +35,41 @@ internal fun SubscribeGroup(
                 onClick = onNavigateToEditSubscription,
                 content = { ChevronIcon() },
             )
-            SettingItem(
+
+            SettingSwitch(
                 iconId = R.drawable.ic_bell_v2,
-                title = stringResource(id = R.string.setting_subscribe_others),
-                onClick = null,
-                content = {
-                    KuringSwitch(
-                        checked = isExtNotificationEnabled,
-                        onCheckedChange = {
-                            onExtNotificationEnabledToggle(!isExtNotificationEnabled)
-                        },
-                    )
-                },
+                titleId = R.string.setting_subscribe_notifications,
+                checked = isExtNotificationEnabled,
+                onCheckedChange = onExtNotificationEnabledToggle,
+                descriptionId = R.string.setting_subscribe_others_caption,
+            )
+            SettingSwitch(
+                iconId = R.drawable.ic_bell_v2,
+                titleId = R.string.setting_subscribe_academic_events,
+                checked = isAcademicNotificationEnabled,
+                onCheckedChange = onAcademicNotificationEnabledToggle,
+                descriptionId = R.string.setting_subscribe_academic_events_caption,
             )
         }
-
-        Text(
-            text = stringResource(id = R.string.setting_subscribe_others_caption),
-            style = TextStyle(
-                fontSize = 12.sp,
-                fontFamily = Pretendard,
-                fontWeight = FontWeight(400),
-                color = KuringTheme.colors.textCaption1,
-                letterSpacing = 0.15.sp,
-            ),
-            modifier = Modifier
-                .padding(start = 56.dp)
-                .offset { IntOffset(0, -(10.dp.roundToPx())) },
-        )
     }
 }
 
 @LightAndDarkPreview
 @Composable
 private fun SubscribeGroupPreview() {
-    var enabled by remember { mutableStateOf(false) }
+    var isExtNotificationEnabled by remember { mutableStateOf(false) }
+    var isAcademicNotificationEnabled by remember { mutableStateOf(false) }
     KuringTheme {
         SubscribeGroup(
             onNavigateToEditSubscription = { },
-            isExtNotificationEnabled = enabled,
-            onExtNotificationEnabledToggle = { enabled = !enabled },
+            isExtNotificationEnabled = isExtNotificationEnabled,
+            onExtNotificationEnabledToggle = {
+                isExtNotificationEnabled = !isExtNotificationEnabled
+            },
+            isAcademicNotificationEnabled = isAcademicNotificationEnabled,
+            onAcademicNotificationEnabledToggle = {
+                isAcademicNotificationEnabled = !isAcademicNotificationEnabled
+            },
             modifier = Modifier
                 .background(KuringTheme.colors.background)
                 .fillMaxWidth(),

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -57,6 +57,7 @@ internal fun SettingScreen(
     onNavigateToSignIn: () -> Unit,
     onNavigateToEditSubscription: () -> Unit,
     onExtNotificationEnabledToggle: (Boolean) -> Unit,
+    onAcademicEventNotificationEnabledToggle: (Boolean) -> Unit,
     onNavigateToUpdateLog: () -> Unit,
     onNavigateToKuringTeam: () -> Unit,
     onNavigateToPrivacyPolicy: () -> Unit,
@@ -100,6 +101,8 @@ internal fun SettingScreen(
                             onNavigateToEditSubscription = onNavigateToEditSubscription,
                             isExtNotificationEnabled = isExtNotificationEnabled,
                             onExtNotificationEnabledToggle = onExtNotificationEnabledToggle,
+                            isAcademicNotificationEnabled = isAcademicEventNotificationEnabled,
+                            onAcademicNotificationEnabledToggle = onAcademicEventNotificationEnabledToggle,
                         )
                         SettingScreenDivider()
                         InformationGroup(
@@ -227,6 +230,7 @@ private fun SettingScreenPreview() {
             onNavigateToSignIn = {},
             onNavigateToEditSubscription = {},
             onExtNotificationEnabledToggle = {},
+            onAcademicEventNotificationEnabledToggle = {},
             onNavigateToUpdateLog = {},
             onNavigateToKuringTeam = {},
             onNavigateToPrivacyPolicy = {},

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -220,8 +220,9 @@ private fun SettingScreenPreview() {
     KuringTheme {
         SettingScreen(
             settingUiState = SettingUiState.Success(
-                isExtNotificationEnabled = true,
                 userProfileState = UserProfileState.LoggedIn("홍길동"),
+                isExtNotificationEnabled = true,
+                isAcademicEventNotificationEnabled = true,
             ),
             onNavigateToSignIn = {},
             onNavigateToEditSubscription = {},

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/setting/compose/inner_screen/SettingScreen.kt
@@ -101,8 +101,8 @@ internal fun SettingScreen(
                             onNavigateToEditSubscription = onNavigateToEditSubscription,
                             isExtNotificationEnabled = isExtNotificationEnabled,
                             onExtNotificationEnabledToggle = onExtNotificationEnabledToggle,
-                            isAcademicNotificationEnabled = isAcademicEventNotificationEnabled,
-                            onAcademicNotificationEnabledToggle = onAcademicEventNotificationEnabledToggle,
+                            isAcademicEventNotificationEnabled = isAcademicEventNotificationEnabled,
+                            onAcademicEventNotificationEnabledToggle = onAcademicEventNotificationEnabledToggle,
                         )
                         SettingScreenDivider()
                         InformationGroup(

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -63,9 +63,8 @@
     <string name="setting_subscribe_notifications">공지 구독하기</string>
     <string name="setting_subscribe_others">기타 알림 받기</string>
     <string name="setting_subscribe_others_caption">주요 공지사항, 앱 내 주요 사항</string>
-    <!--  TODO: 디자인팀에 정확한 문구 문의 중  -->
-    <string name="setting_subscribe_academic_events">학과 알림 받기</string>
-    <string name="setting_subscribe_academic_events_caption">학과 일정 안내</string>
+    <string name="setting_subscribe_academic_events">학사일정 알림 받기</string>
+    <string name="setting_subscribe_academic_events_caption">당일 학사일정 시작과 종료 알림</string>
     <string name="setting_subscribe_academic_events_fail">잠시 후 다시 시도해 주세요.</string>
 
     <string name="setting_information_title">정보</string>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -63,6 +63,10 @@
     <string name="setting_subscribe_notifications">공지 구독하기</string>
     <string name="setting_subscribe_others">기타 알림 받기</string>
     <string name="setting_subscribe_others_caption">주요 공지사항, 앱 내 주요 사항</string>
+    <!--  TODO: 디자인팀에 정확한 문구 문의 중  -->
+    <string name="setting_subscribe_academic_events">학과 알림 받기</string>
+    <string name="setting_subscribe_academic_events_caption">학과 일정 안내</string>
+    <string name="setting_subscribe_academic_events_fail">잠시 후 다시 시도해 주세요.</string>
 
     <string name="setting_information_title">정보</string>
     <string name="setting_information_app_version">앱 버전</string>


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-244?atlOrigin=eyJpIjoiY2I0NTZjOGVmYWJmNDU4OGIyZTIxOTZiZWZhYzE0ZmUiLCJwIjoiaiJ9

## 요약

학사일정 알림 수신 API 및 스위치 UI를 구현했습니다.

스위치를 터치했을 때 API 요청을 보내고, **응답이 success일 때에만** 스위치 및 로컬 pref 값을 변경합니다.

[Screen_recording_20250928_204848.webm](https://github.com/user-attachments/assets/6fd3ff8b-c77b-43e4-9dc9-e9e9645948a9)

## TODO

* 디자인팀에 문구 확인 중 (학사일정? 학과일정?) → 확인 후 수정 필요시 이 PR에 반영 예정 → https://github.com/ku-ring/KU-Ring-Android/pull/571/commits/2c4b9cb00c6dfd9b439d096ba12e3da84630c0f1 에서 수정 완료
* 서버팀에 학사일정 알림 FCM 형식 확인 중 → 별도 PR로 구현 예정 (형식 논의 중 w/ 서버, PM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 설정 화면에 학사 일정 알림 토글 추가 및 SubscribeGroup/SettingScreen 연동
  - 원격 동기화용 API·요청 모델·리포지토리/클라이언트 메서드 추가로 서버 저장 지원
  - 토글 실패 시 토스트 안내 및 ViewModel 상태에 학사 알림 활성 여부 포함
  - 학사 알림 관련 문자열 리소스 3종 추가

- **Refactor**
  - 환경설정(pref) 편집 로직을 scoped edit 블록으로 통일
  - 공통 스위치 컴포넌트 도입으로 UI 구성 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->