### PR TITLE
kuring-248 FCM 메시지 형식 구현

### DIFF
--- a/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/FcmUtil.kt
+++ b/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/FcmUtil.kt
@@ -39,8 +39,9 @@ class FcmUtil @Inject constructor(
     }
 
     fun isAcademicEventNotification(data: Map<String, String?>): Boolean {
-        // TODO: implement academic event verification code
-        return false
+        val title = data["title"]
+        val body = data["body"]
+        return title != null && body != null
     }
 
     fun insertNotificationIntoDatabase(

--- a/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
+++ b/core/thirdparty/src/main/java/com/ku_stacks/ku_ring/thirdparty/firebase/MyFireBaseMessagingService.kt
@@ -89,8 +89,9 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
                 showCustomNotification(type = type, title = title, body = body)
             }
         } else if (fcmUtil.isAcademicEventNotification(remoteMessage.data)) {
-            // TODO: get title and body from message
-            showAcademicEventNotification("", "")
+            val title = remoteMessage.data["title"]!!
+            val body = remoteMessage.data["body"]!!
+            showAcademicEventNotification(title, body)
         }
     }
 

--- a/data/remote/build.gradle.kts
+++ b/data/remote/build.gradle.kts
@@ -15,7 +15,7 @@ android {
             buildConfigField("String", "API_BASE_URL", "\"https://ku-ring.com/api/\"")
         }
         debug {
-            buildConfigField("String", "API_BASE_URL", "\"https://kuring.herokuapp.com/api/\"")
+            buildConfigField("String", "API_BASE_URL", "\"http://dev.ku-ring.com/api/\"")
         }
     }
     testOptions {


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-248?atlOrigin=eyJpIjoiYjM1YWNlYzgxMTBlNGNkZTgzYWY4OTAxNzdkODE1ZmEiLCJwIjoiaiJ9

## 요약

서버팀에서 FCM 메시지 형식을 전달해 주셔서, 메시지로부터 알림 제목 및 본문을 받아오는 코드를 작성했습니다.

추가로, 새 테스트 서버 URL을 적용했습니다.