### PR TITLE
kuring-246 학사일정 UI에 API 연결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(projects.data.domain)
     implementation(projects.data.noticecomment)
     implementation(projects.data.report)
+    implementation(projects.data.academicevent)
     implementation(projects.feature.editDepartments)
     implementation(projects.feature.editSubscription)
     implementation(projects.feature.feedback)

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/indicator/HorizontalSlidingIndicator.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/indicator/HorizontalSlidingIndicator.kt
@@ -31,14 +31,13 @@ fun HorizontalSlidingIndicator(
     modifier: Modifier = Modifier,
     dotSize: Dp = 8.dp,
     spacing: Dp = 8.dp,
+    inactiveBackground: Color = KuringTheme.colors.gray200,
+    activeBackground:Color = KuringTheme.colors.mainPrimary,
 ) {
     // 두 indicator의 왼쪽 경계 간 거리
     val indicatorDistancePx = with(LocalDensity.current) {
         (dotSize + spacing).toPx()
     }
-
-    val inactiveBackground = KuringTheme.colors.gray200
-    val activeBackground = KuringTheme.colors.mainPrimary
     val dotShape = RoundedCornerShape(50)
 
     Box(

--- a/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
+++ b/core/preferences/src/main/java/com/ku_stacks/ku_ring/preferences/PreferenceUtil.kt
@@ -2,9 +2,9 @@ package com.ku_stacks.ku_ring.preferences
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.qualifiers.ApplicationContext
-import androidx.core.content.edit
 
 class PreferenceUtil(@ApplicationContext context: Context) {
 
@@ -43,6 +43,10 @@ class PreferenceUtil(@ApplicationContext context: Context) {
         get() = prefs.getBoolean(SURVEY_2024_COMPLETE, false)
         set(value) = prefs.edit().putBoolean(SURVEY_2024_COMPLETE, value).apply()
 
+    var lastDateAcademicEventShown: String
+        get() = prefs.getString(LAST_DATE_ACADEMIC_EVENT_SHEET_SHOWN, null) ?: ""
+        set(value) = prefs.edit { putString(LAST_DATE_ACADEMIC_EVENT_SHEET_SHOWN, value).apply() }
+
     fun deleteStartDate() {
         prefs.edit().remove(START_DATE).apply()
     }
@@ -68,5 +72,6 @@ class PreferenceUtil(@ApplicationContext context: Context) {
         const val DEFAULT_NOTIFICATION = "DEFAULT_NOTIFICATION"
         const val CAMPUS_USER_ID = "CAMPUS_USER_ID"
         const val SURVEY_2024_COMPLETE = "SURVEY_2024_COMPLETE"
+        const val LAST_DATE_ACADEMIC_EVENT_SHEET_SHOWN = "LAST_DATE_ACADEMIC_EVENT_SHEET_SHOWN"
     }
 }

--- a/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/di/RepositoryModule.kt
+++ b/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/di/RepositoryModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 abstract class RepositoryModule {
     @Binds
     @Singleton
-    abstract fun provideAcademicEventRepository(
+    abstract fun bindsAcademicEventRepository(
         repositoryImpl: AcademicEventRepositoryImpl,
     ): AcademicEventRepository
 }

--- a/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/repository/AcademicEventRepositoryImpl.kt
+++ b/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/repository/AcademicEventRepositoryImpl.kt
@@ -11,6 +11,8 @@ import com.ku_stacks.ku_ring.util.IODispatcher
 import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -46,5 +48,14 @@ class AcademicEventRepositoryImpl @Inject constructor(
         endDate: String,
     ): List<AcademicEventEntity> = withContext(ioDispatcher) {
         academicEventDao.getAcademicEvents(startDate, endDate)
+    }
+
+    override fun getAcademicEventsAsFlow(
+        startDate: String,
+        endDate: String
+    ): Flow<List<AcademicEvent>> = flow {
+        academicEventDao.getAcademicEventsAsFlow(startDate, endDate).collect { entities ->
+            emit(entities.map { it.toDomain() })
+        }
     }
 }

--- a/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/repository/AcademicEventRepositoryImpl.kt
+++ b/data/academicevent/src/main/java/com/ku_stacks/ku_ring/academicevent/repository/AcademicEventRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.ku_stacks.ku_ring.domain.academicevent.repository.AcademicEventReposi
 import com.ku_stacks.ku_ring.local.entity.AcademicEventEntity
 import com.ku_stacks.ku_ring.local.room.AcademicEventDao
 import com.ku_stacks.ku_ring.remote.academicevent.AcademicEventClient
+import com.ku_stacks.ku_ring.util.IODispatcher
 import com.ku_stacks.ku_ring.util.suspendRunCatching
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +17,7 @@ import javax.inject.Inject
 class AcademicEventRepositoryImpl @Inject constructor(
     private val academicEventDao: AcademicEventDao,
     private val academicEventClient: AcademicEventClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AcademicEventRepository {
     override suspend fun fetchAcademicEventsFromRemote(
         startDate: String?,

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.ku_stacks.ku_ring.local.entity.AcademicEventEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AcademicEventDao {
@@ -17,4 +18,11 @@ interface AcademicEventDao {
                 "ORDER BY startTime ASC, endTime ASC"
     )
     suspend fun getAcademicEvents(startDate: String, endDate: String): List<AcademicEventEntity>
+
+    @Query(
+        "SELECT * FROM AcademicEventEntity " +
+                "WHERE NOT (startTime > :endDate or endTime < :startDate) " +
+                "ORDER BY startTime ASC, endTime ASC"
+    )
+    fun getAcademicEventsAsFlow(startDate: String, endDate: String): Flow<List<AcademicEventEntity>>
 }

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
@@ -1,15 +1,14 @@
 package com.ku_stacks.ku_ring.local.room
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Upsert
 import com.ku_stacks.ku_ring.local.entity.AcademicEventEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AcademicEventDao {
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Upsert
     suspend fun insertAcademicEvents(events: List<AcademicEventEntity>)
 
     @Query(

--- a/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
+++ b/data/local/src/main/java/com/ku_stacks/ku_ring/local/room/AcademicEventDao.kt
@@ -13,7 +13,8 @@ interface AcademicEventDao {
 
     @Query(
         "SELECT * FROM AcademicEventEntity " +
-                "WHERE NOT (startTime > :endDate or endTime < :startDate)  ORDER BY startTime ASC"
+                "WHERE NOT (startTime > :endDate or endTime < :startDate) " +
+                "ORDER BY startTime ASC, endTime ASC"
     )
     suspend fun getAcademicEvents(startDate: String, endDate: String): List<AcademicEventEntity>
 }

--- a/domain/academicevent/build.gradle.kts
+++ b/domain/academicevent/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
 
     implementation(libs.javax.inject)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.datetime)
 }

--- a/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/repository/AcademicEventRepository.kt
+++ b/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/repository/AcademicEventRepository.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.domain.academicevent.repository
 
 import com.ku_stacks.ku_ring.domain.AcademicEvent
+import kotlinx.coroutines.flow.Flow
 
 interface AcademicEventRepository {
     /**
@@ -22,4 +23,15 @@ interface AcademicEventRepository {
         startDate: String,
         endDate: String,
     ): Result<List<AcademicEvent>>
+
+    /**
+     * gets flow of academic events from the local database
+     * that have a date range which intersects with the given range
+     * @param startDate start date of the academic events (format: yyyy-MM-dd, no limit if null)
+     * @param endDate end date of the academic events (format: yyyy-MM-dd, no limit if null)
+     */
+    fun getAcademicEventsAsFlow(
+        startDate: String,
+        endDate: String,
+    ): Flow<List<AcademicEvent>>
 }

--- a/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetAcademicEventsUseCase.kt
+++ b/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetAcademicEventsUseCase.kt
@@ -1,0 +1,35 @@
+package com.ku_stacks.ku_ring.domain.academicevent.usecase
+
+import com.ku_stacks.ku_ring.domain.AcademicEvent
+import com.ku_stacks.ku_ring.domain.academicevent.repository.AcademicEventRepository
+import kotlinx.datetime.LocalDate
+import javax.inject.Inject
+
+class GetAcademicEventsUseCase @Inject constructor(
+    private val academicEventRepository: AcademicEventRepository,
+) {
+    suspend operator fun invoke(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): Result<Map<String, List<AcademicEvent>>> = academicEventRepository
+        .getAcademicEvents(startDate.toString(), endDate.toString())
+        .mapByDate(startDate, endDate)
+
+    private fun Result<List<AcademicEvent>>.mapByDate(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ) = map { academicEvents ->
+        buildMap {
+            academicEvents.forEach { event ->
+                val startRange = event.startDateTime.date.coerceAtLeast(startDate)
+                val endRange = event.endDateTime.date.coerceAtMost(endDate)
+
+                // 특정 학사 일정의 기간 내 모든 날짜에 매핑되어야 한다.
+                for (date in startRange..endRange) {
+                    val key = date.toString()
+                    getOrPut(key) { mutableListOf() }.add(event)
+                }
+            }
+        }
+    }
+}

--- a/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetDistinctAcademicEventUseCase.kt
+++ b/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetDistinctAcademicEventUseCase.kt
@@ -1,0 +1,16 @@
+package com.ku_stacks.ku_ring.domain.academicevent.usecase
+
+import com.ku_stacks.ku_ring.domain.AcademicEvent
+import com.ku_stacks.ku_ring.domain.academicevent.repository.AcademicEventRepository
+import kotlinx.datetime.LocalDate
+import javax.inject.Inject
+
+class GetDistinctAcademicEventUseCase @Inject constructor(
+    private val academicEventRepository: AcademicEventRepository,
+) {
+    suspend operator fun invoke(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): Result<List<AcademicEvent>> =
+        academicEventRepository.getAcademicEvents(startDate.toString(), endDate.toString())
+}

--- a/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetDistinctAcademicEventUseCase.kt
+++ b/domain/academicevent/src/main/java/com/ku_stacks/ku_ring/domain/academicevent/usecase/GetDistinctAcademicEventUseCase.kt
@@ -2,15 +2,16 @@ package com.ku_stacks.ku_ring.domain.academicevent.usecase
 
 import com.ku_stacks.ku_ring.domain.AcademicEvent
 import com.ku_stacks.ku_ring.domain.academicevent.repository.AcademicEventRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 import javax.inject.Inject
 
 class GetDistinctAcademicEventUseCase @Inject constructor(
     private val academicEventRepository: AcademicEventRepository,
 ) {
-    suspend operator fun invoke(
+    operator fun invoke(
         startDate: LocalDate,
         endDate: LocalDate,
-    ): Result<List<AcademicEvent>> =
-        academicEventRepository.getAcademicEvents(startDate.toString(), endDate.toString())
+    ): Flow<List<AcademicEvent>> =
+        academicEventRepository.getAcademicEventsAsFlow(startDate.toString(), endDate.toString())
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(projects.data.staff)
     implementation(projects.data.search)
     implementation(projects.domain.user)
+    implementation(projects.domain.academicevent)
 
     implementation(libs.bundles.compose.interop)
     implementation(libs.kotlinx.datetime)

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/MainActivity.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.core.content.IntentCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.domain.WebViewNotice
+import com.ku_stacks.ku_ring.domain.academicevent.repository.AcademicEventRepository
 import com.ku_stacks.ku_ring.ui_util.KuringNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -22,6 +25,9 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var navigator: KuringNavigator
+
+    @Inject
+    lateinit var academicEventRepository: AcademicEventRepository
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -38,6 +44,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        fetchAcademicEvent()
 
         val notice = IntentCompat.getSerializableExtra(
             intent,
@@ -63,6 +70,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun navToNoticeActivity(webViewNotice: WebViewNotice) {
         navigator.navigateToNoticeWeb(this, webViewNotice)
+    }
+
+    private fun fetchAcademicEvent() {
+        lifecycleScope.launch {
+            academicEventRepository.fetchAcademicEventsFromRemote()
+        }
     }
 
     companion object {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/calendar/AcademicCalendarViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/calendar/AcademicCalendarViewModel.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.main.calendar
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.domain.AcademicEvent
+import com.ku_stacks.ku_ring.domain.academicevent.usecase.GetAcademicEventsUseCase
 import com.ku_stacks.ku_ring.main.calendar.type.ScheduleType
 import com.ku_stacks.ku_ring.util.now
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,20 +18,23 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.YearMonth
 import kotlinx.datetime.atTime
 import kotlinx.datetime.plus
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class AcademicCalendarViewModel @Inject constructor() : ViewModel() {
+class AcademicCalendarViewModel @Inject constructor(
+    private val getAcademicEventsUseCase: GetAcademicEventsUseCase
+) : ViewModel() {
     private val _uiState = MutableStateFlow(AcademicCalendarUiState.Empty)
     internal val uiState = _uiState.asStateFlow()
 
-    /*
-     * TODO: API 요청 로직 연결
-     * yearMonth의 firstDay, lastDay를 사용해 API 요청
-     * 요청 결과는 LocalDate의 문자열 키로 매핑 (파일 하단의 mockEvents 참고)
-     */
     internal fun fetchAcademicEvents(yearMonth: YearMonth) = viewModelScope.launch {
-        updateEventLoadState(AcademicEventLoadState.Success(mockEvents))
+        getAcademicEventsUseCase(yearMonth.firstDay, yearMonth.lastDay)
+            .onSuccess {
+                val eventMap = it.toImmutableMap()
+                updateEventLoadState(AcademicEventLoadState.Success(eventMap))
+            }
+            .onFailure(Timber::e)
     }
 
     internal fun updateSelectedDate(date: LocalDate) {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/calendar/compose/component/calendar/CalendarDayCell.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/calendar/compose/component/calendar/CalendarDayCell.kt
@@ -90,28 +90,27 @@ private fun EventIndicators(
 ) {
     val maxIndicatorCount = 6
     val indicatedEvents = events.take(maxIndicatorCount)
-
     Row(modifier = modifier) {
         indicatedEvents.forEachIndexed { index, event ->
             val color = ScheduleType.Companion.from(event.category).color()
-            val shape =
-                when (index) {
-                    0 -> RoundedCornerShape(
-                        topStart = 5.dp,
-                        bottomStart = 5.dp,
-                    )
+            val shape = when {
+                events.size == 1 -> CircleShape
 
-                    indicatedEvents.lastIndex -> RoundedCornerShape(
-                        topEnd = 5.dp,
-                        bottomEnd = 5.dp,
-                    )
+                index == 0 -> RoundedCornerShape(
+                    topStart = 5.dp,
+                    bottomStart = 5.dp,
+                )
 
-                    else -> RectangleShape
-                }
+                index == indicatedEvents.lastIndex -> RoundedCornerShape(
+                    topEnd = 5.dp,
+                    bottomEnd = 5.dp,
+                )
 
+                else -> RectangleShape
+            }
 
             Box(
-                modifier = Modifier
+                modifier = modifier
                     .size(5.dp)
                     .background(
                         color = color,

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
@@ -17,10 +17,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
@@ -41,8 +44,27 @@ class DepartmentNoticeViewModel @Inject constructor(
     private val _subscribedDepartments = MutableStateFlow(emptyList<Department>())
     val subscribedDepartments: StateFlow<List<Department>>
         get() = _subscribedDepartments
-    private val _academicEvents = MutableStateFlow<List<AcademicEvent>>(emptyList())
-    val academicEvents: StateFlow<List<AcademicEvent>> = _academicEvents.asStateFlow()
+
+    val academicEvents: StateFlow<List<AcademicEvent>> = run {
+        val (startDate, endDate) = with(LocalDate.now()) {
+            val dayOfWeek = this.dayOfWeek.ordinal
+            val startDate = this.minus(dayOfWeek, DateTimeUnit.DAY)
+            val endDate = startDate.plus(6, DateTimeUnit.DAY)
+            startDate to endDate
+        }
+        getDistinctAcademicEventUseCase(startDate, endDate)
+            .catch { t ->
+                Timber.e(t)
+            }
+            .filter { it.isNotEmpty() }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = emptyList()
+            )
+    }
+    private val _isAcademicEventSheetVisible = MutableStateFlow(false)
+    val isAcademicEventSheetVisible = _isAcademicEventSheetVisible.asStateFlow()
 
     private val isInitialLoading = MutableStateFlow(true)
 
@@ -91,29 +113,19 @@ class DepartmentNoticeViewModel @Inject constructor(
         }
     }
 
-    suspend fun fetchAcademicEvents() {
-        val (startDate, endDate) = with(LocalDate.now()) {
-            val dayOfWeek = this.dayOfWeek.ordinal
-            val startDate = this.minus(dayOfWeek, DateTimeUnit.DAY)
-            val endDate = startDate.plus(6, DateTimeUnit.DAY)
-            startDate to endDate
-        }
-        val events = getDistinctAcademicEventUseCase(startDate, endDate)
-            .getOrElse { t ->
-                Timber.e(t)
-                emptyList()
+    fun checkAndShowAcademicEventSheet() = viewModelScope.launch {
+        academicEvents
+            .filter { it.isNotEmpty() }
+            .take(1)
+            .collect {
+                _isAcademicEventSheetVisible.update {
+                    preferenceUtil.lastDateAcademicEventShown != LocalDate.now().toString()
+                }
             }
-        _academicEvents.update { events }
-    }
-
-    fun shouldShowAcademicEventSheet(): Boolean {
-        val isEventAvailable = academicEvents.value.isNotEmpty()
-        val isEventSheetNotShown =
-            preferenceUtil.lastDateAcademicEventShown != LocalDate.now().toString()
-        return isEventAvailable && isEventSheetNotShown
     }
 
     fun markAcademicEventSheetAsShown() {
+        _isAcademicEventSheetVisible.update { false }
         preferenceUtil.lastDateAcademicEventShown = LocalDate.now().toString()
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
@@ -95,6 +95,7 @@ class DepartmentNoticeViewModel @Inject constructor(
 
     init {
         collectSubscribedDepartments()
+        checkAndShowAcademicEventSheet()
     }
 
     private fun collectSubscribedDepartments() {
@@ -113,7 +114,7 @@ class DepartmentNoticeViewModel @Inject constructor(
         }
     }
 
-    fun checkAndShowAcademicEventSheet() = viewModelScope.launch {
+    private fun checkAndShowAcademicEventSheet() = viewModelScope.launch {
         academicEvents
             .filter { it.isNotEmpty() }
             .take(1)

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/DepartmentNoticeViewModel.kt
@@ -4,24 +4,45 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import com.ku_stacks.ku_ring.department.repository.DepartmentRepository
+import com.ku_stacks.ku_ring.domain.AcademicEvent
 import com.ku_stacks.ku_ring.domain.Department
 import com.ku_stacks.ku_ring.domain.Notice
+import com.ku_stacks.ku_ring.domain.academicevent.usecase.GetDistinctAcademicEventUseCase
 import com.ku_stacks.ku_ring.notice.repository.NoticeRepository
+import com.ku_stacks.ku_ring.preferences.PreferenceUtil
+import com.ku_stacks.ku_ring.util.now
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class DepartmentNoticeViewModel @Inject constructor(
+    private val preferenceUtil: PreferenceUtil,
     private val noticeRepository: NoticeRepository,
     private val departmentRepository: DepartmentRepository,
+    private val getDistinctAcademicEventUseCase: GetDistinctAcademicEventUseCase,
 ) : ViewModel() {
 
     private val _subscribedDepartments = MutableStateFlow(emptyList<Department>())
     val subscribedDepartments: StateFlow<List<Department>>
         get() = _subscribedDepartments
+    private val _academicEvents = MutableStateFlow<List<AcademicEvent>>(emptyList())
+    val academicEvents: StateFlow<List<AcademicEvent>> = _academicEvents.asStateFlow()
 
     private val isInitialLoading = MutableStateFlow(true)
 
@@ -68,6 +89,32 @@ class DepartmentNoticeViewModel @Inject constructor(
             departmentRepository.clearMainDepartments()
             departmentRepository.updateMainDepartmentStatus(department.name, true)
         }
+    }
+
+    suspend fun fetchAcademicEvents() {
+        val (startDate, endDate) = with(LocalDate.now()) {
+            val dayOfWeek = this.dayOfWeek.ordinal
+            val startDate = this.minus(dayOfWeek, DateTimeUnit.DAY)
+            val endDate = startDate.plus(6, DateTimeUnit.DAY)
+            startDate to endDate
+        }
+        val events = getDistinctAcademicEventUseCase(startDate, endDate)
+            .getOrElse { t ->
+                Timber.e(t)
+                emptyList()
+            }
+        _academicEvents.update { events }
+    }
+
+    fun shouldShowAcademicEventSheet(): Boolean {
+        val isEventAvailable = academicEvents.value.isNotEmpty()
+        val isEventSheetNotShown =
+            preferenceUtil.lastDateAcademicEventShown != LocalDate.now().toString()
+        return isEventAvailable && isEventSheetNotShown
+    }
+
+    fun markAcademicEventSheetAsShown() {
+        preferenceUtil.lastDateAcademicEventShown = LocalDate.now().toString()
     }
 }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.ku_stacks.ku_ring.main.notice.compose.inner_screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -22,7 +23,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LightAndDarkPreview
@@ -118,27 +121,27 @@ private fun AcademicEventBottomSheetContent(
                     )
                     .padding(16.dp),
             ) {
-                Text(
+                CenterStartAlignedText(
                     text = academicEvent.summary,
-                    style = KuringTheme.typography.body1,
+                    style = KuringTheme.typography.body2SB,
                     color = KuringTheme.colors.textTitle,
-                    maxLines = 1,
                     modifier = Modifier.heightIn(min = 24.dp),
                 )
-                Text(
+                Spacer(modifier = Modifier.height(4.dp))
+                CenterStartAlignedText(
                     text = academicEvent.period,
                     style = KuringTheme.typography.tag2,
                     color = KuringTheme.colors.textCaption1,
-                    maxLines = 1,
                     modifier = Modifier.heightIn(min = 18.dp),
                 )
             }
         }
 
         if (isIndicatorVisible) {
-            Spacer(modifier = Modifier.height(8.dp))
             HorizontalSlidingIndicator(
                 pagerState = pagerState,
+                inactiveBackground = KuringTheme.colors.mainPrimarySelected,
+                modifier = Modifier.padding(top = 20.dp, bottom = 4.dp)
             )
         }
 
@@ -147,6 +150,26 @@ private fun AcademicEventBottomSheetContent(
             text = stringResource(academic_event_bottom_sheet_cta),
             modifier = Modifier.fillMaxWidth(),
             blur = false,
+        )
+    }
+}
+
+@Composable
+private fun CenterStartAlignedText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        contentAlignment = Alignment.CenterStart,
+        modifier = modifier
+    ) {
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            maxLines = 1,
         )
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
@@ -13,9 +13,9 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,25 +38,10 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
 
-// TODO: api 연결 후 삭제
-private val mockAcademicEvents = buildList {
-    repeat(5) { index ->
-        add(
-            AcademicEvent(
-                id = index.toLong(),
-                summary = "수강바구니 ${index}차",
-                category = ScheduleType.EVENT.name,
-                startDateTime = LocalDateTime.now(),
-                endDateTime = LocalDateTime.now(),
-            )
-        )
-    }
-}.toImmutableList()
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun AcademicEventBottomSheet(
-    academicEvents: ImmutableList<AcademicEvent> = mockAcademicEvents,
+    academicEvents: ImmutableList<AcademicEvent>,
     isVisible: Boolean,
     onNavigateToAcademicEvent: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/AcademicScheduleBottomSheet.kt
@@ -43,6 +43,7 @@ import kotlinx.datetime.LocalDateTime
 internal fun AcademicEventBottomSheet(
     academicEvents: ImmutableList<AcademicEvent>,
     isVisible: Boolean,
+    onDismissRequest: () -> Unit,
     onNavigateToAcademicEvent: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -55,7 +56,10 @@ internal fun AcademicEventBottomSheet(
 
     if (sheetState.isVisible) {
         ModalBottomSheet(
-            onDismissRequest = { scope.launch { sheetState.hide() } },
+            onDismissRequest = {
+                onDismissRequest()
+                scope.launch { sheetState.hide() }
+            },
             sheetState = sheetState,
             shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
             dragHandle = null,
@@ -65,6 +69,7 @@ internal fun AcademicEventBottomSheet(
                 academicEvents = academicEvents,
                 onNavigateToAcademicEvent = {
                     onNavigateToAcademicEvent()
+                    onDismissRequest()
                     scope.launch { sheetState.hide() }
                 },
             )

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -48,6 +48,7 @@ import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LazyPagingNoticeItemColumn
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import com.ku_stacks.ku_ring.domain.AcademicEvent
 import com.ku_stacks.ku_ring.domain.Department
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.main.R
@@ -55,6 +56,8 @@ import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeScreenState
 import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeViewModel
 import com.ku_stacks.ku_ring.main.notice.compose.LocalKuringBotFabState
 import com.ku_stacks.ku_ring.main.notice.compose.components.DepartmentHeader
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -84,6 +87,18 @@ internal fun DepartmentNoticeScreen(
 
     val departmentNoticeScreenState by viewModel.departmentNoticeScreenState.collectAsStateWithLifecycle()
 
+    val academicEvents by viewModel.academicEvents.collectAsStateWithLifecycle()
+    var isAcademicEventSheetVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        viewModel.fetchAcademicEvents()
+        if (viewModel.shouldShowAcademicEventSheet()) {
+            isAcademicEventSheetVisible = true
+            viewModel.markAcademicEventSheetAsShown()
+        } else {
+            isAcademicEventSheetVisible = false
+        }
+    }
+
     when (departmentNoticeScreenState) {
         DepartmentNoticeScreenState.InitialLoading -> {
             Box(modifier = modifier.background(KuringTheme.colors.background)) {
@@ -108,6 +123,8 @@ internal fun DepartmentNoticeScreen(
                 onNoticeClick = onNoticeClick,
                 isRefreshing = isRefreshing,
                 refreshState = refreshState,
+                academicEvents = academicEvents.toImmutableList(),
+                isAcademicEventSheetVisible = isAcademicEventSheetVisible,
                 modifier = modifier,
             )
         }
@@ -170,6 +187,8 @@ private fun DepartmentNoticeScreen(
     onNoticeClick: (Notice) -> Unit,
     isRefreshing: Boolean,
     refreshState: PullRefreshState,
+    academicEvents: ImmutableList<AcademicEvent>,
+    isAcademicEventSheetVisible: Boolean,
     modifier: Modifier = Modifier,
     scope: CoroutineScope = rememberCoroutineScope(),
 ) {
@@ -189,10 +208,10 @@ private fun DepartmentNoticeScreen(
         }
     }
 
-    // TODO: 학사일정 목록와 표시 여부를
     AcademicEventBottomSheet(
+        academicEvents = academicEvents,
         onNavigateToAcademicEvent = onNavigateToAcademicEvent,
-        isVisible = true,
+        isVisible = isAcademicEventSheetVisible,
     )
 
     ModalBottomSheetLayout(

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -87,9 +87,6 @@ internal fun DepartmentNoticeScreen(
 
     val academicEvents by viewModel.academicEvents.collectAsStateWithLifecycle()
     val isAcademicEventSheetVisible by viewModel.isAcademicEventSheetVisible.collectAsStateWithLifecycle()
-    LaunchedEffect(Unit) {
-        viewModel.checkAndShowAcademicEventSheet()
-    }
 
     AcademicEventBottomSheet(
         academicEvents = academicEvents.toImmutableList(),

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -86,21 +86,16 @@ internal fun DepartmentNoticeScreen(
     val departmentNoticeScreenState by viewModel.departmentNoticeScreenState.collectAsStateWithLifecycle()
 
     val academicEvents by viewModel.academicEvents.collectAsStateWithLifecycle()
-    var isAcademicEventSheetVisible by remember { mutableStateOf(false) }
+    val isAcademicEventSheetVisible by viewModel.isAcademicEventSheetVisible.collectAsStateWithLifecycle()
     LaunchedEffect(Unit) {
-        viewModel.fetchAcademicEvents()
-        if (viewModel.shouldShowAcademicEventSheet()) {
-            isAcademicEventSheetVisible = true
-            viewModel.markAcademicEventSheetAsShown()
-        } else {
-            isAcademicEventSheetVisible = false
-        }
+        viewModel.checkAndShowAcademicEventSheet()
     }
 
     AcademicEventBottomSheet(
         academicEvents = academicEvents.toImmutableList(),
-        onNavigateToAcademicEvent = onNavigateToAcademicEvent,
         isVisible = isAcademicEventSheetVisible,
+        onNavigateToAcademicEvent = onNavigateToAcademicEvent,
+        onDismissRequest = viewModel::markAcademicEventSheetAsShown,
     )
 
     when (departmentNoticeScreenState) {
@@ -205,12 +200,6 @@ private fun DepartmentNoticeScreen(
             kuringBotFabState.hide()
         }
     }
-
-    /*AcademicEventBottomSheet(
-        academicEvents = academicEvents,
-        onNavigateToAcademicEvent = onNavigateToAcademicEvent,
-        isVisible = isAcademicEventSheetVisible,
-    )*/
 
     ModalBottomSheetLayout(
         sheetContent = {

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -48,7 +48,6 @@ import com.ku_stacks.ku_ring.designsystem.components.KuringCallToAction
 import com.ku_stacks.ku_ring.designsystem.components.LazyPagingNoticeItemColumn
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
-import com.ku_stacks.ku_ring.domain.AcademicEvent
 import com.ku_stacks.ku_ring.domain.Department
 import com.ku_stacks.ku_ring.domain.Notice
 import com.ku_stacks.ku_ring.main.R
@@ -56,7 +55,6 @@ import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeScreenState
 import com.ku_stacks.ku_ring.main.notice.DepartmentNoticeViewModel
 import com.ku_stacks.ku_ring.main.notice.compose.LocalKuringBotFabState
 import com.ku_stacks.ku_ring.main.notice.compose.components.DepartmentHeader
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -99,6 +97,12 @@ internal fun DepartmentNoticeScreen(
         }
     }
 
+    AcademicEventBottomSheet(
+        academicEvents = academicEvents.toImmutableList(),
+        onNavigateToAcademicEvent = onNavigateToAcademicEvent,
+        isVisible = isAcademicEventSheetVisible,
+    )
+
     when (departmentNoticeScreenState) {
         DepartmentNoticeScreenState.InitialLoading -> {
             Box(modifier = modifier.background(KuringTheme.colors.background)) {
@@ -118,13 +122,10 @@ internal fun DepartmentNoticeScreen(
                 selectedDepartments = selectedDepartments,
                 onSelectDepartment = viewModel::selectDepartment,
                 onNavigateToEditDepartment = onNavigateToEditDepartment,
-                onNavigateToAcademicEvent = onNavigateToAcademicEvent,
                 notices = notices,
                 onNoticeClick = onNoticeClick,
                 isRefreshing = isRefreshing,
                 refreshState = refreshState,
-                academicEvents = academicEvents.toImmutableList(),
-                isAcademicEventSheetVisible = isAcademicEventSheetVisible,
                 modifier = modifier,
             )
         }
@@ -182,13 +183,10 @@ private fun DepartmentNoticeScreen(
     selectedDepartments: List<Department>,
     onSelectDepartment: (Department) -> Unit,
     onNavigateToEditDepartment: () -> Unit,
-    onNavigateToAcademicEvent: () -> Unit,
     notices: LazyPagingItems<Notice>?,
     onNoticeClick: (Notice) -> Unit,
     isRefreshing: Boolean,
     refreshState: PullRefreshState,
-    academicEvents: ImmutableList<AcademicEvent>,
-    isAcademicEventSheetVisible: Boolean,
     modifier: Modifier = Modifier,
     scope: CoroutineScope = rememberCoroutineScope(),
 ) {
@@ -208,11 +206,11 @@ private fun DepartmentNoticeScreen(
         }
     }
 
-    AcademicEventBottomSheet(
+    /*AcademicEventBottomSheet(
         academicEvents = academicEvents,
         onNavigateToAcademicEvent = onNavigateToAcademicEvent,
         isVisible = isAcademicEventSheetVisible,
-    )
+    )*/
 
     ModalBottomSheetLayout(
         sheetContent = {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-246?atlOrigin=eyJpIjoiMTE4NGNiOWZhMmUxNDFiYWFiMmRhOTNkMjkxNzYxNmUiLCJwIjoiaiJ9

## 요약

#### 학사일정 달력

- 데이터 조회를 위한 도메인 유즈케이스 구현
- 조회한 데이터를 학사일정 달력 화면에 표시

#### MainActivity

- MainActivity 실행 시 서버에게 학사일정 데이터 요청
- DB 데이터 업데이트 정책을 `Upsert`로 수정

#### 학사일정 바텀시트

- 학사일정 바텀시트 표시 여부를 확인하기 위한 값을 PreferenceUtil에 추가
- 학과 공지 화면(앱의 첫 화면)에 주간 학사일정을 조회하고 표시
- 조회한 학사일정을 Flow로 반환하는 Dao 메서드 추가
- 기타 UI 수정

## 기타

- 메인화면에서 DB에 업로드한 데이터를 공지화면에서 조회할 때 동기화 문제가 발생해서, RoomDB로부터 데이터 flow를 반환받는 메서드를 추가했습니다! 

- 메인화면에선 위 메서드로 학사일정을 구독하고, `학사일정 존재 여부`와 `마지막으로 바텀시트를 확인한 날짜`를 사용해 학사일정 바텀시트 표시 여부를 결정하도록 구현했습니다!

- 지난번에 우영님이 추천해주신 Upsert 방식으로 DB를 업데이트하도록 수정했습니다! 변경사항을 무시하는건 좋은 방법이 아닌 것 같더라고요😅 